### PR TITLE
Fixed: Double slash problem 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/kadira:flow-router"]
+	path = packages/kadira:flow-router
+	url = git@github.com:Serubin/flow-router.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "packages/kadira:flow-router"]
 	path = packages/kadira:flow-router
-	url = git@github.com:Serubin/flow-router.git
+	url = https://github.com/Serubin/flow-router.git

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -50,7 +50,6 @@ arillo:flow-router-helpers
 audit-argument-checks
 kadira:blaze-layout
 kadira:dochead
-kadira:flow-router
 meteorhacks:fast-render
 meteorhacks:picker
 meteorhacks:subs-manager
@@ -76,3 +75,4 @@ templates:tabs
 verron:autosize
 simple:json-routes
 rajit:bootstrap3-datepicker
+kadira:flow-router

--- a/app.env
+++ b/app.env
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export PACKAGE_DIRS="$(pwd)/packages"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The open-source Trello-like kanban",
   "private": true,
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --ignore-pattern 'packages/*' .",
     "test": "npm run --silent lint"
   },
   "repository": {


### PR DESCRIPTION
This fixes issue #785 by adding a patched local version of kadira:flow-router to wekan. The flow-router fix is explained in issue #785.

I tested this in three instances, each was newly installed in it's own location. The urls that were tested are as follows: `example.com/wekan`, `brd.example.com/wekan`, `brd.example.com`.

It's important to note that when building or starting the server it is required to execute the following command to export the local package directory for meteor: `source app.env`. All worked as expected.

The patched flow-router repo can be transferred to the wekan namespace upon request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/932)
<!-- Reviewable:end -->
