### PR TITLE
Feature: WIP Soft Limits #1311

### DIFF
--- a/client/components/lists/list.styl
+++ b/client/components/lists/list.styl
@@ -79,6 +79,9 @@
   .list-header-plus-icon
     color: #a6a6a6
 
+  .highlight
+    color: #ce1414
+
 .list-body
   flex: 1
   display: flex
@@ -126,3 +129,9 @@
 
   .wip-limit-error
     display: none
+
+  .soft-wip-limit
+    margin-right: 8px
+
+  div
+    float: left

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -102,8 +102,7 @@ BlazeComponent.extendComponent({
 
   reachedWipLimit() {
     const list = Template.currentData();
-    if( !list.getWipLimit() ) { return false; }
-    return list.getWipLimit('enabled') && list.getWipLimit('value') === list.cards().count();
+    return !list.getWipLimit('soft') && list.getWipLimit('enabled') && list.getWipLimit('value') <= list.cards().count();
   },
 
   events() {

--- a/client/components/lists/listHeader.jade
+++ b/client/components/lists/listHeader.jade
@@ -5,10 +5,12 @@ template(name="listHeader")
     else
       h2.list-header-name(
         class="{{#if currentUser.isBoardMember}}js-open-inlined-form is-editable{{/if}}")
-        = title
-        if isWipLimitEnabled
-          span
-            | ({{cards.count}}/#{wipLimit.value})
+        = title 
+        if wipLimit.enabled
+         |&nbsp;(
+         span(class="{{#if reachedWipLimit}}highlight{{/if}}") {{cards.count}}
+         |/#{wipLimit.value})
+        
         if showCardsCountForList cards.count
           = cards.count
           span.lowercase
@@ -18,7 +20,7 @@ template(name="listHeader")
           i.list-header-watch-icon.fa.fa-eye
         div.list-header-menu
           unless currentUser.isCommentOnly
-            unless isWipLimitEnabled
+            if canSeeAddCard
               a.js-add-card.fa.fa-plus.list-header-plus-icon
             a.fa.fa-navicon.js-open-list-menu
 
@@ -86,6 +88,10 @@ template(name="setWipLimitPopup")
         input.wip-limit-value(type="number" value="{{ wipLimitValue }}" min="1" max="99")
         input.wip-limit-apply(type="submit" value="{{_ 'apply'}}")
         input.wip-limit-error
+      p
+        .soft-wip-limit
+          .materialCheckBox(class="{{#if isWipLimitSoft}}is-checked{{/if}}")
+        label Soft Limit
         
 template(name="wipLimitErrorPopup")
   .wip-limit-invalid

--- a/models/cards.js
+++ b/models/cards.js
@@ -182,7 +182,7 @@ Cards.helpers({
 
   canBeRestored() {
     const list = Lists.findOne({_id: this.listId});
-    if(list.getWipLimit() && list.getWipLimit('enabled') && list.getWipLimit('value') === list.cards().count()){
+    if(!list.getWipLimit('soft') && list.getWipLimit('enabled') && list.getWipLimit('value') === list.cards().count()){
       return false;
     }
     return true;


### PR DESCRIPTION
Added option for a 'Soft Limit'.

Soft limit option behavior,when active:
- any number of cards can be added or moved to the list, regardless of the WIP limit value;
- the WIP limit may be set to a lower value than the current amount of cards in the list;
- any archived cards can be restored regardless of the WIP limit value.

Basicaly, when this option is set, the program behavior remains pretty much the same as if it was working without WIP limits.

I've tested this feature for all use cases but may have missed something! If so, I would be glad to fix whatever is broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1319)
<!-- Reviewable:end -->
