### PR TITLE
Fix card shadow to cover the full page.

### DIFF
--- a/client/components/boards/boardBody.styl
+++ b/client/components/boards/boardBody.styl
@@ -1,8 +1,11 @@
 @import 'nib'
 
 position()
-  if arguments[0] == cover
-    position: absolute
+  if arguments[0] == cover || arguments[0] == fixed-cover
+    if arguments[0] == cover
+      position: absolute
+    else
+      position: fixed
     left: 0
     right: 0
     top: 0
@@ -30,7 +33,7 @@ position()
       overflow-y: hidden
 
     .board-overlay
-      position: cover
+      position: fixed-cover
       top: -100px
       right: -400px
       background: black

--- a/client/components/main/header.styl
+++ b/client/components/main/header.styl
@@ -4,6 +4,7 @@
   color: white
   transition: background-color 0.4s
   background: #2980B9
+  z-index: 17
 
   #header-main-bar
     height: 40px
@@ -99,6 +100,7 @@
   height: 28px
   font-size: 12px
   display: flex
+  z-index: 17
 
   #header-user-bar,
   #header-new-board-icon,


### PR DESCRIPTION
Hello @xet7,

I have recently updated my wekan installation to version 0.75 and noticed that the card-shadow no longer covered the page if you scroll down.
I believe this PR fixes the problem without introducing any side effects.

Hope this helps,
Thanks for Wekan!