### PR TITLE
Fix Other Users cannot create labels

### DIFF
--- a/client/components/cards/labels.jade
+++ b/client/components/cards/labels.jade
@@ -34,4 +34,5 @@ template(name="cardLabelsPopup")
             = name
             if(isLabelSelected ../_id)
               i.card-label-selectable-icon.fa.fa-check
-  a.quiet-button.full.js-add-label {{_ 'label-create'}}
+  if currentUser.isBoardAdmin
+    a.quiet-button.full.js-add-label {{_ 'label-create'}}


### PR DESCRIPTION
Only an board administrator can create a label
To determine whether there is a label making authority
Closes #1229

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1261)
<!-- Reviewable:end -->
