### PR TITLE
added exact time as tooltip to activity time

### DIFF
--- a/client/components/activities/activities.jade
+++ b/client/components/activities/activities.jade
@@ -71,7 +71,7 @@ template(name="boardActivities")
           else
             | {{{_ 'activity-removed' memberLink cardLink}}}.
 
-        span.activity-meta {{ moment createdAt }}
+        span(title=createdAt).activity-meta {{ moment createdAt }}
 
 template(name="cardActivities")
   each currentCard.activities
@@ -114,7 +114,7 @@ template(name="cardActivities")
             .activity-comment
               +viewer
                 = comment.text
-            span.activity-meta {{ moment createdAt }}
+            span(title=createdAt).activity-meta {{ moment createdAt }}
               if ($eq currentUser._id comment.userId)
                 = ' - '
                 a.js-open-inlined-form {{_ "edit"}}
@@ -122,4 +122,4 @@ template(name="cardActivities")
                 a.js-delete-comment {{_ "delete"}}
 
         else
-          span.activity-meta {{ moment createdAt }}
+          span(title=createdAt).activity-meta {{ moment createdAt }}


### PR DESCRIPTION
This is a very small change, but it helps very much to see the exact time of an activity.
The activity time is a good description relative to the current time (like "1 month ago"). But sometimes it is important to know the exact time. Now you only have to point your mouse onto it, and it show the exact time stamp.

I hope this helps others, too.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/468)
<!-- Reviewable:end -->
