### PR TITLE
Different icons for start date and due date

### DIFF
--- a/client/components/cards/cardDate.js
+++ b/client/components/cards/cardDate.js
@@ -171,11 +171,12 @@ class CardStartDate extends CardDate {
   }
 
   classes() {
+    let classes = 'start-date' + ' ';
     if (this.date.get().isBefore(this.now.get(), 'minute') &&
         this.now.get().isBefore(this.data().dueAt)) {
-      return 'current';
+      classes += 'current';
     }
-    return '';
+    return classes;
   }
 
   showTitle() {
@@ -200,13 +201,14 @@ class CardDueDate extends CardDate {
   }
 
   classes() {
+    let classes = 'due-date' + ' ';
     if (this.now.get().diff(this.date.get(), 'days') >= 2)
-      return 'long-overdue';
+      classes += 'long-overdue';
     else if (this.now.get().diff(this.date.get(), 'minute') >= 0)
-      return 'due';
+      classes += 'due';
     else if (this.now.get().diff(this.date.get(), 'days') >= -1)
-      return 'almost-due';
-    return '';
+      classes += 'almost-due';
+    return classes;
   }
 
   showTitle() {

--- a/client/components/cards/cardDate.styl
+++ b/client/components/cards/cardDate.styl
@@ -49,10 +49,20 @@
     &:hover, &.is-active
       background-color: darken(#fd5d47, 7)
 
+  &.due-date
+    time
+      &::before
+        content: "\f090"  // symbol: fa-sign-in
+
+  &.start-date
+    time
+      &::before
+        content: "\f08b"  // symbol: fa-sign-out
+
   time
     &::before
       font: normal normal normal 14px/1 FontAwesome
       font-size: inherit
       -webkit-font-smoothing: antialiased
-      content: "\f017"  // clock symbol
       margin-right: 0.3em
+


### PR DESCRIPTION
Proposed fix for issue #1414 

I chose two new icons (one for start date, one for due date):
<img width="340" alt="screen shot 2018-01-04 at 6 16 04 pm" src="https://user-images.githubusercontent.com/19991/34585762-6b806546-f1a1-11e7-903f-d15a5f4f2f97.png">

An alternative approach could be:
<img width="364" alt="screen shot 2018-01-04 at 6 11 51 pm" src="https://user-images.githubusercontent.com/19991/34585773-78345aa4-f1a1-11e7-904d-b181ce538f35.png">

What do you think? Please let me know what I can improve in my solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1420)
<!-- Reviewable:end -->
