### PR TITLE
Shortcut: Spacebar assigns self to current card, 'F' toggles filter sidebar

### DIFF
--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -36,6 +36,26 @@ Mousetrap.bind(['down', 'up'], (evt, key) => {
   }
 });
 
+// XXX This shortcut should also work when hovering over a card in board view
+Mousetrap.bind('space', (evt) => {
+  if (!Session.get('currentCard')) {
+    return;
+  }
+
+  const currentUserId = Meteor.userId();
+  if (currentUserId === null) {
+    return;
+  }
+
+  if (Meteor.user().isBoardMember()) {
+    const card = Cards.findOne(Session.get('currentCard'));
+    card.toggleMember(currentUserId);
+    // We should prevent scrolling in card when spacebar is clicked
+    // This should do it according to Mousetrap docs, but it doesn't
+    evt.preventDefault();
+  }
+});
+
 Template.keyboardShortcuts.helpers({
   mapping: [{
     keys: ['W'],
@@ -58,5 +78,8 @@ Template.keyboardShortcuts.helpers({
   }, {
     keys: [':'],
     action: 'shortcut-autocomplete-emojies',
+  }, {
+    keys: ['SPACE'],
+    action: 'shortcut-assign-self',
   }],
 });

--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -23,6 +23,14 @@ Mousetrap.bind('x', () => {
   }
 });
 
+Mousetrap.bind('f', () => {
+  if (Sidebar.isOpen() && Sidebar.getView() === 'filter') {
+    Sidebar.toggle();
+  } else {
+    Sidebar.setView('filter');
+  }
+});
+
 Mousetrap.bind(['down', 'up'], (evt, key) => {
   if (!Session.get('currentCard')) {
     return;
@@ -63,6 +71,9 @@ Template.keyboardShortcuts.helpers({
   }, {
     keys: ['Q'],
     action: 'shortcut-filter-my-cards',
+  }, {
+    keys: ['F'],
+    action: 'shortcut-toggle-filterbar',
   }, {
     keys: ['X'],
     action: 'shortcut-clear-filters',

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -177,6 +177,7 @@
     "save": "Save",
     "search": "Search",
     "select-color": "Select a color",
+    "shortcut-assign-self": "Assign yourself to current card",
     "shortcut-autocomplete-emojies": "Autocomplete emojies",
     "shortcut-autocomplete-members": "Autocomplete members",
     "shortcut-clear-filters": "Clear all filters",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -184,6 +184,7 @@
     "shortcut-close-dialog": "Close Dialog",
     "shortcut-filter-my-cards": "Filter my cards",
     "shortcut-show-shortcuts": "Bring up this shortcuts list",
+    "shortcut-toggle-filterbar": "Toggle Filter Sidebar",
     "shortcut-toggle-sidebar": "Toggle Board Sidebar",
     "signupPopup-title": "Create an Account",
     "star-board-title": "Click to star this board. It will show up at top of your boards list.",


### PR DESCRIPTION
Hey,

This implements simple keybind that assigns self to current card when spacebar is pressed.
It's a feature that I like dearly so I implemented it as it was missing.

Also fixed a very minor translate typo in finnish translation.