### PR TITLE
make METEOR_EDGE optional. Fix node_gyp bug in docker build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,4 @@ before_install:
 language: node_js
 
 node_js:
-  - "6.10.2"
-
-install:
-  - "npm install"
-
-script:
-  - "npm test"
+  - "4.8.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,13 @@ before_install:
   # ^^ Note - need to come up with some way of checking the output from docker run
   # that it was a success... perhaps the nodejs server can output a success message?
 
-language: node_js
-
-node_js:
-  - "4.8.1"
+#language: node_js
+#
+#node_js:
+#  - "4.8.1"
+#
+#install:
+#  - "npm install"
+#
+#script:
+#  - "npm test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,18 @@ MAINTAINER wekan
 ARG NODE_VERSION
 ARG METEOR_RELEASE
 ARG METEOR_EDGE
+ARG USE_EDGE
 ARG NPM_VERSION
 ARG ARCHITECTURE
 ARG SRC_PATH
 
 # Set the environment variables (defaults where required)
-ENV BUILD_DEPS="wget curl bzip2 build-essential python git ca-certificates"
+ENV BUILD_DEPS="wget curl bzip2 build-essential python git ca-certificates gcc-4.9"
 ENV GOSU_VERSION=1.10
 ENV NODE_VERSION ${NODE_VERSION:-v4.8.1}
-ENV METEOR_RELEASE ${METEOR_RELEASE:-1.4.5}
-ENV METEOR_EDGE ${METEOR_EDGE:-1.4.4.1}
+ENV METEOR_RELEASE ${METEOR_RELEASE:-1.4.4.1}
+ENV USE_EDGE ${USE_EDGE:-false}
+ENV METEOR_EDGE ${METEOR_EDGE:-1.4.4-rc.6}
 ENV NPM_VERSION ${NPM_VERSION:-4.5.0}
 ENV ARCHITECTURE ${ARCHITECTURE:-linux-x64}
 ENV SRC_PATH ${SRC_PATH:-./}
@@ -76,18 +78,16 @@ RUN \
     sed -i "s|RELEASE=.*|RELEASE=${METEOR_RELEASE}\"\"|g" ./install_meteor.sh && \
     echo "Starting meteor ${METEOR_RELEASE} installation...   \n" && \
     chown wekan:wekan ./install_meteor.sh && \
-    ###########################
-    ###########################
-    # Block for ensuring installation of release candidates - perhaps remove later.
-    gosu wekan:wekan sh ./install_meteor.sh || \
-    ( \
+    \
+    # Check if opting for a release candidate instead of major release
+    if [ "$USE_EDGE" = false ]; then \
+      gosu wekan:wekan sh ./install_meteor.sh; \
+    else \
       gosu wekan:wekan git clone --recursive git://github.com/meteor/meteor.git /home/wekan/.meteor && \
       cd /home/wekan/.meteor && \
       gosu wekan:wekan git checkout release/METEOR@${METEOR_EDGE} && \
-      gosu wekan /home/wekan/.meteor/meteor -- help \
-    ) && \
-    ###########################
-    ###########################
+      gosu wekan /home/wekan/.meteor/meteor -- help; \
+    fi && \
     \
     # Build app
     cd /home/wekan/app && \


### PR DESCRIPTION
- make METEOR_EDGE optional.
- Fix node_gyp bug in docker build - docker build works fine now.
- Cannot fix `npm install` in the host because this
runs in the travis container and that is running
on an old ubuntu precise 12 and I'm not sure if that can be updated to gcc-4.9?

***Temporary measure:***
- remove npm install for now.
- Investigate if newer container can run as host on travis or if gcc-4.9 can
be updated on the host. 
- possibly `run install` or `npm test` against docker container
as alternative. Just need to think about how that can be done..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1016)
<!-- Reviewable:end -->
