### PR TITLE
Fix for dragging into scrolled-down list #476

### DIFF
--- a/client/components/lists/list.styl
+++ b/client/components/lists/list.styl
@@ -88,12 +88,14 @@
 
 .list-body
   flex: 1
+  flex-direction: column
   display: flex
   overflow-y: auto
   padding: 5px 11px
 
   .minicards
-    flex: 1
+    flex-grow: 1
+    flex-shrink: 0
 
     form
       margin-bottom: 9px


### PR DESCRIPTION
Partially addresses #476:

Repro:
1. Add cards to the list so that scrolling appears (e.g. if 10 cards are usually visible, add 20)
1. Scroll
1. Try to drag a card to the section of the list not originally visible
Expected: drops normally
Actual:
*unable to drop (placeholder not appearing)
* Debug: .js-minicards scrolls out of the view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1424)
<!-- Reviewable:end -->
