### PR TITLE
card detail: fix title editing with shift key

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -198,7 +198,7 @@ Template.editCardTitleForm.events({
   'keydown .js-edit-card-title' (evt) {
     // If enter key was pressed, submit the data
     // Unless the shift key is also being pressed
-    if (evt.keyCode === 13 && !event.shiftKey) {
+    if (evt.keyCode === 13 && !evt.shiftKey) {
       $('.js-submit-edit-card-title-form').click();
     }
   },


### PR DESCRIPTION
in firefox there is no global `event` object, therefore we should use the `evt` argument from the event handler (this way it works in both browsers, and other browsers without global `event` object)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1348)
<!-- Reviewable:end -->
