### PR TITLE
ports in docker-compose.yml must be an array

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ wekandb:
 #    - ./data/runtime/db:/data/db
 #    - ./data/dump:/dump
   command: mongod --smallfiles --oplogSize 128
-  ports: 27017
+  ports:
+    - 27017
 
 wekan:
   image: mquandalle/wekan


### PR DESCRIPTION
Otherwise we run into the following issue with docker-compose 1.5.2:

    $ docker-compose up
    ERROR: Validation failed in file './docker-compose.yml', reason(s):
    Service 'wekandb' configuration key 'ports' contains an invalid type, it should be an array

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/478)
<!-- Reviewable:end -->
