### PR TITLE
Added login-buttons for packages

### DIFF
--- a/client/components/main/layouts.jade
+++ b/client/components/main/layouts.jade
@@ -15,6 +15,9 @@ template(name="userFormsLayout")
     section.auth-dialog
       +Template.dynamic(template=content)
       div.at-form-lang
+      
+        | {{> loginButtons}}
+        
         select.select-lang.js-userform-set-language
           each languages
             if isCurrentLanguage


### PR DESCRIPTION
* Added login buttons for packages. Makes it possible to add packages, such as accounts-google, accounts-github and such for easy and fast authentication up against third-party providers. Doesen't "damage" the already existing view for login if the user doesn't add any third-party authentications services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/628)
<!-- Reviewable:end -->
