### PR TITLE
Fix showing card activity history in IE11

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -21,6 +21,14 @@ BlazeComponent.extendComponent({
     this.parentComponent().showOverlay.set(true);
     this.parentComponent().mouseHasEnterCardDetails = false;
     this.calculateNextPeak();
+    setTimeout(() => {
+      // Work around animationend event dispatch bug in IE11.
+      // The animationend listener is placed on the root node,
+      // not on the node specified by the selector.  As a result,
+      // IE never sees the completion of the animation, and never
+      // shows the activity list.
+      this.isLoaded.set(true);
+    }, 100);
   },
 
   isWatching() {


### PR DESCRIPTION
The animationend event doesn't seem to fire the way we expect it to under IE11.  This means that card history will never be visible when looking at card details in IE11, so work around it by also setting a timeout matching the animation time in case the animationend event never fires.

If you know of a better way to deal with this, I'm happy to adjust this patchset. :)

Tested in IE11 on Win7 via the modern.ie VMs: https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/646)
<!-- Reviewable:end -->
