### PR TITLE
Add DPlatform as an installation way

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ that by providing one-click installation on Heroku or [Sandstorm]
 
 [![Deploy][heroku_button]][heroku_deploy]
 
+[![DP deploy](https://raw.githubusercontent.com/j8r/DPlatform/gh-pages/img/deploy.png)](https://j8r.github.io/DPlatform/)
+
 [![SignUp][indiehosters_button]][indiehosters_saas]
 
 [![Deploy to Scalingo][scalingo_button]][scalingo_deploy]


### PR DESCRIPTION
Hello, i'm the creator of [DPlatform](https://github.com/j8r/DPlatform), that aims to make it easy to install self-hosted applications.
I really like your Kanban board, so I added its support to my project.
I would like to add a link to it on your main page and in your Wiki, so that other people can easily install Wekan on their Linux servers.
RaspberryPi users can also install Wekan (thanks to #521 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/589)
<!-- Reviewable:end -->
