### PR TITLE
Fix Drag Board To Scroll

### DIFF
--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -75,7 +75,7 @@ BlazeComponent.extendComponent({
         // the user will legitimately expect to be able to select some text with
         // his mouse.
         const noDragInside = ['a', 'input', 'textarea', 'p', '.js-list-header'];
-        if ($(evt.target).closest(noDragInside.join(',')).length === 0) {
+        if ($(evt.target).closest(noDragInside.join(',')).length === 0 && $('.lists').prop('clientHeight') > evt.offsetY) {
           this._isDragging = true;
           this._lastDragPositionX = evt.clientX;
         }


### PR DESCRIPTION
Win7 and IE 11 when Click on the scrollbar,  the mouse 'sticks' to the scrollbar and slides the slide whenever you move the mouse. 

On investigation it looks like this is caused by IE 11 not emitting a onmouseup event when you click on the scrollbar.
https://stackoverflow.com/questions/29787519/jquery-mouse-up-event-didnt-work-with-ie-11-scrollbar

This PR improves Detect when over the scrollbar and then simply do nothing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1052)
<!-- Reviewable:end -->
