### PR TITLE
Fix disable a href=“#” link

### DIFF
--- a/client/lib/escapeActions.js
+++ b/client/lib/escapeActions.js
@@ -134,3 +134,7 @@ $(document).on('click', (evt) => {
     EscapeActions.clickExecute(evt.target, 'multiselection');
   }
 });
+
+$(document).on('click', 'a[href=#]',  (evt) => {
+  evt.preventDefault();
+});


### PR DESCRIPTION
Please Consider disabling unnecessary link functionality.

Closes #806 
Related #337

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1042)
<!-- Reviewable:end -->
