### PR TITLE
remove erroneous minicard title whitespace

### DIFF
--- a/client/components/cards/minicard.styl
+++ b/client/components/cards/minicard.styl
@@ -77,6 +77,9 @@
       height: @width
       border-radius: 2px
       margin-left: 3px
+  .minicard-title
+    p:last-child
+      margin-bottom: 0
   .dates
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
introduced by the markdown viewer in commit 309c1d0 (the markdown viewer uses `<p>` tags which have a margin-bottom)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1347)
<!-- Reviewable:end -->
