### PR TITLE
fix updateUserPermissions() on Sandstorm

### DIFF
--- a/sandstorm.js
+++ b/sandstorm.js
@@ -205,7 +205,8 @@ if (isSandstorm && Meteor.isServer) {
   function updateUserPermissions(userId, permissions) {
     const isActive = permissions.indexOf('participate') > -1;
     const isAdmin = permissions.indexOf('configure') > -1;
-    const permissionDoc = { userId, isActive, isAdmin };
+    const isCommentOnly = false;
+    const permissionDoc = { userId, isActive, isAdmin, isCommentOnly };
 
     const boardMembers = Boards.findOne(sandstormBoard._id).members;
     const memberIndex = _.pluck(boardMembers, 'userId').indexOf(userId);


### PR DESCRIPTION
Fixes breakage from https://github.com/wekan/wekan/pull/925.

The new isCommentOnly property needs to be set when Sandstorm updates user permissions, because otherwise a schema validation error occurs and users never get added as members of boards.

In this pull request we always set `isCommentOnly` to false. Eventually it might make sense to allow "comment-only" permissions to be used in Sandstorm. Doing so would probably involve adding a `canComment` permission (in the sandstorm-pkgdef.capnp) that defaults to `true`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/976)
<!-- Reviewable:end -->
