### PR TITLE
user high availability key server and update  travis.yml for docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,25 @@
-sudo: false
+sudo: required
+
+env:
+  DOCKER_COMPOSE_VERSION: 1.11.2
+
+before_install:
+  - sudo curl -fsSL https://get.docker.com/ | sh
+  - if [ -e /usr/local/bin/docker-compose ]; then sudo rm /usr/local/bin/docker-compose; fi
+  - sudo curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - sudo chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - sudo docker-compose build --no-cache --force-rm
+  - sudo docker-compose up && docker ps -a
+  - sudo docker run wekan-app /bin/sh -c "npm test"
+
 language: node_js
+
 node_js:
   - "0.10.48"
+
 install:
   - "npm install"
+
 script:
   - "npm test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,14 +44,14 @@ RUN \
     # Verify nodejs authenticity
     grep ${NODE_VERSION}-${ARCHITECTURE}.tar.gz SHASUMS256.txt.asc | shasum -a 256 -c - && \
     export GNUPGHOME="$(mktemp -d)" && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5 && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE44734EB7990E && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 && \
-    gpg --keyserver pool.sks-keyservers.net --recv-keys B9AE9905FFD7803F25714661B63B535A4C206CA9 && \
-    gpg --refresh-keys pool.sks-keyservers.net && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 9554F04D7259F04124DE6B476D5A82AC7E37093B && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 94AE36675C464D64BAFA68DD7434390BDBE9B9C5 && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys FD3A5288F042B6850C66B31F09FE44734EB7990E && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys DD8F2338BAE7501E3DD5AC78C273792F7D83545D && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B9AE9905FFD7803F25714661B63B535A4C206CA9 && \
+    gpg --refresh-keys ha.pool.sks-keyservers.net && \
     gpg --verify SHASUMS256.txt.asc && \
     rm -R "$GNUPGHOME" SHASUMS256.txt.asc && \
     \


### PR DESCRIPTION
### This pull request has two elements

1. Add high available server for getting the gpg keys - suppose it should lead to fewer failures on getting the gpg keys leading to some rare build failures.

2. Add a docker build to the `.travis.yml` - this will help determine if pull requests need further review ***before*** merging into devel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/942)
<!-- Reviewable:end -->
