### PR TITLE
Fix executeUpTo label when dragging cards

### DIFF
--- a/client/components/lists/list.js
+++ b/client/components/lists/list.js
@@ -44,7 +44,7 @@ BlazeComponent.extendComponent({
       placeholder: 'minicard-wrapper placeholder',
       start(evt, ui) {
         ui.placeholder.height(ui.helper.height());
-        EscapeActions.executeUpTo('popup');
+        EscapeActions.executeUpTo('popup-close');
         boardComponent.setIsDragging(true);
       },
       stop(evt, ui) {


### PR DESCRIPTION
'popup' is not in the predefined hierarchy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/782)
<!-- Reviewable:end -->
