### PR TITLE
[sandstorm] re-enable "add member" sidebar button, using powerbox

### DIFF
--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -30,10 +30,12 @@ template(name="membersWidget")
     .board-widget-content
       each currentBoard.activeMembers
         +userAvatar(userId=this.userId showStatus=true)
-      unless isSandstorm
-        if currentUser.isBoardAdmin
-          a.member.add-member.js-manage-board-members
-            i.fa.fa-plus
+      if isSandstorm
+        a.member.add-member.sandstorm-powerbox-request-identity
+          i.fa.fa-plus
+      else if currentUser.isBoardAdmin
+        a.member.add-member.js-manage-board-members
+          i.fa.fa-plus
       .clearfix
   if isInvited
     hr

--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -31,8 +31,9 @@ template(name="membersWidget")
       each currentBoard.activeMembers
         +userAvatar(userId=this.userId showStatus=true)
       if isSandstorm
-        a.member.add-member.sandstorm-powerbox-request-identity
-          i.fa.fa-plus
+        if currentUser.isBoardMember
+          a.member.add-member.sandstorm-powerbox-request-identity
+            i.fa.fa-plus
       else if currentUser.isBoardAdmin
         a.member.add-member.js-manage-board-members
           i.fa.fa-plus

--- a/client/components/sidebar/sidebar.js
+++ b/client/components/sidebar/sidebar.js
@@ -163,6 +163,9 @@ Template.membersWidget.helpers({
 Template.membersWidget.events({
   'click .js-member': Popup.open('member'),
   'click .js-manage-board-members': Popup.open('addMember'),
+  'click .sandstorm-powerbox-request-identity'() {
+    window.sandstormRequestIdentity();
+  },
   'click .js-member-invite-accept'() {
     const boardId = Session.get('currentBoard');
     Meteor.user().removeInvite(boardId);

--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -184,6 +184,7 @@ const myCommand :Spk.Manifest.Command = (
   environ = [
     # Note that this defines the *entire* environment seen by your app.
     (key = "PATH", value = "/usr/local/bin:/usr/bin:/bin"),
+    (key = "SANDSTORM", value = "1"),
     (key = "METEOR_SETTINGS", value = "{\"public\": {\"sandstorm\": true}}")
   ]
 );

--- a/sandstorm.js
+++ b/sandstorm.js
@@ -28,10 +28,11 @@ if (isSandstorm && Meteor.isServer) {
     Capnp.importSystem('sandstorm/sandstorm-http-bridge.capnp').SandstormHttpBridge;
 
   let httpBridge = null;
+  let capnpConnection = null;
 
   function getHttpBridge() {
     if (!httpBridge) {
-      const capnpConnection = Capnp.connect('unix:/tmp/sandstorm-api');
+      capnpConnection = Capnp.connect('unix:/tmp/sandstorm-api');
       httpBridge = capnpConnection.restore(null, SandstormHttpBridge);
     }
     return httpBridge;


### PR DESCRIPTION
Sandstorm apps can now make powerbox requests for identities: https://github.com/sandstorm-io/sandstorm/pull/2562. This pull request updates Wekan to take advantage of that new functionality, making it possible to add someone on a card _before_ they've visited the grain.

I've published a [test SPK](https://oigimtlx81ukwop56zlo.oasis.sandstorm.io) so that you can try it out.

Note that the building the SPK currently requires some manual updating of meteor-spk's schema files, due to https://github.com/sandstorm-io/meteor-spk/issues/25.

Includes the commits from https://github.com/wekan/wekan/pull/689.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/695)

<!-- Reviewable:end -->
