### PR TITLE
Bug: orphan documents were created when cards were deleted

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -354,8 +354,18 @@ if (Meteor.isServer) {
   });
 
   // Remove all activities associated with a card if we remove the card
+  // Remove also card_comments / checklists / attachments
   Cards.after.remove((userId, doc) => {
     Activities.remove({
+      cardId: doc._id,
+    });
+    Checklists.remove({
+      cardId: doc._id,
+    });
+    CardComments.remove({
+      cardId: doc._id,
+    });
+    Attachments.remove({
       cardId: doc._id,
     });
   });


### PR DESCRIPTION
Hi,
This pull request corrects the creation of orphan document following the deletion of card in the collections card_comments / checklists / attachments and gridFS collections.

I will had an issue soon, to explain how to remove orphan documents from mongodb databases.

Bye.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/872)
<!-- Reviewable:end -->
