### PR TITLE
Autosize card title

### DIFF
--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -2,10 +2,7 @@ template(name="cardDetails")
   section.card-details.js-card-details.js-perfect-scrollbar: .card-details-canvas
     .card-details-header
       +inlinedForm(classNames="js-card-details-title")
-        input.full-line(type="text" value=title autofocus)
-        .edit-controls.clearfix
-          button.primary.confirm(type="submit") {{_ 'save'}}
-          a.fa.fa-times-thin.js-close-inlined-form
+        +editCardTitleForm
       else
         a.fa.fa-times-thin.close-card-details.js-close-card-details
         if currentUser.isBoardMember
@@ -76,6 +73,13 @@ template(name="cardDetails")
       +commentForm
     if isLoaded.get
       +activities(card=this mode="card")
+
+template(name="editCardTitleForm")
+  textarea.js-edit-card-title(rows='1' autofocus)
+    = title
+  .edit-controls.clearfix
+    button.primary.confirm.js-submit-edit-card-title-form(type="submit") {{_ 'save'}}
+    a.fa.fa-times-thin.js-close-inlined-form
 
 template(name="cardDetailsActionsPopup")
   ul.pop-over-list

--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -141,6 +141,19 @@ Template.cardDetailsActionsPopup.events({
   'click .js-more': Popup.open('cardMore'),
 });
 
+Template.editCardTitleForm.onRendered(function() {
+  autosize(this.$('.js-edit-card-title'));
+});
+
+Template.editCardTitleForm.events({
+  'keydown .js-edit-card-title'(evt) {
+    // If enter key was pressed, submit the data
+    if (evt.keyCode === 13) {
+      $('.js-submit-edit-card-title-form').click();
+    }
+  },
+});
+
 Template.moveCardPopup.events({
   'click .js-select-list'() {
     // XXX We should *not* get the currentCard from the global state, but


### PR DESCRIPTION
I have moved the input component and controls from `cardDetails` template to a separate template called `editCardTitleForm`. 

Then in `cardDetails.js`, I have created the `onRendered` hook and used the autosize package to expand the textarea by default.

Please review the changes, and if I need to change anything kindly let me know!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/463)
<!-- Reviewable:end -->
