### PR TITLE
Add ESLint-plugin-Meteor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,14 @@
 ecmaFeatures:
   experimentalObjectRestSpread: true
 
+plugins:
+  - meteor
+
+parser: babel-eslint
+
 rules:
+  strict: 0
+  no-undef: 2
   accessor-pairs: 2
   comma-dangle: [2, 'always-multiline']
   consistent-return: 2
@@ -43,36 +50,35 @@ rules:
   prefer-spread: 2
   prefer-template: 2
 
-globals:
-  # Meteor globals
-  Meteor: false
-  DDP: false
-  Mongo: false
-  Session: false
-  Accounts: false
-  Template: false
-  Blaze: false
-  UI: false
-  Match: false
-  check: false
-  Tracker: false
-  Deps: false
-  ReactiveVar: false
-  EJSON: false
-  HTTP: false
-  Email: false
-  Assets: false
-  Handlebars: false
-  Package: false
-  App: false
-  Npm: false
-  Tinytest: false
-  Random: false
-  HTML: false
+  # eslint-plugin-meteor
+  meteor/globals: 2
+  meteor/no-zero-timeout: 2
+  meteor/no-session: 0
+  meteor/pubsub: 2
+  meteor/core: 2
+  meteor/methods: 2
+  meteor/check: 2
+  meteor/connections: 2
+  meteor/collections: 2
+  meteor/session: [2, 'no-equal']
 
+settings:
+  meteor:
+
+    # Our collections
+    collections:
+      - AccountsTemplates
+      - Activities
+      - Attachments
+      - Boards
+      - CardComments
+      - Cards
+      - Lists
+      - UnsavedEditCollection
+      - Users
+
+globals:
   # Exported by packages we use
-  '$': false
-  _: false
   autosize: false
   Avatar: true
   Avatars: true
@@ -96,17 +102,6 @@ globals:
   SubsManager: false
   T9n: false
   TAPi18n: false
-
-  # Our collections
-  AccountsTemplates: true
-  Activities: true
-  Attachments: true
-  Boards: true
-  CardComments: true
-  Cards: true
-  Lists: true
-  UnsavedEditCollection: true
-  Users: true
 
   # Our objects
   CSSEvents: true

--- a/.eslintrc
+++ b/.eslintrc
@@ -51,16 +51,20 @@ rules:
   prefer-template: 2
 
   # eslint-plugin-meteor
+  ## Meteor API
   meteor/globals: 2
-  meteor/no-zero-timeout: 2
-  meteor/no-session: 0
-  meteor/pubsub: 2
   meteor/core: 2
+  meteor/pubsub: 2
   meteor/methods: 2
   meteor/check: 2
   meteor/connections: 2
   meteor/collections: 2
   meteor/session: [2, 'no-equal']
+
+  ## Best practices
+  meteor/no-session: 0
+  meteor/no-zero-timeout: 2
+  meteor/no-blaze-lifecycle-assignment: 2
 
 settings:
   meteor:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .tx/
 *.sublime-workspace
 tmp/
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "0.10.40"
 install:
-  - "npm install -g eslint"
-  - "npm install -g eslint-plugin-meteor"
+  - "npm install"
 script:
-  - "eslint ./"
+  - "npm test"

--- a/client/components/activities/comments.js
+++ b/client/components/activities/comments.js
@@ -23,7 +23,7 @@ BlazeComponent.extendComponent({
         commentFormIsOpen.set(true);
       },
       'submit .js-new-comment-form'(evt) {
-        const input = this.getInput()
+        const input = this.getInput();
         const text = input.val().trim();
         if (text) {
           CardComments.insert({

--- a/models/attachments.js
+++ b/models/attachments.js
@@ -1,4 +1,4 @@
-Attachments = new FS.Collection('attachments', {
+Attachments = new FS.Collection('attachments', { // eslint-disable-line meteor/collections
   stores: [
 
     // XXX Add a new store for cover thumbnails so we don't load big images in

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "wekan",
+  "version": "1.0.0",
+  "description": "The open-source Trello-like kanban",
+  "private": true,
+  "scripts": {
+    "lint": "eslint .",
+    "test": "npm run lint"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wekan/wekan.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/wekan/wekan/issues"
+  },
+  "homepage": "https://github.com/wekan/wekan#readme",
+  "devDependencies": {
+    "babel-eslint": "4.1.3",
+    "eslint": "1.7.3",
+    "eslint-plugin-meteor": "1.5.0"
+  }
+}

--- a/sandstorm.js
+++ b/sandstorm.js
@@ -109,7 +109,7 @@ if (isSandstorm && Meteor.isClient) {
   // sandstorm client to return relative paths instead of absolutes.
   const _absoluteUrl = Meteor.absoluteUrl;
   const _defaultOptions = Meteor.absoluteUrl.defaultOptions;
-  Meteor.absoluteUrl = (path, options) => {
+  Meteor.absoluteUrl = (path, options) => { // eslint-disable-line meteor/core
     const url = _absoluteUrl(path, options);
     return url.replace(/^https?:\/\/127\.0\.0\.1:[0-9]{2,5}/, '');
   };


### PR DESCRIPTION
Enable [ESLint-plugin-Meteor](https://github.com/dferber90/eslint-plugin-meteor).

*This PR is an example for how to properly set up ESLint-plugin-Meteor in a project.*
*That's why I included so many annotations in the source code.*
*Make sure to check out the [Files changed](/wekan/wekan/pull/370/files) tab for details.*

#### ESLint-plugin-Meteor
This PR enables the rules of ESLint-plugin-Meteor. They
- validate usage of the Meteor API
- prevent overwrites of collections
- define Meteor globals based on the context of the files are used in (browser, server, package, ..)
- [and much more](https://github.com/dferber90/eslint-plugin-meteor/tree/master/docs/rules)

#### Local versions
By adding a `package.json` npm's tools can be used for this project.

New developers now don't need to install ESLint and ESLint-plugin-Meteor globally. Instead, they can simply do `npm install` and get going. They will need to have node and npm installed for this to work, which are necessary for ESLint anyways.

Using a local version of ESLint and [ESLint-plugin-Meteor](https://github.com/dferber90/eslint-plugin-meteor) instead of relying on global versions further ensures consistency across the development team and the CI.

#### Pinned versions
The versions of ESLint and ESLint-plugin-Meteor are pinned down exactly in `package.json`. This means even if there are new versions of these plugins the specified ones will be used. Enable the free-for-open-source [greenkeeper.io](http://greenkeeper.io/) for this repository to automatically get pull-requests whenever a new version is released.

#### babel-eslint
This PR also adds the [babel-eslint](https://github.com/babel/babel-eslint) parser which makes ESLint understand all valid "babel code".

#### CI
The CI now no longer installs *eslint* and *eslint-plugin-meteor* globally. Instead it uses local versions.

```bash
# setup
$ npm install

# actual testing
$ npm test
```

`npm test` will only do `npm run lint` for now. `$ npm run lint` can also be executed during development to check which files have errors and resolve them before sending a PR and having the CI figure it out.


*Happy linting* :)