### PR TITLE
Improve integrations

### DIFF
--- a/client/components/boards/boardHeader.jade
+++ b/client/components/boards/boardHeader.jade
@@ -227,11 +227,21 @@ template(name="archiveBoardPopup")
   button.js-confirm.negate.full(type="submit") {{_ 'archive'}}
 
 template(name="outgoingWebhooksPopup")
-  form
+  each integrations
+    form.integration-form
+      if title
+        h4 {{title}}
+      else
+        h4 {{_ 'no-name'}}
+      label
+        | URL
+        input.js-outgoing-webhooks-url(type="text" name="url" value=url)
+        input(type="hidden" value=_id name="id")
+      input.primary.wide(type="submit" value="{{_ 'save'}}")
+  form.integration-form
+    h4
+      | {{_ 'new-integration'}}
     label
       | URL
-      if integration.enabled
-        input.js-outgoing-webhooks-url(type="text" value=integration.url autofocus)
-      else
-        input.js-outgoing-webhooks-url(type="text" autofocus)
+      input.js-outgoing-webhooks-url(type="text" name="url" autofocus)
     input.primary.wide(type="submit" value="{{_ 'save'}}")

--- a/client/components/boards/boardHeader.styl
+++ b/client/components/boards/boardHeader.styl
@@ -1,0 +1,3 @@
+.integration-form
+  padding: 5px
+  border-bottom: 1px solid #ccc

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -368,6 +368,8 @@
     "error-notAuthorized": "You are not authorized to view this page.",
     "outgoing-webhooks": "Outgoing Webhooks",
     "outgoingWebhooksPopup-title": "Outgoing Webhooks",
+    "new-integration": "New integration",
+    "no-name": "(Unknown)",
     "Wekan_version": "Wekan version",
     "Node_version": "Node version",
     "OS_Arch": "OS Arch",

--- a/models/activities.js
+++ b/models/activities.js
@@ -140,9 +140,9 @@ if (Meteor.isServer) {
       Notifications.notify(user, title, description, params);
     });
 
-    const integration = Integrations.findOne({ boardId: board._id, type: 'outgoing-webhooks', enabled: true });
-    if (integration) {
-      Meteor.call('outgoingWebhooks', integration, description, params);
+    const integrations = Integrations.find({ boardId: board._id, type: 'outgoing-webhooks', enabled: true, activities: { '$in': [description, 'all'] } }).fetch();
+    if (integrations.length > 0) {
+      Meteor.call('outgoingWebhooks', integrations, description, params);
     }
   });
 }

--- a/models/integrations.js
+++ b/models/integrations.js
@@ -50,6 +50,9 @@ Integrations.allow({
   update(userId, doc) {
     return allowIsBoardAdmin(userId, Boards.findOne(doc.boardId));
   },
+  remove(userId, doc) {
+    return allowIsBoardAdmin(userId, Boards.findOne(doc.boardId));
+  },
   fetch: ['boardId'],
 });
 

--- a/models/integrations.js
+++ b/models/integrations.js
@@ -11,6 +11,11 @@ Integrations.attachSchema(new SimpleSchema({
   },
   type: {
     type: String,
+    defaultValue: 'outgoing-webhooks',
+  },
+  activities: {
+    type: [String],
+    defaultValue: ['all'],
   },
   url: { // URL validation regex (https://mathiasbynens.be/demo/url-regex)
     type: String,
@@ -35,11 +40,6 @@ Integrations.attachSchema(new SimpleSchema({
   },
   userId: {
     type: String,
-    autoValue() { // eslint-disable-line consistent-return
-      if (this.isInsert || this.isUpdate) {
-        return this.userId;
-      }
-    },
   },
 }));
 
@@ -52,3 +52,136 @@ Integrations.allow({
   },
   fetch: ['boardId'],
 });
+
+//INTEGRATIONS REST API
+if (Meteor.isServer) {
+  // Get all integrations in board
+  JsonRoutes.add('GET', '/api/boards/:boardId/integrations', function(req, res, next) {
+    const paramBoardId = req.params.boardId;
+    Authentication.checkBoardAccess(req.userId, paramBoardId);
+
+    const data = Integrations.find({ boardId: paramBoardId }, { fields: { token: 0 } }).map(function(doc) {
+      return doc;
+    });
+
+    JsonRoutes.sendResult(res, {code: 200, data});
+  });
+
+  // Get a single integration in board
+  JsonRoutes.add('GET', '/api/boards/:boardId/integrations/:intId', function(req, res, next) {
+    const paramBoardId = req.params.boardId;
+    const paramIntId = req.params.intId;
+    Authentication.checkBoardAccess(req.userId, paramBoardId);
+
+    JsonRoutes.sendResult(res, {
+      code: 200,
+      data: Integrations.findOne({ _id: paramIntId, boardId: paramBoardId }, { fields: { token: 0 } }),
+    });
+  });
+
+  // Create a new integration
+  JsonRoutes.add('POST', '/api/boards/:boardId/integrations', function(req, res, next) {
+    const paramBoardId = req.params.boardId;
+    Authentication.checkBoardAccess(req.userId, paramBoardId);
+
+    const id = Integrations.insert({
+      userId: req.userId,
+      boardId: paramBoardId,
+      url: req.body.url,
+    });
+
+    JsonRoutes.sendResult(res, {
+      code: 200,
+      data: {
+        _id: id,
+      },
+    });
+  });
+
+  // Edit integration data
+  JsonRoutes.add('PUT', '/api/boards/:boardId/integrations/:intId', function (req, res, next) {
+    const paramBoardId = req.params.boardId;
+    const paramIntId = req.params.intId;
+    Authentication.checkBoardAccess(req.userId, paramBoardId);
+
+    if (req.body.hasOwnProperty('enabled')) {
+      const newEnabled = req.body.enabled;
+      Integrations.direct.update({_id: paramIntId, boardId: paramBoardId},
+        {$set: {enabled: newEnabled}});
+    }
+    if (req.body.hasOwnProperty('title')) {
+      const newTitle = req.body.title;
+      Integrations.direct.update({_id: paramIntId, boardId: paramBoardId},
+        {$set: {title: newTitle}});
+    }
+    if (req.body.hasOwnProperty('url')) {
+      const newUrl = req.body.url;
+      Integrations.direct.update({_id: paramIntId, boardId: paramBoardId},
+        {$set: {url: newUrl}});
+    }
+    if (req.body.hasOwnProperty('token')) {
+      const newToken = req.body.token;
+      Integrations.direct.update({_id: paramIntId, boardId: paramBoardId},
+        {$set: {token: newToken}});
+    }
+    if (req.body.hasOwnProperty('activities')) {
+      const newActivities = req.body.activities;
+      Integrations.direct.update({_id: paramIntId, boardId: paramBoardId},
+        {$set: {activities: newActivities}});
+    }
+
+    JsonRoutes.sendResult(res, {
+      code: 200,
+      data: {
+        _id: paramIntId,
+      },
+    });
+  });
+
+  // Delete subscribed activities
+  JsonRoutes.add('DELETE', '/api/boards/:boardId/integrations/:intId/activities', function (req, res, next) {
+    const paramBoardId = req.params.boardId;
+    const paramIntId = req.params.intId;
+    const newActivities = req.body.activities;
+    Authentication.checkBoardAccess(req.userId, paramBoardId);
+
+    Integrations.direct.update({_id: paramIntId, boardId: paramBoardId},
+      {$pullAll: {activities: newActivities}});
+
+    JsonRoutes.sendResult(res, {
+      code: 200,
+      data: Integrations.findOne({_id: paramIntId, boardId: paramBoardId}, { fields: {_id: 1, activities: 1}}),
+    });
+  });
+
+  // Add subscribed activities
+  JsonRoutes.add('POST', '/api/boards/:boardId/integrations/:intId/activities', function (req, res, next) {
+    const paramBoardId = req.params.boardId;
+    const paramIntId = req.params.intId;
+    const newActivities = req.body.activities;
+    Authentication.checkBoardAccess(req.userId, paramBoardId);
+
+    Integrations.direct.update({_id: paramIntId, boardId: paramBoardId},
+      {$addToSet: {activities: { $each: newActivities}}});
+
+    JsonRoutes.sendResult(res, {
+      code: 200,
+      data: Integrations.findOne({_id: paramIntId, boardId: paramBoardId}, { fields: {_id: 1, activities: 1}}),
+    });
+  });
+
+  // Delete integration
+  JsonRoutes.add('DELETE', '/api/boards/:boardId/integrations/:intId', function (req, res, next) {
+    const paramBoardId = req.params.boardId;
+    const paramIntId = req.params.intId;
+    Authentication.checkBoardAccess(req.userId, paramBoardId);
+
+    Integrations.direct.remove({_id: paramIntId, boardId: paramBoardId});
+    JsonRoutes.sendResult(res, {
+      code: 200,
+      data: {
+        _id: paramIntId,
+      },
+    });
+  });
+}

--- a/server/notifications/outgoing.js
+++ b/server/notifications/outgoing.js
@@ -19,7 +19,8 @@ Meteor.methods({
       if (quoteParams[key]) quoteParams[key] = `"${params[key]}"`;
     });
 
-    const user = Users.findOne(params.userId);
+    const userId = (params.userId)?params.userId:integrations[0].userId;
+    const user = Users.findOne(userId);
     const text = `${params.user} ${TAPi18n.__(description, quoteParams, user.getLanguage())}\n${params.url}`;
 
     if (text.length === 0) return;
@@ -31,7 +32,7 @@ Meteor.methods({
     ['cardId', 'listId', 'oldListId', 'boardId'].forEach((key) => {
       if (params[key]) value[key] = params[key];
     });
-    value.$description = description;
+    value.description = description;
 
     const options = {
       headers: {


### PR DESCRIPTION
## The idea

Right now, you could only add one webhook from the UI. I added the ability to save many integrations per board (and show them in the UI).

Also, sometimes you may want to subscribe to only certain activities, such as `act-moveCard`. For this purpose I added a field named `activities` to the schema of Integrations. Default value is `all` which gives backwards compatibility.

Before executing `outgoingWebhooks`, integrations are filtered based on the `activities` field.

## userId autoValue()

- In order to be able to CRUD integrations from the added API, I had to delete the autoValue() for userId, as `this.userId` was `null`. Then you provide explicitly the userId from the request body. Is there other way to do this?

## Snapshots

### New integration form
![seleccion_001](https://user-images.githubusercontent.com/7302217/29883692-6e735ba6-8d87-11e7-9fa6-efe1266adb14.png)

### Existing integrations
![seleccion_003](https://user-images.githubusercontent.com/7302217/29883691-6e70c68e-8d87-11e7-86b9-cb8594277874.png)

`(Unknown)` refers to the `title`field, which for the moment only can be set from the API

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1199)
<!-- Reviewable:end -->
