### PR TITLE
Resolve "Frequent Subscriptions" problem that make Excessive CPU usage

### DIFF
--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -1,11 +1,11 @@
 const subManager = new SubsManager();
 
 BlazeComponent.extendComponent({
-    onCreated() {
-      // Here is the only place that boards data needed, all boards data will stop sync when leaving this template
-      Meteor.subscribe('boards');
-      Meteor.subscribe('setting');
-      Meteor.subscribe('user-admin');
+  onCreated() {
+    // Here is the only place that boards data needed, all boards data will stop sync when leaving this template
+    Meteor.subscribe('boards');
+    Meteor.subscribe('setting');
+    Meteor.subscribe('user-admin');
   },
 
   boards() {

--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -1,6 +1,13 @@
 const subManager = new SubsManager();
 
 BlazeComponent.extendComponent({
+    onCreated() {
+      // Here is the only place that boards data needed, all boards data will stop sync when leaving this template
+      Meteor.subscribe('boards');
+      Meteor.subscribe('setting');
+      Meteor.subscribe('user-admin');
+  },
+
   boards() {
     return Boards.find({
       archived: false,

--- a/client/components/main/layouts.js
+++ b/client/components/main/layouts.js
@@ -1,7 +1,3 @@
-Meteor.subscribe('boards');
-Meteor.subscribe('setting');
-Meteor.subscribe('user-admin');
-
 BlazeLayout.setRoot('body');
 
 const i18nTagToT9n = (i18nTag) => {


### PR DESCRIPTION
I found the solution. The problem is "Frequent Subscriptions" in top of client\components\main\layouts.js

`Meteor.subscribe('boards');`
`Meteor.subscribe('setting');`
`Meteor.subscribe('user-admin');`

I move these code to top of client\components\boards\boardList.js

`BlazeComponent.extendComponent({`
`    onCreated() {`
`        Meteor.subscribe('boards');`
`        Meteor.subscribe('setting');`
`        Meteor.subscribe('user-admin');`
`    },`

CPU is no longer too high, from 100% down to 30% - 50%.
The subscriptions at top of layouts.js will make boards data sync every where, it's the reason that cause CPU heavy when user number is increased. To move it to creation time of boardList.js, there is the only place that boards data needed, all boards data will not sync when user enter a board or card. 
I will try to update the code or you can told me how to do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1362)
<!-- Reviewable:end -->
