### PR TITLE
Fix Docker Build when USE_EDGE=true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,9 +96,11 @@ RUN \
       gosu wekan:wekan sh ./install_meteor.sh; \
     else \
       gosu wekan:wekan git clone --recursive --depth 1 -b release/METEOR@${METEOR_EDGE} git://github.com/meteor/meteor.git /home/wekan/.meteor && \
-      cd /home/wekan/packages && \
+      cd /home/wekan/.meteor/packages && \
       gosu wekan:wekan git clone --depth 1 -b master git://github.com/wekan/flow-router.git kadira-flow-router && \
       gosu wekan:wekan git clone --depth 1 -b master git://github.com/meteor-useraccounts/core.git meteor-useraccounts-core && \
+      sed -i 's/api\.versionsFrom/\/\/api.versionsFrom/' /home/wekan/.meteor/packages/kadira-flow-router/package.js && \
+      sed -i 's/api\.versionsFrom/\/\/api.versionsFrom/' /home/wekan/.meteor/packages/meteor-useraccounts-core/package.js && \
       cd /home/wekan/.meteor && \
       gosu wekan /home/wekan/.meteor/meteor -- help; \
     fi && \


### PR DESCRIPTION
This kind-of fixes #1110, but only if you build your Dockerfile with USE_EDGE=true.  The wekanteam/wekan:latest on Docker Hub still has the double-slash bug.

Note that the changes are: fixed a path from /home/wekan/packages to /home/wekan/.meteor/packages; and commented out the 'api.versionsFrom(...)' code in package.js for both kadira-flow-router and meteor-useraccounts-core.  I know nothing about Meteor so there may be a better way to fix this, but the change got it to where my Dockerfile would build, and now there is no double-slash issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1114)
<!-- Reviewable:end -->
