### PR TITLE
Move cards to top / bottom

### DIFF
--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -93,6 +93,10 @@ template(name="cardDetailsActionsPopup")
     li: a.js-attachments {{_ 'card-edit-attachments'}}
   hr
   ul.pop-over-list
+    li: a.js-move-card-to-top {{_ 'moveCardToTop-title'}}
+    li: a.js-move-card-to-bottom {{_ 'moveCardToBottom-title'}}
+  hr
+  ul.pop-over-list
     li: a.js-move-card {{_ 'moveCardPopup-title'}}
     unless archived
       li: a.js-archive {{_ 'archive-card'}}

--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -144,6 +144,16 @@ Template.cardDetailsActionsPopup.events({
   'click .js-labels': Popup.open('cardLabels'),
   'click .js-attachments': Popup.open('cardAttachments'),
   'click .js-move-card': Popup.open('moveCard'),
+  'click .js-move-card-to-top'(evt) {
+    evt.preventDefault();
+    const minOrder = _.min(this.list().cards().map((c) => c.sort));
+    this.move(this.listId, minOrder / 2);
+  },
+  'click .js-move-card-to-bottom'(evt) {
+    evt.preventDefault();
+    const maxOrder = _.max(this.list().cards().map((c) => c.sort));
+    this.move(this.listId, Math.floor(maxOrder) + 1);
+  },
   'click .js-archive'(evt) {
     evt.preventDefault();
     this.archive();

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -215,6 +215,8 @@
     "menu": "Menu",
     "move-selection": "Move selection",
     "moveCardPopup-title": "Move Card",
+    "moveCardToBottom-title": "Move to Bottom",
+    "moveCardToTop-title": "Move to Top",
     "moveSelectionPopup-title": "Move selection",
     "multi-selection": "Multi-Selection",
     "multi-selection-on": "Multi-Selection is on",


### PR DESCRIPTION
I'm offering these simple commands to move cards to the top / bottom of the whole list.

Issue #476 bothering me very much, but "move to top/bottom of the list" are commands I'm using very often. If they're here, then #476 is not that a big problem anymore (but we will still need a proper fix for that).

Please tell me what are you thinking about adding this function, and review my code. I don't know much about Wekan architecture, meteor or mongodb, but this simplest implementation seems to work good. If this PR has any problems with code style or my approach to making things - please tell me, I'm ready to collaborate and change it based on your requirements.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/530)
<!-- Reviewable:end -->
