### PR TITLE
sidebar: Filter archived cards/lists for current board

### DIFF
--- a/client/components/sidebar/sidebarArchives.js
+++ b/client/components/sidebar/sidebarArchives.js
@@ -11,11 +11,17 @@ BlazeComponent.extendComponent({
   },
 
   archivedCards() {
-    return Cards.find({ archived: true });
+    return Cards.find({
+      archived: true,
+      boardId: Session.get('currentBoard'),
+    });
   },
 
   archivedLists() {
-    return Lists.find({ archived: true });
+    return Lists.find({
+      archived: true,
+      boardId: Session.get('currentBoard'),
+    });
   },
 
   cardIsInArchivedList() {


### PR DESCRIPTION
The archived items should be filtered for the current board or else you
will get a global list of all archived items on all boards.

This fixes #318.