### PR TITLE
Bugfix stylus error on mobileweb

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -7,9 +7,9 @@ meteor-base
 
 # Build system
 ecmascript
-stylus
 standard-minifiers
 mquandalle:jade
+mquandalle:stylus
 
 # Polyfills
 es5-shim

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -99,6 +99,7 @@ mquandalle:jquery-ui-drag-drop-sort@0.2.0
 mquandalle:moment@1.0.1
 mquandalle:mousetrap-bindglobal@0.0.1
 mquandalle:perfect-scrollbar@0.6.5_2
+mquandalle:stylus@1.1.1
 npm-bcrypt@0.7.8_2
 npm-mongo@1.4.40-faster-rebuild.0
 observe-sequence@1.0.7
@@ -130,7 +131,6 @@ spacebars@1.0.7
 spacebars-compiler@1.0.7
 srp@1.0.4
 standard-minifiers@1.0.3-faster-rebuild.0
-stylus@2.511.2-faster-rebuild.0
 tap:i18n@1.7.0
 templates:tabs@2.2.0
 templating@1.1.6-faster-rebuild.0


### PR DESCRIPTION
@mquandalle After you change package "mquandalle:stylus" to "stylus", the display and drag&drop of cards on mobile web (on iPhone Chrome and Safari) will be buggy. (It's looks okay on PC chrome narrow window.) 

This PR just revert this change.

When use "mquandalle:stylus": | When use "stylus":
---|---
![correct](https://cloud.githubusercontent.com/assets/2339512/12048152/36db0fb8-af12-11e5-9abd-bbfd94ce9b76.jpg) | ![bug](https://cloud.githubusercontent.com/assets/2339512/12048161/4eaf28a4-af12-11e5-9d6c-b9a1f63a3c16.jpg)
---|---

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/461)
<!-- Reviewable:end -->
