### PR TITLE
UI: Fix overlapping click event handler

### DIFF
--- a/client/components/main/editor.js
+++ b/client/components/main/editor.js
@@ -90,15 +90,10 @@ Blaze.Template.registerHelper('mentions', new Template('mentions', function() {
 }));
 
 Template.viewer.events({
-  'click .js-open-member'(evt, tpl) {
-    const userId = evt.currentTarget.dataset.userid;
-    Popup.open('member').call({ userId }, evt, tpl);
-  },
-
   // Viewer sometimes have click-able wrapper around them (for instance to edit
   // the corresponding text). Clicking a link shouldn't fire these actions, stop
   // we stop these event at the viewer component level.
-  'click a'(evt) {
+  'click a'(evt, tpl) {
     evt.stopPropagation();
 
     // XXX We hijack the build-in browser action because we currently don't have
@@ -106,9 +101,16 @@ Template.viewer.events({
     // handled by a third party package that we can't configure easily. Fix that
     // by using directly `_blank` attribute in the rendered HTML.
     evt.preventDefault();
-    const href = evt.currentTarget.href;
-    if (href) {
-      window.open(href, '_blank');
+
+    const userId = evt.currentTarget.dataset.userid;
+    if (userId) {
+      Popup.open('member').call({ userId }, evt, tpl);
+    }
+    else {
+      const href = evt.currentTarget.href;
+      if (href) {
+        window.open(href, '_blank');
+      }
     }
   },
 });


### PR DESCRIPTION
The click event handler for links in the card display are overlapping:
The general event for opening the link in a new window matches on user
mentions, too. But user mentions cannot be opened in a new window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/614)
<!-- Reviewable:end -->
