### PR TITLE
Bugfix: #504 Trello import displayed blank popup

### DIFF
--- a/client/components/import/import.js
+++ b/client/components/import/import.js
@@ -7,6 +7,10 @@
 /// - getLabel(): i18n key for the text displayed in the popup, usually to
 /// explain how to get the data out of the source system.
 const ImportPopup = BlazeComponent.extendComponent({
+  template() {
+    // DO NOT remove, this is needed by sub-classes!
+    return 'importPopup';
+  },
   jsonText() {
     return Session.get('import.text');
   },


### PR DESCRIPTION
commit [ac6491ea127215cb07ca490fc2cc1af7c3778e8f](https://github.com/wekan/wekan/commit/ac6491ea127215cb07ca490fc2cc1af7c3778e8f) was a bit too agressive and broke import sub-components, causing #504

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/505)
<!-- Reviewable:end -->
