### PR TITLE
Fix "Hide system messages" slider doesn't obey Wekan color conventions

### DIFF
--- a/client/components/boards/boardColors.styl
+++ b/client/components/boards/boardColors.styl
@@ -51,6 +51,17 @@ setBoardColor(color)
     &:not(.is-checked) + .minicard:hover:not(.minicard-composer)
       background: lighten(color, 97%)
 
+  .toggle-label
+
+    &:after
+      background-color: darken(color, 20%)
+
+  .toggle-switch:checked ~ .toggle-label
+    background-color: lighten(color, 20%)
+
+    &:after
+      background-color: darken(color, 20%)
+
   @media screen and (max-width: 800px)
     &.pop-over .header
       background: color

--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -87,13 +87,14 @@ template(name="cardDetails")
     hr
     .activity-title
       h2 {{ _ 'activity'}}
-      .material-toggle-switch
-        span.toggle-switch-title {{_ 'hide-system-messages'}}
-        if hiddenSystemMessages
-          input.toggle-switch(type="checkbox" id="toggleButton" checked="checked")
-        else
-          input.toggle-switch(type="checkbox" id="toggleButton")
-        label.toggle-label(for="toggleButton")
+      if currentUser.isBoardMember
+        .material-toggle-switch
+          span.toggle-switch-title {{_ 'hide-system-messages'}}
+          if hiddenSystemMessages
+            input.toggle-switch(type="checkbox" id="toggleButton" checked="checked")
+          else
+            input.toggle-switch(type="checkbox" id="toggleButton")
+          label.toggle-label(for="toggleButton")
     if currentUser.isBoardMember
       +commentForm
     if isLoaded.get


### PR DESCRIPTION
Closes #1274 

![wekan_toggle-switch-change-color-iloveimg-compressed](https://user-images.githubusercontent.com/22808079/31166234-fd8a70a6-a928-11e7-87f1-c44a1093ace9.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1275)
<!-- Reviewable:end -->
