### PR TITLE
Card title is now pre-filled in copy card dialog

### DIFF
--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -127,6 +127,7 @@ template(name="moveCardPopup")
 template(name="copyCardPopup")
   label(for='copy-card-title') {{_ 'title'}}:
   textarea#copy-card-title.minicard-composer-textarea.js-card-title(autofocus)
+    = title
   label {{_ 'lists'}}:
   +boardLists
 


### PR DESCRIPTION
This small edit makes sure the title of a card is pre-filled in the title field of the "copy card" dialog.

Fixes in part #1213.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1214)
<!-- Reviewable:end -->
