### PR TITLE
Fix swimlane header rotation on Google Chrome

### DIFF
--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -32,7 +32,8 @@
     border-bottom: 1px solid #CCC
 
     .swimlane-header
-      writing-mode: sideways-lr;
+      writing-mode: vertical-rl;
+      transform: rotate(180deg);
       font-size: 14px;
       line-height: 50px;
       margin-top: 50px;


### PR DESCRIPTION
With Google Chrome `writing-mode: sideways-lr;` is marked as invalid property value and swimlane header is under swimlane menu icon.

After this change both Firefox 58 and Google Chrome 64 have properly rotated swimlane header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1526)
<!-- Reviewable:end -->
