### PR TITLE
Sandstorm fixes

### DIFF
--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -184,6 +184,7 @@ const myCommand :Spk.Manifest.Command = (
   environ = [
     # Note that this defines the *entire* environment seen by your app.
     (key = "PATH", value = "/usr/local/bin:/usr/bin:/bin"),
+    (key = "SANDSTORM", value = "1"),
     (key = "METEOR_SETTINGS", value = "{\"public\": {\"sandstorm\": true}}")
   ]
 );


### PR DESCRIPTION
At the current `HEAD` of the `devel` branch, Wekan fails to launch under Sandstorm. Additionally, modifications to a user's profile and permissions only get propagated when the user visits the root path of the grain --- so e.g. it's possible that Alice could demote Bob to read-only access, but as long as Bob doesn't visit `/`, he will still be able to edit the board.

This pull request fixes both of these problems. See @zarvox's commit messages for some more detailed commentary.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/689)

<!-- Reviewable:end -->
