### PR TITLE
update sandstorm metadata for appVersion 19 release

### DIFF
--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -22,10 +22,10 @@ const pkgdef :Spk.PackageDefinition = (
     appTitle = (defaultText = "Wekan"),
     # The name of the app as it is displayed to the user.
 
-    appVersion = 17,
+    appVersion = 19,
     # Increment this for every release.
 
-    appMarketingVersion = (defaultText = "0.11.0~2016-11-28"),
+    appMarketingVersion = (defaultText = "0.16.0~2017-03-21"),
     # Human-readable presentation of the app version.
 
     minUpgradableAppVersion = 0,


### PR DESCRIPTION
As of this writing, the spk is in queue to be published in the app market. You can test it out here: https://apps.sandstorm.io/app/m86q05rdvj14yvn78ghaxynqz7u2svw6rnttptxx49g1785cdv1h?experimental=true

It might be good if someone who knows about the new admin interface can verify that it's not accidentally accessible from the Sandstorm app. As far as I can tell it's not, but I don't really know where to look.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/930)
<!-- Reviewable:end -->
