### PR TITLE
Some UI enhancements for the public board view 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# v0.11
+
+This release adds the following new features:
+
+* Notification system with email notifications of the changes in a board,
+  a list or on a card;
+* Show the exact time when hovering the activity time;
+* Allow to edit more easily longer card titles by resizing the input box;
+* Add shortcuts to move cards to the top or the bottom of a list;
+* A new log-in button on the public board view to sign in, even if the board
+  is published;
+
+and fixes the following bugs:
+
+* Fix the syntax of the docker-compose.yml;
+* Use the correct pluralization of emoji;
+* Only publish required user data and keep the hashed passwords confidential;
+* Fix the generation and alignment of the initials avatars;
+* Only display the buttons in the board header, if the data is avialable
+  and the user is able to use it;
+
+Thanks to GitHub users alayek, AlexanderS, choclin, floatinghotpot, ForNeVeR,
+seschwar, and TheElf for their contributions.
+
 # v0.10.1
 
 This patch release fixes two bugs on Sandstorm:

--- a/client/components/boards/boardHeader.jade
+++ b/client/components/boards/boardHeader.jade
@@ -19,16 +19,17 @@ template(name="boardHeaderBar")
           i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
           span {{_ currentBoard.permission}}
 
-        a.board-header-btn.js-watch-board
-          if $eq watchLevel "watching"
-            i.fa.fa-eye
-            span {{_ 'watching'}}
-          if $eq watchLevel "tracking"
-            i.fa.fa-bell
-            span {{_ 'tracking'}}
-          if $eq watchLevel "muted"
-            i.fa.fa-bell-slash
-            span {{_ 'muted'}}
+        if currentUser
+          a.board-header-btn.js-watch-board
+            if $eq watchLevel "watching"
+              i.fa.fa-eye
+              span {{_ 'watching'}}
+            if $eq watchLevel "tracking"
+              i.fa.fa-bell
+              span {{_ 'tracking'}}
+            if $eq watchLevel "muted"
+              i.fa.fa-bell-slash
+              span {{_ 'muted'}}
 
   .board-header-btns.right
     if isMiniScreen
@@ -47,15 +48,16 @@ template(name="boardHeaderBar")
           i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
           span {{_ currentBoard.permission}}
 
-        a.board-header-btn.js-watch-board(
-          title="{{_ watchLevel }}")
-          if $eq watchLevel "watching"
-            i.fa.fa-eye
-          if $eq watchLevel "tracking"
-            i.fa.fa-bell
-          if $eq watchLevel "muted"
-            i.fa.fa-bell-slash
-          span {{_ watchLevel}}
+        if currentUser
+          a.board-header-btn.js-watch-board(
+            title="{{_ watchLevel }}")
+            if $eq watchLevel "watching"
+              i.fa.fa-eye
+            if $eq watchLevel "tracking"
+              i.fa.fa-bell
+            if $eq watchLevel "muted"
+              i.fa.fa-bell-slash
+            span {{_ watchLevel}}
 
     a.board-header-btn.js-open-filter-view(
         title="{{#if Filter.isActive}}{{_ 'filter-on-desc'}}{{else}}{{_ 'filter'}}{{/if}}"

--- a/client/components/boards/boardHeader.jade
+++ b/client/components/boards/boardHeader.jade
@@ -16,20 +16,21 @@ template(name="boardHeaderBar")
                 span
                   = currentBoard.stars
 
-            a.board-header-btn(class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}")
+            a.board-header-btn(
+              class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}"
+              title="{{_ currentBoard.permission}}")
               i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
               span {{_ currentBoard.permission}}
 
-            a.board-header-btn.js-watch-board
+            a.board-header-btn.js-watch-board(
+              title="{{_ watchLevel }}")
               if $eq watchLevel "watching"
                 i.fa.fa-eye
-                span {{_ 'watching'}}
               if $eq watchLevel "tracking"
                 i.fa.fa-bell
-                span {{_ 'tracking'}}
               if $eq watchLevel "muted"
                 i.fa.fa-bell-slash
-                span {{_ 'muted'}}
+              span {{_ watchLevel}}
 
           else
             a.board-header-btn.js-log-in(

--- a/client/components/boards/boardHeader.jade
+++ b/client/components/boards/boardHeader.jade
@@ -16,11 +16,10 @@ template(name="boardHeaderBar")
                 span
                   = currentBoard.stars
 
-          a.board-header-btn(class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}")
-            i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
-            span {{_ currentBoard.permission}}
+            a.board-header-btn(class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}")
+              i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
+              span {{_ currentBoard.permission}}
 
-          if currentUser
             a.board-header-btn.js-watch-board
               if $eq watchLevel "watching"
                 i.fa.fa-eye
@@ -31,6 +30,12 @@ template(name="boardHeaderBar")
               if $eq watchLevel "muted"
                 i.fa.fa-bell-slash
                 span {{_ 'muted'}}
+
+          else
+            a.board-header-btn.js-log-in(
+              title="{{_ 'log-in'}}")
+              i.fa.fa-sign-in
+              span {{_ 'log-in'}}
 
   .board-header-btns.right
     if currentBoard
@@ -44,13 +49,12 @@ template(name="boardHeaderBar")
                 span
                   = currentBoard.stars
 
-          a.board-header-btn(
-            class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}"
-            title="{{_ currentBoard.permission}}")
-            i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
-            span {{_ currentBoard.permission}}
+            a.board-header-btn(
+              class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}"
+              title="{{_ currentBoard.permission}}")
+              i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
+              span {{_ currentBoard.permission}}
 
-          if currentUser
             a.board-header-btn.js-watch-board(
               title="{{_ watchLevel }}")
               if $eq watchLevel "watching"
@@ -60,6 +64,12 @@ template(name="boardHeaderBar")
               if $eq watchLevel "muted"
                 i.fa.fa-bell-slash
               span {{_ watchLevel}}
+  
+          else
+            a.board-header-btn.js-log-in(
+              title="{{_ 'log-in'}}")
+              i.fa.fa-sign-in
+              span {{_ 'log-in'}}
 
       a.board-header-btn.js-open-filter-view(
           title="{{#if Filter.isActive}}{{_ 'filter-on-desc'}}{{else}}{{_ 'filter'}}{{/if}}"

--- a/client/components/boards/boardHeader.jade
+++ b/client/components/boards/boardHeader.jade
@@ -7,80 +7,82 @@ template(name="boardHeaderBar")
   .board-header-btns.left
     unless isMiniScreen
       unless isSandstorm
-        if currentUser
-          a.board-header-btn.js-star-board(class="{{#if isStarred}}is-active{{/if}}"
-            title="{{#if isStarred}}{{_ 'click-to-unstar'}}{{else}}{{_ 'click-to-star'}}{{/if}} {{_ 'starred-boards-description'}}")
-            i.fa(class="fa-star{{#unless isStarred}}-o{{/unless}}")
-            if showStarCounter
-              span
-                = currentBoard.stars
+        if currentBoard
+          if currentUser
+            a.board-header-btn.js-star-board(class="{{#if isStarred}}is-active{{/if}}"
+              title="{{#if isStarred}}{{_ 'click-to-unstar'}}{{else}}{{_ 'click-to-star'}}{{/if}} {{_ 'starred-boards-description'}}")
+              i.fa(class="fa-star{{#unless isStarred}}-o{{/unless}}")
+              if showStarCounter
+                span
+                  = currentBoard.stars
 
-        a.board-header-btn(class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}")
-          i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
-          span {{_ currentBoard.permission}}
+          a.board-header-btn(class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}")
+            i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
+            span {{_ currentBoard.permission}}
 
-        if currentUser
-          a.board-header-btn.js-watch-board
-            if $eq watchLevel "watching"
-              i.fa.fa-eye
-              span {{_ 'watching'}}
-            if $eq watchLevel "tracking"
-              i.fa.fa-bell
-              span {{_ 'tracking'}}
-            if $eq watchLevel "muted"
-              i.fa.fa-bell-slash
-              span {{_ 'muted'}}
+          if currentUser
+            a.board-header-btn.js-watch-board
+              if $eq watchLevel "watching"
+                i.fa.fa-eye
+                span {{_ 'watching'}}
+              if $eq watchLevel "tracking"
+                i.fa.fa-bell
+                span {{_ 'tracking'}}
+              if $eq watchLevel "muted"
+                i.fa.fa-bell-slash
+                span {{_ 'muted'}}
 
   .board-header-btns.right
-    if isMiniScreen
-      unless isSandstorm
-        if currentUser
-          a.board-header-btn.js-star-board(class="{{#if isStarred}}is-active{{/if}}"
-            title="{{#if isStarred}}{{_ 'click-to-unstar'}}{{else}}{{_ 'click-to-star'}}{{/if}} {{_ 'starred-boards-description'}}")
-            i.fa(class="fa-star{{#unless isStarred}}-o{{/unless}}")
-            if showStarCounter
-              span
-                = currentBoard.stars
+    if currentBoard
+      if isMiniScreen
+        unless isSandstorm
+          if currentUser
+            a.board-header-btn.js-star-board(class="{{#if isStarred}}is-active{{/if}}"
+              title="{{#if isStarred}}{{_ 'click-to-unstar'}}{{else}}{{_ 'click-to-star'}}{{/if}} {{_ 'starred-boards-description'}}")
+              i.fa(class="fa-star{{#unless isStarred}}-o{{/unless}}")
+              if showStarCounter
+                span
+                  = currentBoard.stars
 
-        a.board-header-btn(
-          class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}"
-          title="{{_ currentBoard.permission}}")
-          i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
-          span {{_ currentBoard.permission}}
+          a.board-header-btn(
+            class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}"
+            title="{{_ currentBoard.permission}}")
+            i.fa(class="{{#if currentBoard.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
+            span {{_ currentBoard.permission}}
 
-        if currentUser
-          a.board-header-btn.js-watch-board(
-            title="{{_ watchLevel }}")
-            if $eq watchLevel "watching"
-              i.fa.fa-eye
-            if $eq watchLevel "tracking"
-              i.fa.fa-bell
-            if $eq watchLevel "muted"
-              i.fa.fa-bell-slash
-            span {{_ watchLevel}}
+          if currentUser
+            a.board-header-btn.js-watch-board(
+              title="{{_ watchLevel }}")
+              if $eq watchLevel "watching"
+                i.fa.fa-eye
+              if $eq watchLevel "tracking"
+                i.fa.fa-bell
+              if $eq watchLevel "muted"
+                i.fa.fa-bell-slash
+              span {{_ watchLevel}}
 
-    a.board-header-btn.js-open-filter-view(
-        title="{{#if Filter.isActive}}{{_ 'filter-on-desc'}}{{else}}{{_ 'filter'}}{{/if}}"
-        class="{{#if Filter.isActive}}emphasis{{/if}}")
-      i.fa.fa-filter
-      span {{#if Filter.isActive}}{{_ 'filter-on'}}{{else}}{{_ 'filter'}}{{/if}}
-      if Filter.isActive
-        a.board-header-btn-close.js-filter-reset(title="{{_ 'filter-clear'}}")
-          i.fa.fa-times-thin
-
-    if currentUser.isBoardMember
-      a.board-header-btn.js-multiselection-activate(
-          title="{{#if MultiSelection.isActive}}{{_ 'multi-selection-on'}}{{else}}{{_ 'multi-selection'}}{{/if}}"
-          class="{{#if MultiSelection.isActive}}emphasis{{/if}}")
-        i.fa.fa-check-square-o
-        span {{#if MultiSelection.isActive}}{{_ 'multi-selection-on'}}{{else}}{{_ 'multi-selection'}}{{/if}}
-        if MultiSelection.isActive
-          a.board-header-btn-close.js-multiselection-reset(title="{{_ 'filter-clear'}}")
+      a.board-header-btn.js-open-filter-view(
+          title="{{#if Filter.isActive}}{{_ 'filter-on-desc'}}{{else}}{{_ 'filter'}}{{/if}}"
+          class="{{#if Filter.isActive}}emphasis{{/if}}")
+        i.fa.fa-filter
+        span {{#if Filter.isActive}}{{_ 'filter-on'}}{{else}}{{_ 'filter'}}{{/if}}
+        if Filter.isActive
+          a.board-header-btn-close.js-filter-reset(title="{{_ 'filter-clear'}}")
             i.fa.fa-times-thin
 
-    .separator
-    a.board-header-btn.js-open-board-menu
-      i.board-header-btn-icon.fa.fa-navicon
+      if currentUser.isBoardMember
+        a.board-header-btn.js-multiselection-activate(
+            title="{{#if MultiSelection.isActive}}{{_ 'multi-selection-on'}}{{else}}{{_ 'multi-selection'}}{{/if}}"
+            class="{{#if MultiSelection.isActive}}emphasis{{/if}}")
+          i.fa.fa-check-square-o
+          span {{#if MultiSelection.isActive}}{{_ 'multi-selection-on'}}{{else}}{{_ 'multi-selection'}}{{/if}}
+          if MultiSelection.isActive
+            a.board-header-btn-close.js-multiselection-reset(title="{{_ 'filter-clear'}}")
+            i.fa.fa-times-thin
+
+      .separator
+      a.board-header-btn.js-open-board-menu
+        i.board-header-btn-icon.fa.fa-navicon
 
 template(name="boardMenuPopup")
   ul.pop-over-list

--- a/client/components/boards/boardHeader.js
+++ b/client/components/boards/boardHeader.js
@@ -90,6 +90,9 @@ BlazeComponent.extendComponent({
         evt.stopPropagation();
         MultiSelection.disable();
       },
+      'click .js-log-in'() {
+        FlowRouter.go('atSignIn');
+      },
     }];
   },
 }).register('boardHeaderBar');

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -209,6 +209,7 @@
     "listImportCardPopup-title": "Import a Trello card",
     "lists": "Lists",
     "log-out": "Log Out",
+    "log-in": "Log In",
     "loginPopup-title": "Log In",
     "memberMenuPopup-title": "Member Settings",
     "members": "Members",


### PR DESCRIPTION
The public board view was kind of broken:

* The notification settings are only useful if you are logged in. It will use the email address from your profile, that is not there if you do not have a user account.
* If the board is private or if the board does not exists the options should not be visible. The visibility indicator for example will display "undefined". So the header bar should be empty if there is no board available.
* If you are member of a public board and you are currently not signed in, you may want to sign in to take changes if you follow a link to a board/card. So I think it is ok to replace the visibility indicator with a sign-in link for public boards. It does not provide any more value. If you can see the board without being logged in, it will always display "public".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/578)
<!-- Reviewable:end -->
