### PR TITLE
add console, file, and zulip logger on database changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,7 +52,8 @@
     "prefer-const": 2,
     "prefer-spread": 2,
     "prefer-template": 2,
-    "no-console":"off"
+    "no-console":"off",
+    "no-unused-vars":"warn"
   },
   "globals": {
     "Meteor": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,7 +51,8 @@
     "object-shorthand": 2,
     "prefer-const": 2,
     "prefer-spread": 2,
-    "prefer-template": 2
+    "prefer-template": 2,
+    "no-console":"off"
   },
   "globals": {
     "Meteor": false,
@@ -122,6 +123,7 @@
     "Emoji": true,
     "Checklists": true,
     "Settings": true,
-    "InvitationCodes": true
+    "InvitationCodes": true,
+    "Winston":true
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "meteor-node-stubs": "^0.2.6",
+    "winston": "^2.3.1",
+    "winston-zulip": "0.0.6",
     "xss": "^0.3.3"
   }
 }

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,0 +1,59 @@
+Meteor.startup(() => {
+  Winston = require('winston');
+  require('winston-zulip');
+  const fs = require('fs');
+
+  //remove default logger
+  Winston.remove(Winston.transports.Console);
+
+
+  const loggerEnable = process.env.LOGGER_ENABLE || false;
+  console.log('here1');
+  console.log(loggerEnable);
+  if (loggerEnable) {
+    console.log('here2');
+    const loggers = process.env.LOGGERS.split(',') || 'console';
+
+    if (loggers.includes('console')) {
+      Winston.add(Winston.transports.Console, {
+        json: true,
+        timestamp: true,
+      });
+    }
+
+    if (loggers.includes('file')) {
+      //create logs directory
+      fs.mkdir('logs', (err) => {
+        if (err) throw err;
+      });
+
+      const fileName = `logs/${process.env.LOGGER_FILE_NAME}` || 'logs/server.log';
+
+      Winston.add(Winston.transports.File, {
+        filename: fileName,
+        json: true,
+        options: {
+          flags: 'a+',
+        },
+      });
+    }
+
+    if (loggers.includes('zulip')) {
+      const loggerZulipUsername = process.env.LOGGER_ZULIP_USERNAME;
+      const loggerZulipApikey = process.env.LOGGER_ZULIP_APIKEY;
+      const loggerZulipRealm = process.env.LOGGER_ZULIP_REALM;
+      const loggerZulipTo = process.env.LOGGER_ZULIP_TO || 'logs';
+      const loggerZulipSubject = process.env.LOGGER_ZULIP_SUBJECT || 'wekan';
+
+      Winston.add(Winston.transports.Zulip, {
+        zulipUsername: loggerZulipUsername,
+        zulipApikey: loggerZulipApikey,
+        zulipRealm: loggerZulipRealm,
+        zulipTo: loggerZulipTo,
+        zulipSubject: loggerZulipSubject,
+      });
+    }
+
+  }
+});
+

--- a/server/observableChanges.js
+++ b/server/observableChanges.js
@@ -1,0 +1,100 @@
+class Message {
+  constructor(userId, type, method, doc, selector, fieldNames, modifier) {
+    this.userId = userId;
+    this.type = type;
+    this.method = method;
+    this.doc = doc;
+    this.selector;
+    this.fieldNames = fieldNames;
+    this.modifier = modifier;
+  }
+
+}
+
+//------------- CARDS --------------------
+Cards.before.update(function (userId, doc, fieldNames, modifier, options) {
+  Winston.log('info', new Message(userId, 'card', 'update', doc, null, fieldNames, modifier));
+});
+
+Cards.before.remove(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'card', 'remove', doc));
+});
+
+Cards.before.insert(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'card', 'insert', doc));
+});
+
+Cards.before.upsert(function (userId, selector, modifier, options) {
+  Winston.log('info', new Message(userId, 'card', 'update', null, selector, null, modifier));
+});
+
+
+//------------- BOARDS --------------------
+Boards.before.update(function (userId, doc, fieldNames, modifier, options) {
+  Winston.log('info', new Message(userId, 'board', 'update', doc, null, fieldNames, modifier));
+});
+
+Boards.before.remove(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'board', 'remove', doc));
+});
+
+Boards.before.insert(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'board', 'insert', doc));
+});
+
+Boards.before.upsert(function (userId, selector, modifier, options) {
+  Winston.log('info', new Message(userId, 'board', 'update', null, selector, null, modifier));
+});
+
+//------------- LISTS --------------------
+Lists.before.update(function (userId, doc, fieldNames, modifier, options) {
+  Winston.log('info', new Message(userId, 'list', 'update', doc, null, fieldNames, modifier));
+});
+
+Lists.before.remove(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'list', 'remove', doc));
+});
+
+Lists.before.insert(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'list', 'insert', doc));
+});
+
+Lists.before.upsert(function (userId, selector, modifier, options) {
+  Winston.log('info', new Message(userId, 'list', 'update', null, selector, null, modifier));
+});
+
+
+//------------- CARD COMMENTS --------------------
+CardComments.before.update(function (userId, doc, fieldNames, modifier, options) {
+  Winston.log('info', new Message(userId, 'card-comments', 'update', doc, null, fieldNames, modifier));
+});
+
+CardComments.before.remove(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'card-comments', 'remove', doc));
+});
+
+CardComments.before.insert(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'card-comments', 'insert', doc));
+});
+
+CardComments.before.upsert(function (userId, selector, modifier, options) {
+  Winston.log('info', new Message(userId, 'card-comments', 'update', null, selector, null, modifier));
+});
+
+
+//------------- USERS --------------------
+Users.before.update(function (userId, doc, fieldNames, modifier, options) {
+  Winston.log('info', new Message(userId, 'user', 'update', doc, null, fieldNames, modifier));
+});
+
+Users.before.remove(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'user', 'remove', doc));
+});
+
+Users.before.insert(function (userId, doc) {
+  Winston.log('info', new Message(userId, 'user', 'insert', doc));
+});
+
+Users.before.upsert(function (userId, selector, modifier, options) {
+  Winston.log('info', new Message(userId, 'user', 'update', null, selector, null, modifier));
+});


### PR DESCRIPTION
hi there,

Related here: #1001 

I create a logging mechanism using winstonjs.

The supported log is console, file, and zulip, up to you if you want more.

Actually, only JSON is supported as output.

Possible output 
```
{"userId":"7gLzSQYeLadyScLb4","type":"card","method":"update","doc":{"_id":"DvwygsfayN2KTSFjt","title":"regezrg","members":[],"labelIds":[],"listId":"kFApw5GrTRSwc86BZ","boardId":"ZeEpvQXNfKG2BDoFD","sort":6,"archived":false,"createdAt":"2017-04-14T13:09:56.617Z","dateLastActivity":"2017-04-19T13:51:30.937Z","userId":"7gLzSQYeLadyScLb4"},"fieldNames":["listId","sort","dateLastActivity"],"modifier":{"$set":{"listId":"th5sg8cYSBzB4Qm3J","sort":6,"dateLastActivity":"2017-04-19T13:57:18.579Z"}},"timestamp":"2017-04-19T13:57:18.581Z","message":"","level":"info"}
```
This one is when a card is moved.

Only database changes are logged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1010)
<!-- Reviewable:end -->
