### PR TITLE
to remove 'multiple attributes' error

### DIFF
--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -1,7 +1,8 @@
 template(name="sidebar")
   .board-sidebar.sidebar(class="{{#if isOpen}}is-open{{/if}}")
     a.sidebar-tongue.js-toggle-sidebar(
-      class="{{#if isTongueHidden}}is-hidden{{/if}}")(title="{{showTongueTitle}}")
+      class="{{#if isTongueHidden}}is-hidden{{/if}}",
+      title="{{showTongueTitle}}")
       i.fa.fa-angle-left
     .sidebar-shadow
       .sidebar-content.sidebar-shortcuts


### PR DESCRIPTION
closes #853 

I changed it so that both attributes are in the same parenthesis bracket. I'm not too familiar with JADE but I _think_ that this is the proper way for it to be done. I built the project again (using the `build for production` instructions) and didn't see a build error so I'm assuming it's fixed.

If there's any special procedure to enable verbose build please let me know @xet7 .

Regards,
-Joel :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/856)
<!-- Reviewable:end -->
