### PR TITLE
Fix bug where you get a "null" option in @-mention autocomplete

### DIFF
--- a/client/components/main/editor.js
+++ b/client/components/main/editor.js
@@ -10,7 +10,7 @@ Template.editor.onRendered(() => {
       search(term, callback) {
         callback(Emoji.values.map((emoji) => {
           return emoji.includes(term) ? emoji : null;
-        }));
+        }).filter(emoji => !!emoji));
       },
       template(value) {
         const imgSrc = Emoji.baseImagePath + value;
@@ -31,7 +31,7 @@ Template.editor.onRendered(() => {
         callback(currentBoard.activeMembers().map((member) => {
           const username = Users.findOne(member.userId).username;
           return username.includes(term) ? username : null;
-        }));
+        }).filter(username => !!username));
       },
       template(value) {
         return value;


### PR DESCRIPTION
When autocompleting an @-mention of a user, if any users would be filtered out by the currently-entered text, there will be an entry "null" shown in the autocomplete dropdown.  This is caused by null return values not getting filtered out of the possible completions array before being visualized.

This commit filters out falsy autocomplete options before passing them off to the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/649)
<!-- Reviewable:end -->
