### PR TITLE
Add a new API route to create a new label in a given board

### DIFF
--- a/models/boards.js
+++ b/models/boards.js
@@ -719,4 +719,33 @@ if (Meteor.isServer) {
       });
     }
   });
+
+  JsonRoutes.add('PUT', '/api/boards/:id/labels', function (req, res) {
+    Authentication.checkUserId(req.userId);
+    const id = req.params.id;
+    try {
+      if (req.body.hasOwnProperty('label')) {
+        const board = Boards.findOne({ _id: id });
+        const color = req.body.label.color;
+        const name = req.body.label.name;
+        const labelId = Random.id(6);
+        if (!board.getLabel(name, color)) {
+          Boards.direct.update({ _id: id }, { $push: { labels: { "_id": labelId, "name": name, "color": color } } });
+          JsonRoutes.sendResult(res, {
+            code: 200,
+            data: labelId,
+          });
+        } else {
+          JsonRoutes.sendResult(res, {
+            code: 200,
+          });
+        }
+      }
+    }
+    catch (error) {
+      JsonRoutes.sendResult(res, {
+        data: error,
+      });
+    }
+  });
 }

--- a/models/boards.js
+++ b/models/boards.js
@@ -730,7 +730,7 @@ if (Meteor.isServer) {
         const name = req.body.label.name;
         const labelId = Random.id(6);
         if (!board.getLabel(name, color)) {
-          Boards.direct.update({ _id: id }, { $push: { labels: { "_id": labelId, "name": name, "color": color } } });
+          Boards.direct.update({ _id: id }, { $push: { labels: { _id: labelId,  name,  color } } });
           JsonRoutes.sendResult(res, {
             code: 200,
             data: labelId,


### PR DESCRIPTION
I decided to refuse to create the label if an other label with the same name already exist. I don't know if it's a good idea to check here but it can be easily removed.

So if I create a new label, i return the label id, if not I return nothing without error (can be changed too).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1630)
<!-- Reviewable:end -->
