### PR TITLE
Fix remove user actions

### DIFF
--- a/models/boards.js
+++ b/models/boards.js
@@ -494,6 +494,18 @@ if (Meteor.isServer) {
 
         const board = Boards._transform(doc);
         board.setWatcher(memberId, false);
+
+        // Remove board from users starred list
+        if (!board.isPublic()) {
+          Users.update(
+            memberId,
+            {
+              $pull: {
+                'profile.starredBoards': boardId,
+              },
+            }
+          );
+        }
       });
     }
   });

--- a/models/boards.js
+++ b/models/boards.js
@@ -449,17 +449,28 @@ if (Meteor.isServer) {
     );
   });
 
+  const foreachRemovedMember = (doc, modifier, callback) => {
+    Object.keys(modifier).forEach((set) => {
+      if (modifier[set] !== false) {
+        return;
+      }
+
+      const parts = set.split('.');
+      if (parts.length === 3 && parts[0] === 'members' && parts[2] === 'isActive') {
+        callback(doc.members[parts[1]].userId);
+      }
+    });
+  };
+
   // Add a new activity if we add or remove a member to the board
   Boards.after.update((userId, doc, fieldNames, modifier) => {
     if (!_.contains(fieldNames, 'members')) {
       return;
     }
 
-    let memberId;
-
     // Say hello to the new member
     if (modifier.$push && modifier.$push.members) {
-      memberId = modifier.$push.members.userId;
+      const memberId = modifier.$push.members.userId;
       Activities.insert({
         userId,
         memberId,
@@ -470,14 +481,15 @@ if (Meteor.isServer) {
     }
 
     // Say goodbye to the former member
-    if (modifier.$pull && modifier.$pull.members) {
-      memberId = modifier.$pull.members.userId;
-      Activities.insert({
-        userId,
-        memberId,
-        type: 'member',
-        activityType: 'removeBoardMember',
-        boardId: doc._id,
+    if (modifier.$set) {
+      foreachRemovedMember(doc, modifier.$set, (memberId) => {
+        Activities.insert({
+          userId,
+          memberId,
+          type: 'member',
+          activityType: 'removeBoardMember',
+          boardId: doc._id,
+        });
       });
     }
   });


### PR DESCRIPTION
This fixes the current actions (adding an activity) when a user leaves a board. The current check if the member is `$pull`'ed from the members list is wrong, because the user is only set to inactive (`isActive` will be false).

This also adds two new features:
* The removed user will be removed from all cards, lists and the board itself from the watchers list (and the member list of the cards). This fixes #667.
* If the board is not public, the board will be remove from the starred list of the removed user. This fixes the starred count of the board. The user could not see the board before but because the `boardId` was contained in the list, the user counted in the star count.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/669)
<!-- Reviewable:end -->
