### PR TITLE
set sandstorm grain URL when router changes

### DIFF
--- a/client/config/router.js
+++ b/client/config/router.js
@@ -6,7 +6,7 @@ FlowRouter.triggers.exit([({path}) => {
 FlowRouter.triggers.enter([({path}) => {
   if (window.parent) {
     window.parent.postMessage({
-      setPath: path
+      setPath: path,
     }, '*');
   }
 }]);

--- a/client/config/router.js
+++ b/client/config/router.js
@@ -3,6 +3,14 @@ FlowRouter.triggers.exit([({path}) => {
   previousPath = path;
 }]);
 
+FlowRouter.triggers.enter([({path}) => {
+  if (window.parent) {
+    window.parent.postMessage({
+      setPath: path
+    }, '*');
+  }
+}]);
+
 FlowRouter.route('/', {
   name: 'home',
   triggersEnter: [AccountsTemplates.ensureSignedIn],


### PR DESCRIPTION
Sandstorm supports a grain sending `postMessage` on the parent window with `setPath` to update the outer URL. This allows the outer URL to change as you browse around within the grain, and if you reload, you'll end up on the right page.

This pull request causes every route entered to update the browser's URL. In an ideal world we wouldn't see the `/sandstorm` part, but that would involve quite a bit more route hacking than has been done so far to integrate with Sandstorm.