### PR TITLE
Edit card description with invalid markdown

### DIFF
--- a/client/components/main/layouts.styl
+++ b/client/components/main/layouts.styl
@@ -335,6 +335,8 @@ a
   margin-left: 38px
 
 .viewer
+  min-height: 18px
+
   ol
     list-style-type: decimal
     padding-left: 20px


### PR DESCRIPTION
The viewer has a minimum height of 18px (at least a single line) so the anchor can still be clickable even there is no text shown.
Fixes #1039

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1073)
<!-- Reviewable:end -->
