### PR TITLE
Fix untranslated watch/unwatch for gecko

### DIFF
--- a/client/config/gecko-fix.js
+++ b/client/config/gecko-fix.js
@@ -1,0 +1,4 @@
+if (Object.prototype.hasOwnProperty('watch')) {
+  Object.prototype.watch = undefined;
+  Object.prototype.unwatch = undefined;
+}


### PR DESCRIPTION
In the Gecko JavaScript engine the Object prototype has a method
'watch()' and 'unwatch()'. This causes strange error messages displayed,
if 'watch' and 'unwatch' are not translated in the chosen localization.
The i18n module cannot handle, if it gets a function for the
translation.

This is a quick fix that removes the 'watch' and 'unwatch' properties
from the Object prototype.

See also: https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/watch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/606)
<!-- Reviewable:end -->
