### PR TITLE
Make card titles accept html

### DIFF
--- a/client/components/cards/minicard.jade
+++ b/client/components/cards/minicard.jade
@@ -7,7 +7,9 @@ template(name="minicard")
       .minicard-labels
         each labels
           .minicard-label(class="card-label-{{color}}" title="{{name}}")
-    .minicard-title= title
+    .minicard-title
+      +viewer
+         = title
     if members
       .minicard-members.js-minicard-members
         each members


### PR DESCRIPTION
This change makes card titles accept html.  In particular, it means that a link cut and pasted to a card will still be clickable without requiring navigating to the details section and using the description field.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/361)
<!-- Reviewable:end -->
