### PR TITLE
Deprecate Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,3 +1,9 @@
+# IMPORTANT NOTE :
+
+This page is deprecated, please consult the 'Developer Documentation' page on the Wiki, the information here might be out of date.
+
+---
+
 # Contributing
 
 We’re glad you’re interested in helping the Wekan project! We welcome bug

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,6 +1,6 @@
 # IMPORTANT NOTE :
 
-This page is deprecated, please consult the [Developer Documentation](https://github.com/wekan/wekan/wiki/Developer-Documentation)' page on the Wiki, the information here might be out of date.
+This page is deprecated, please consult the [Developer Documentation](https://github.com/wekan/wekan/wiki/Developer-Documentation) page on the Wiki, the information here might be out of date.
 
 ---
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,6 +1,6 @@
 # IMPORTANT NOTE :
 
-This page is deprecated, please consult the 'Developer Documentation' page on the Wiki, the information here might be out of date.
+This page is deprecated, please consult the [Developer Documentation](https://github.com/wekan/wekan/wiki/Developer-Documentation)' page on the Wiki, the information here might be out of date.
 
 ---
 


### PR DESCRIPTION
Moving all this information to the Wiki, there's no need for there to be another file for contributor information. It just makes it harder to keep up to date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/780)
<!-- Reviewable:end -->
