### PR TITLE
add ESLint-plugin-Meteor

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,5 +1,8 @@
-ecmaFeatures:
-  experimentalObjectRestSpread: true
+parserOptions:
+  ecmaVersion: 6
+  sourceType: module
+  ecmaFeatures:
+    experimentalObjectRestSpread: true
 
 rules:
   strict: 0
@@ -47,23 +50,17 @@ rules:
   prefer-spread: 2
   prefer-template: 2
 
-globals:
-  # Meteor globals
-  Meteor: false
-  Session: false
-  HTML: false
-  check: false
-  Tracker: false
-  Blaze: false
-  Accounts: false
-  Match: false
-  Mongo: false
-  Random: false
-  ReactiveVar: false
-  Email: false
-  Template: false
+  # ESLint-plugin-Meteor
+  meteor/no-session: [0]
+  meteor/prefer-session-equals: [2]
+  meteor/eventmap-params:
+    - 2
+    - eventParamName: evt
+      templateInstanceParamName: tpl
 
+globals:
   # Exported by packages we use
+  HTML: false
   '$': false
   _: false
   autosize: false
@@ -125,5 +122,11 @@ env:
   es6: true
   node: true
   browser: true
+  meteor: true
 
-extends: 'eslint:recommended'
+plugins:
+  - meteor
+
+extends:
+  - 'eslint:recommended'
+  - 'plugin:meteor/recommended'

--- a/client/components/cards/attachments.js
+++ b/client/components/cards/attachments.js
@@ -8,8 +8,8 @@ Template.attachmentsGalery.events({
   ),
   // If we let this event bubble, FlowRouter will handle it and empty the page
   // content, see #101.
-  'click .js-download'(event) {
-    event.stopPropagation();
+  'click .js-download'(evt) {
+    evt.stopPropagation();
   },
   'click .js-open-viewer'() {
     // XXX Not implemented!

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -203,16 +203,15 @@ BlazeComponent.extendComponent({
         match: /\B#(\w*)$/,
         search(term, callback) {
           const currentBoard = Boards.findOne(Session.get('currentBoard'));
-          callback($.map(currentBoard.labels, (label) => {
-            if (label.name.indexOf(term) > -1 ||
-                label.color.indexOf(term) > -1) {
-              return label;
-            }
-          }));
+          callback($.map(currentBoard.labels, (label) =>
+            label.name.indexOf(term) > -1 || label.color.indexOf(term) > -1
+              ? label
+              : undefined
+          ));
         },
         template(label) {
           return Blaze.toHTMLWithData(Template.autocompleteLabelLine, {
-            hasNoName: !Boolean(label.name),
+            hasNoName: !label.name,
             colorName: label.color,
             labelName: label.name || label.color,
           });
@@ -233,6 +232,7 @@ BlazeComponent.extendComponent({
           evt.stopPropagation();
           return commands.KEY_ENTER;
         }
+        return undefined;
       },
     });
   },

--- a/client/components/main/editor.js
+++ b/client/components/main/editor.js
@@ -61,18 +61,17 @@ Blaze.Template.registerHelper('mentions', new Template('mentions', function() {
   const mentionRegex = /\B@(\w*)/gi;
   let content = Blaze.toHTML(view.templateContentBlock);
 
-  let currentMention, knowedUser, linkClass, linkValue, link;
-  while (Boolean(currentMention = mentionRegex.exec(content))) {
-
-    knowedUser = _.findWhere(knowedUsers, { username: currentMention[1] });
+  let currentMention, linkClass;
+  while (currentMention = mentionRegex.exec(content)) { // eslint-disable-line no-cond-assign
+    const knowedUser = _.findWhere(knowedUsers, { username: currentMention[1] });
     if (!knowedUser)
       continue;
 
-    linkValue = [' ', at, knowedUser.username];
+    const linkValue = [' ', at, knowedUser.username];
     linkClass = 'atMention js-open-member';
     if (knowedUser.userId === Meteor.userId())
       linkClass += ' me';
-    link = HTML.A({
+    const link = HTML.A({
       'class': linkClass,
       // XXX Hack. Since we stringify this render function result below with
       // `Blaze.toHTML` we can't rely on blaze data contexts to pass the

--- a/client/components/sidebar/sidebar.js
+++ b/client/components/sidebar/sidebar.js
@@ -295,10 +295,10 @@ BlazeComponent.extendComponent({
 }).register('addMemberPopup');
 
 Template.changePermissionsPopup.events({
-  'click .js-set-admin, click .js-set-normal'(event) {
+  'click .js-set-admin, click .js-set-normal'(evt) {
     const currentBoard = Boards.findOne(Session.get('currentBoard'));
     const memberId = this.userId;
-    const isAdmin = $(event.currentTarget).hasClass('js-set-admin');
+    const isAdmin = $(evt.currentTarget).hasClass('js-set-admin');
     currentBoard.setMemberPermission(memberId, isAdmin);
     Popup.back(1);
   },

--- a/client/components/sidebar/sidebarFilters.js
+++ b/client/components/sidebar/sidebarFilters.js
@@ -70,6 +70,7 @@ BlazeComponent.extendComponent({
           // UI components systems.
           return popup.call(this.currentData(), evt);
         }
+        return undefined;
       },
       'click .js-toggle-member-multiselection'(evt) {
         const memberId = this.currentData()._id;
@@ -84,6 +85,7 @@ BlazeComponent.extendComponent({
           // UI components systems.
           return popup.call(this.currentData(), evt);
         }
+        return undefined;
       },
       'click .js-move-selection': Popup.open('moveSelection'),
       'click .js-archive-selection'() {

--- a/client/config/blazeHelpers.js
+++ b/client/config/blazeHelpers.js
@@ -1,15 +1,15 @@
 Blaze.registerHelper('currentBoard', () => {
   const boardId = Session.get('currentBoard');
-  if (boardId) {
-    return Boards.findOne(boardId);
-  }
+  return boardId
+    ? Boards.findOne(boardId)
+    : undefined;
 });
 
 Blaze.registerHelper('currentCard', () => {
   const cardId = Session.get('currentCard');
-  if (cardId) {
-    return Cards.findOne(cardId);
-  }
+  return cardId
+   ? Cards.findOne(cardId)
+   : undefined;
 });
 
 Blaze.registerHelper('getUser', (userId) => Users.findOne(userId));

--- a/client/lib/cssEvents.js
+++ b/client/lib/cssEvents.js
@@ -15,6 +15,7 @@ function whichTransitionEvent() {
       return transitions[t];
     }
   }
+  return undefined;
 }
 
 function whichAnimationEvent() {
@@ -32,6 +33,7 @@ function whichAnimationEvent() {
       return transitions[t];
     }
   }
+  return undefined;
 }
 
 CSSEvents = {

--- a/client/lib/escapeActions.js
+++ b/client/lib/escapeActions.js
@@ -72,6 +72,7 @@ EscapeActions = {
         clickTarget: target,
       });
     }
+    return undefined;
   },
 
   preventNextClick() {

--- a/client/lib/multiSelection.js
+++ b/client/lib/multiSelection.js
@@ -109,12 +109,11 @@ MultiSelection = {
 
   toggleRange(cardId) {
     const selectedCards = this._selectedCards.get();
-    let startRange;
     this.reset();
     if (!this.isActive() || selectedCards.length === 0) {
       this.toggle(cardId);
     } else {
-      startRange = selectedCards[selectedCards.length - 1];
+      const startRange = selectedCards[selectedCards.length - 1];
       this.toggle(getCardsBetween(startRange, cardId));
     }
   },

--- a/client/lib/popup.js
+++ b/client/lib/popup.js
@@ -38,7 +38,8 @@ window.Popup = new class {
       if (self.isOpen()) {
         const previousOpenerElement = self._getTopStack().openerElement;
         if (previousOpenerElement === evt.currentTarget) {
-          return self.close();
+          self.close();
+          return;
         } else {
           $(previousOpenerElement).removeClass('is-active');
         }
@@ -204,4 +205,3 @@ escapeActions.forEach((actionName) => {
     }
   );
 });
-

--- a/client/lib/textComplete.js
+++ b/client/lib/textComplete.js
@@ -14,6 +14,7 @@ $.fn.escapeableTextComplete = function(strategies, options, ...otherArgs) {
         evt.stopPropagation();
         return commands.KEY_ENTER;
       }
+      return undefined;
     },
     ...options,
   };

--- a/models/boards.js
+++ b/models/boards.js
@@ -201,6 +201,7 @@ Boards.mutations({
       const _id = Random.id(6);
       return { $push: {labels: { _id, name, color }}};
     }
+    return undefined;
   },
 
   editLabel(labelId, name, color) {
@@ -213,6 +214,7 @@ Boards.mutations({
         },
       };
     }
+    return undefined;
   },
 
   removeLabel(labelId) {

--- a/models/import.js
+++ b/models/import.js
@@ -398,7 +398,7 @@ class TrelloCreator {
   parseActions(trelloActions) {
     trelloActions.forEach((action) => {
       switch (action.type) {
-      case 'addAttachmentToCard':
+      case 'addAttachmentToCard': {
         // We have to be cautious, because the attachment could have been removed later.
         // In that case Trello still reports its addition, but removes its 'url' field.
         // So we test for that
@@ -413,7 +413,8 @@ class TrelloCreator {
           this.attachments[trelloCardId].push(trelloAttachment);
         }
         break;
-      case 'commentCard':
+      }
+      case 'commentCard': {
         const id = action.data.card.id;
         if (this.comments[id]) {
           this.comments[id].push(action);
@@ -421,18 +422,21 @@ class TrelloCreator {
           this.comments[id] = [action];
         }
         break;
+      }
       case 'createBoard':
         this.createdAt.board = action.date;
         break;
-      case 'createCard':
+      case 'createCard': {
         const cardId = action.data.card.id;
         this.createdAt.cards[cardId] = action.date;
         this.createdBy.cards[cardId] = action.idMemberCreator;
         break;
-      case 'createList':
+      }
+      case 'createList': {
         const listId = action.data.list.id;
         this.createdAt.lists[listId] = action.date;
         break;
+      }
       default:
         // do nothing
         break;
@@ -446,10 +450,11 @@ Meteor.methods({
     const trelloCreator = new TrelloCreator(data);
 
     // 1. check all parameters are ok from a syntax point of view
+    check(trelloBoard, Match.Any);
+    check(data, {
+      membersMapping: Match.Optional(Object),
+    });
     try {
-      check(data, {
-        membersMapping: Match.Optional(Object),
-      });
       trelloCreator.checkActions(trelloBoard.actions);
       trelloCreator.checkBoard(trelloBoard);
       trelloCreator.checkLabels(trelloBoard.labels);

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "homepage": "https://wekan.io",
   "devDependencies": {
-    "babel-eslint": "4.1.3",
-    "eslint": "1.7.3",
-    "eslint-plugin-meteor": "1.7.0"
+    "eslint": "2.3.0",
+    "eslint-plugin-meteor": "3.0.2"
   }
 }


### PR DESCRIPTION
This adds [ESLint-plugin-Meteor](https://github.com/dferber90/eslint-plugin-meteor/).

**Changes**
- adds ESLint-plugin-Meteor
- upgrade ESLint to v2
- use Meteor environment, remove resulting duplicate globals definitions
- enable ESLint-plugin-Meteor in eslintrc
- fix surfaced issues

**Potential Problems**
I haven't tested the fixes for the surfaced issues. After pulling/merging this branch, make sure to run `npm install` again.

*I know ESLint-plugin-Meteor has been added before and then I dropped support for it because ESLint and Meteor were both changing so heavily and it wasn't possible to keep up. Now things have settled down and I rewrote the plugin.*

---
To read up on linting and ESLint-plugin-Meteor, you can read [this article](https://medium.com/@dferber90/linting-meteor-8f229ebc7942).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/540)
<!-- Reviewable:end -->
