### PR TITLE
Make userId optional when importing Wekan boards

### DIFF
--- a/models/wekanCreator.js
+++ b/models/wekanCreator.js
@@ -71,7 +71,6 @@ export class WekanCreator {
 
   checkActivities(wekanActivities) {
     check(wekanActivities, [Match.ObjectIncluding({
-      userId: String,
       activityType: String,
       createdAt: DateString,
     })]);


### PR DESCRIPTION
Sandstorm will have an activity of adding a member by default which will have an empty userId. This caused issues when importing exported Sandstorm boards.

This PR is related to #799

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1197)
<!-- Reviewable:end -->
