### PR TITLE
Add some IDs to webhook body

### DIFF
--- a/models/activities.js
+++ b/models/activities.js
@@ -73,12 +73,14 @@ if (Meteor.isServer) {
       // No need send notification to user of activity
       // participants = _.union(participants, [activity.userId]);
       params.user = activity.user().getName();
+      params.userId = activity.userId;
     }
     if (activity.boardId) {
       board = activity.board();
       params.board = board.title;
       title = 'act-withBoardTitle';
       params.url = board.absoluteUrl();
+      params.boardId = activity.boardId;
     }
     if (activity.memberId) {
       participants = _.union(participants, [activity.memberId]);
@@ -88,11 +90,13 @@ if (Meteor.isServer) {
       const list = activity.list();
       watchers = _.union(watchers, list.watchers || []);
       params.list = list.title;
+      params.listId = activity.listId;
     }
     if (activity.oldListId) {
       const oldList = activity.oldList();
       watchers = _.union(watchers, oldList.watchers || []);
       params.oldList = oldList.title;
+      params.oldListId = activity.oldListId;
     }
     if (activity.cardId) {
       const card = activity.card();
@@ -101,6 +105,7 @@ if (Meteor.isServer) {
       params.card = card.title;
       title = 'act-withCardTitle';
       params.url = card.absoluteUrl();
+      params.cardId = activity.cardId;
     }
     if (activity.commentId) {
       const comment = activity.comment();

--- a/server/notifications/outgoing.js
+++ b/server/notifications/outgoing.js
@@ -28,6 +28,11 @@ Meteor.methods({
       text: `${text}`,
     };
 
+    ['cardId', 'listId', 'oldListId', 'boardId'].forEach((key) => {
+      if (params[key]) value[key] = params[key];
+    });
+    value['description'] = description;
+
     const options = {
       headers: {
         // 'Content-Type': 'application/json',


### PR DESCRIPTION
I am working on a [Gogs](https://github.com/gogits/gogs) <--> Wekan integration, and to maintain the data coherence it is necessary to know the IDs of the elements involved in a given activity.

This PR adds several IDs to the webhook payload and the description of the activity.

I am working on some new activities but I will submit a different PR when that's ready.

Please let me know if changes are needed in order to have this merged upstream.

Thank you for this great tool!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1189)
<!-- Reviewable:end -->
