### PR TITLE
Add feature: Reorder checklist items 

### DIFF
--- a/client/components/cards/checklists.jade
+++ b/client/components/cards/checklists.jade
@@ -46,8 +46,8 @@ template(name="editChecklistItemForm")
       a.js-delete-checklist-item {{_ "delete"}}...
 
 template(name="checklistItems")
-  .checklist-items
-    each item in checklist.items
+  .checklist-items.js-checklist-items
+    each item in checklist.getItems
       +inlinedForm(classNames="js-edit-checklist-item" item = item checklist = checklist)
         +editChecklistItemForm(type = 'item' item = item checklist = checklist)
       else
@@ -61,11 +61,10 @@ template(name="checklistItems")
           | {{_ 'add-checklist-item'}}...
 
 template(name='itemDetail')
-  .item
+  .item.js-checklist-item
     if canModifyCard
       .check-box.materialCheckBox(class="{{#if item.isFinished }}is-checked{{/if}}")
       .item-title.js-open-inlined-form.is-editable(class="{{#if item.isFinished }}is-checked{{/if}}") {{item.title}}
     else
       .materialCheckBox(class="{{#if item.isFinished }}is-checked{{/if}}")
       .item-title(class="{{#if item.isFinished }}is-checked{{/if}}") {{item.title}}
-

--- a/models/checklists.js
+++ b/models/checklists.js
@@ -17,6 +17,10 @@ Checklists.attachSchema(new SimpleSchema({
   'items.$.title': {
     type: String,
   },
+  'items.$.sort': {
+    type: Number,
+    decimal: true,
+  },
   'items.$.isFinished': {
     type: Boolean,
     defaultValue: false,
@@ -36,11 +40,33 @@ Checklists.attachSchema(new SimpleSchema({
       }
     },
   },
+  sort: {
+    type: Number,
+    decimal: true,
+  },
+  newItemIndex: {
+    type: Number,
+    decimal: true,
+    defaultValue: 0,
+  },
 }));
+
+const self = Checklists;
 
 Checklists.helpers({
   itemCount() {
     return this.items.length;
+  },
+  getItems() {
+    return this.items.sort(function (itemA, itemB) {
+      if (itemA.sort < itemB.sort) {
+        return -1;
+      }
+      if (itemA.sort > itemB.sort) {
+        return 1;
+      }
+      return 0;
+    });
   },
   finishedCount() {
     return this.items.filter((item) => {
@@ -54,7 +80,8 @@ Checklists.helpers({
     return _.findWhere(this.items, { _id });
   },
   itemIndex(itemId) {
-    return _.pluck(this.items, '_id').indexOf(itemId);
+    const items = self.findOne({_id : this._id}).items;
+    return _.pluck(items, '_id').indexOf(itemId);
   },
 });
 
@@ -86,14 +113,11 @@ Checklists.mutations({
   //for items in checklist
   addItem(title) {
     const itemCount = this.itemCount();
-    let idx = 0;
-    if (itemCount > 0) {
-      const lastId = this.items[itemCount - 1]._id;
-      const lastIdSuffix = lastId.substr(this._id.length);
-      idx = parseInt(lastIdSuffix, 10) + 1;
-    }
-    const _id = `${this._id}${idx}`;
-    return { $addToSet: { items: { _id, title, isFinished: false } } };
+    const _id = `${this._id}${this.newItemIndex}`;
+    return {
+      $addToSet: { items: { _id, title, isFinished: false, sort: itemCount } },
+      $set: { newItemIndex: this.newItemIndex + 1},
+    };
   },
   removeItem(itemId) {
     return { $pull: { items: { _id: itemId } } };
@@ -142,6 +166,21 @@ Checklists.mutations({
       };
     }
     return {};
+  },
+  sortItems(itemIDs) {
+    const validItems = [];
+    for (const itemID of itemIDs) {
+      if (this.getItem(itemID)) {
+        validItems.push(this.itemIndex(itemID));
+      }
+    }
+    const modifiedValues = {};
+    for (let i = 0; i < validItems.length; i++) {
+      modifiedValues[`items.${validItems[i]}.sort`] = i;
+    }
+    return {
+      $set: modifiedValues,
+    };
   },
 });
 


### PR DESCRIPTION
This pull request partially implements #876. It makes checklist items sortable both within a checklist and across checklists. Checklists themselves cannot be sorted but model support for this was added as well.

The previous implementation of the model of checklists didn't support sortable checklist items so a bigger overhaul was necessary.

Known visual glitches: 
When dragging a checklist item to it's new place and releasing the mouse button, it doesn't persist immediately but reversed back to it's previous position. Less than a second later it is at the new position. Reason for this is the interior behaviour of Blaze. Blaze updates the template based upon database changes. Therefore we cannot modify the DOM with the jQuery UI Sortable widget and must cancel the movement after making the database change.
The small time difference between canceling the movement and the reactive change to the template is visible. But that should be acceptable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1215)
<!-- Reviewable:end -->
