### PR TITLE
One click deploy to Scalingo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ that by providing one-click installation on Heroku or [Sandstorm]
 
 [![Deploy][heroku_button]][heroku_deploy]
 
+[![Deploy to Scalingo][scalingo_button]][scalingo_deploy]
+
 Wekan is released under the very permissive [MIT license](LICENSE), and made
 with [Meteor](https://www.meteor.com).
 
@@ -36,3 +38,5 @@ with [Meteor](https://www.meteor.com).
 [docker_image]: https://hub.docker.com/r/mquandalle/wekan/
 [heroku_button]: https://www.herokucdn.com/deploy/button.png
 [heroku_deploy]: https://heroku.com/deploy?template=https://github.com/wekan/wekan/tree/master
+[scalingo_button]: https://cdn.scalingo.com/deploy/button.svg
+[scalingo_deploy]: https://my.scalingo.com/deploy?source=https://github.com/wekan/wekan#devel

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,8 @@
+{
+  "name": "wekan",
+  "description": "The open-source Trello-like kanban (build with Meteor)",
+  "repository": "https://github.com/wekan/wekan/",
+  "logo": "https://raw.githubusercontent.com/wekan/wekan/master/meta/icons/wekan-150.png",
+  "website": "https://wekan.io",
+  "addons": ["scalingo-mongodb"]
+}


### PR DESCRIPTION
Scalingo is a PaaS that supports Meteor pretty well, we've done a lot of work to make things work out of the box. Oplog and horizontal scaling are available for further needs. Meteor is a really promising technology and we'd be glad helping this project to grow. So this PR is in the continuity of the heroku deploy button and works the same way to let users deploy their own version of 'wekan' in an instant.

You can test the button (link to fork) here : https://github.com/Zyko0/wekan/tree/one_click