### PR TITLE
Permit editing the WIP limit

### DIFF
--- a/client/components/lists/listHeader.jade
+++ b/client/components/lists/listHeader.jade
@@ -76,14 +76,14 @@ template(name="listDeletePopup")
 
 template(name="setWipLimitPopup")
   #js-wip-limit-edit
-    lable {{_ 'set-wip-limit-value'}}
+    label {{_ 'set-wip-limit-value'}}
     ul.pop-over-list
       li: a.js-enable-wip-limit {{_ 'enable-wip-limit'}} 
         if isWipLimitEnabled  
           i.fa.fa-check
     if isWipLimitEnabled
       p
-        input.wip-limit-value(type="number" value="{{ wipLimitValue }}" min="1" max="99" onkeydown="return false")
+        input.wip-limit-value(type="number" value="{{ wipLimitValue }}" min="1" max="99")
         input.wip-limit-apply(type="submit" value="{{_ 'apply'}}")
         input.wip-limit-error
         


### PR DESCRIPTION
This fixes #1310 and required for Edge users to be able to edit the WIP limit. (The up/down buttons appear to be "optional" according to the HTML5 spec, and can't be assumed to be present.)

I also believe I fixed a spelling error in the same section.

This PR is **NOT TESTED**

Also, @amadilsons for opinions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1312)
<!-- Reviewable:end -->
