### PR TITLE
Use navigator language by default instead of english

### DIFF
--- a/client/lib/i18n.js
+++ b/client/lib/i18n.js
@@ -7,8 +7,14 @@ Tracker.autorun(() => {
   let language;
   if (currentUser) {
     language = currentUser.profile && currentUser.profile.language;
-  } else {
-    language = navigator.language || navigator.userLanguage;
+  }
+
+  if (!language) {
+    if(navigator.languages) {
+      language = navigator.languages[0];
+    } else {
+      language = navigator.language || navigator.userLanguage;
+    }
   }
 
   if (language) {


### PR DESCRIPTION
There is no profile language set in a newly created user account. Wekan uses english as fallback language in this case. If there is no current user, Wekan takes care of the navigator properties. Instead we should always have a look at the navigator language.

If the navigator provides multiple preferred languages, select the most-preferred one.
https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/716)

<!-- Reviewable:end -->
