### PR TITLE
add: set user preferred lang and allow select lang for user form

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -125,7 +125,7 @@ seriousm:emoji-continued@1.4.0
 service-configuration@1.0.5
 session@1.1.1
 sha@1.0.4
-softwarerero:accounts-t9n@1.1.6
+softwarerero:accounts-t9n@1.1.7
 spacebars@1.0.7
 spacebars-compiler@1.0.7
 srp@1.0.4

--- a/client/components/main/layouts.jade
+++ b/client/components/main/layouts.jade
@@ -13,6 +13,13 @@ template(name="userFormsLayout")
     h1.at-form-landing-logo
       img(src="{{pathFor '/wekan-logo.png'}}" alt="Wekan")
     +Template.dynamic(template=content)
+    div.at-form-lang
+      select.select-lang.js-userform-set-language
+        each languages
+          if isCurrentLanguage
+            option(value="{{tag}}" selected="selected") {{name}}
+          else
+            option(value="{{tag}}") {{name}}
 
 template(name="defaultLayout")
   +header

--- a/client/components/main/layouts.js
+++ b/client/components/main/layouts.js
@@ -2,8 +2,41 @@ Meteor.subscribe('boards');
 
 BlazeLayout.setRoot('body');
 
+const i18nTagToT9n = (i18nTag) => {
+  // t9n/i18n tags are same now, see: https://github.com/softwarerero/meteor-accounts-t9n/pull/129
+  // but we keep this conversion function here, to be aware that that they are different system.
+  return i18nTag;
+};
+
 Template.userFormsLayout.onRendered(() => {
+  const i18nTag = navigator.language;
+  if (i18nTag) {
+    T9n.setLanguage(i18nTagToT9n(i18nTag));
+  }
   EscapeActions.executeAll();
+});
+
+Template.userFormsLayout.helpers({
+  languages() {
+    return _.map(TAPi18n.getLanguages(), (lang, tag) => {
+      const name = lang.name;
+      return { tag, name };
+    });
+  },
+
+  isCurrentLanguage() {
+    const t9nTag = i18nTagToT9n(this.tag);
+    const curLang = T9n.getLanguage() || 'en';
+    return t9nTag === curLang;
+  },
+});
+
+Template.userFormsLayout.events({
+  'change .js-userform-set-language'(evt) {
+    const i18nTag = $(evt.currentTarget).val();
+    T9n.setLanguage(i18nTagToT9n(i18nTag));
+    evt.preventDefault();
+  },
 });
 
 Template.defaultLayout.events({

--- a/client/components/users/userForm.styl
+++ b/client/components/users/userForm.styl
@@ -45,3 +45,13 @@
       .at-signUp,
       .at-signIn
         font-weight: bold
+
+  .at-form-lang
+    margin: auto
+    width: 275px
+    padding: 25px
+    padding-bottom: 10px
+
+    .select-lang
+      width: 275px
+      font-size: 1.0em


### PR DESCRIPTION
Currently, before login, the user form always display English. This patch set user form language according to browser language, and allow user to select from the language list that WeKan supports.