### PR TITLE
use version scriptlet instead of hardcoded version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: wekan
-version: "0.32-SNAPSHOT"
+version: 0
+version-script: git describe --dirty --tags |  cut -c 2-
 summary: The open-source Trello-like kanban
 description: |
    Wekan is an open-source and collaborative kanban board application.


### PR DESCRIPTION
moving to use version script instead of hardcoded version which needs to be updated every release

With this in place, we might abandon build from wekan-snap repository and instead just promote to stable channel builds based on tagged version.
Version should represent last tag + number of git commit since + last git commit id (e.g. 0.32-10-g57219df)
in case of build from tag, this will end up being only tagged version (e.g. 0.32) so we can clearly distinguish those in store when promoting.
Also when bugs are reported, we have easy way to track version they are on in case of non stable channel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1164)
<!-- Reviewable:end -->
