### PR TITLE
Fix removeMemberPopup

### DIFF
--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -76,7 +76,7 @@ template(name="memberPopup")
 
 
 template(name="removeMemberPopup")
-  p {{_ 'remove-member-pop' name=user.profile.name username=user.username boardTitle=board.title}}
+  p {{_ 'remove-member-pop' name=user.profile.fullname username=user.username boardTitle=board.title}}
   button.js-confirm.negate.full(type="submit") {{_ 'remove-member'}}
 
 template(name="addMemberPopup")

--- a/client/components/sidebar/sidebar.js
+++ b/client/components/sidebar/sidebar.js
@@ -137,6 +137,15 @@ Template.memberPopup.events({
   },
 });
 
+Template.removeMemberPopup.helpers({
+  user() {
+    return Users.findOne(this.userId);
+  },
+  board() {
+    return Boards.findOne(Session.get('currentBoard'));
+  },
+});
+
 Template.membersWidget.events({
   'click .js-member': Popup.open('member'),
   'click .js-manage-board-members': Popup.open('addMember'),


### PR DESCRIPTION
The `removeMemberPopup` was missing the required helper to get the user and board
information and the user profile field is called `fullname` and not `name`.