### PR TITLE
Fix move to top

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -147,12 +147,12 @@ Template.cardDetailsActionsPopup.events({
   'click .js-move-card-to-top'(evt) {
     evt.preventDefault();
     const minOrder = _.min(this.list().cards().map((c) => c.sort));
-    this.move(this.listId, minOrder / 2);
+    this.move(this.listId, minOrder - 1);
   },
   'click .js-move-card-to-bottom'(evt) {
     evt.preventDefault();
     const maxOrder = _.max(this.list().cards().map((c) => c.sort));
-    this.move(this.listId, Math.floor(maxOrder) + 1);
+    this.move(this.listId, maxOrder + 1);
   },
   'click .js-archive'(evt) {
     evt.preventDefault();


### PR DESCRIPTION
If the `minOrder` is 0, the previous code does not work. This code is now
doing the obvious stuff to change the order. 

I could not imagine a case where this is not working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/605)
<!-- Reviewable:end -->
