### PR TITLE
filtering out swap file created at build time, adding stage package

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -96,6 +96,8 @@ parts:
             - npm
             - curl
             - execstack
+        stage-packages:
+            - libfontconfig1
         override-build: |
             echo "Cleaning environment first"
             rm -rf ~/.meteor ~/.npm /usr/local/lib/node_modules
@@ -153,6 +155,8 @@ parts:
             execstack --clear-execstack $SNAPCRAFT_PART_INSTALL/programs/server/npm/node_modules/meteor/rajit_bootstrap3-datepicker/lib/bootstrap-datepicker/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs
         organize:
             README: README.wekan
+        prime:
+            - -lib/node_modules/node-pre-gyp/node_modules/tar/lib/.unpack.js.swp
 
     helpers:
         source: snap-src


### PR DESCRIPTION
Filtering out 
'lib/node_modules/node-pre-gyp/node_modules/tar/lib/.unpack.js.swp'
which is causing review problem in snap store

Adding stage package to remover snapcraft warning about missing dependency

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1660)
<!-- Reviewable:end -->
