### PR TITLE
Center text in the initails avatars

### DIFF
--- a/client/components/users/userAvatar.jade
+++ b/client/components/users/userAvatar.jade
@@ -17,7 +17,7 @@ template(name="userAvatar")
 
 template(name="userAvatarInitials")
   svg.avatar.avatar-initials(viewBox="0 0 {{viewPortWidth}} 15")
-    text(x="0" y="13")= initials
+    text(x="50%" y="13" text-anchor="middle")= initials
 
 template(name="userPopup")
   .board-member-menu


### PR DESCRIPTION
I had the impression, that the text inside the avatars is not really centered. Instead of adjusting the x-coordinate it seems easier to change the text-anchor to the middle and center the text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/581)
<!-- Reviewable:end -->
