### PR TITLE
Do not publish the whole user doc of board members

### DIFF
--- a/server/publications/boards.js
+++ b/server/publications/boards.js
@@ -105,7 +105,11 @@ Meteor.publishRelations('board', function(boardId) {
     //
     this.cursor(Users.find({
       _id: { $in: _.pluck(board.members, 'userId') },
-    }), function(userId) {
+    }, { fields: {
+      'username': 1,
+      'profile.fullname': 1,
+      'profile.avatarUrl': 1,
+    }}), function(userId) {
       // Presence indicators
       this.cursor(presences.find({ userId }));
     });


### PR DESCRIPTION
The user document contains hashed passwords and hashed resume tokens.
We should only publish the required bits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/579)
<!-- Reviewable:end -->
