### PR TITLE
bug fix: #1780 (adding scroll to long cards)

### DIFF
--- a/client/components/cards/cardDetails.styl
+++ b/client/components/cards/cardDetails.styl
@@ -5,7 +5,8 @@
   flex-shrink: 0
   flex-basis: 470px
   will-change: flex-basis
-  overflow: hidden
+  overflow-y: scroll
+  overflow-x: hidden
   background: darken(white, 3%)
   border-radius: bottom 3px
   z-index: 20 !important


### PR DESCRIPTION
Cards that are longer than the screen height can now scroll on the y-axis in order to be able to see the whole card.

Note: My first pull request, so bear with me if I have done something strange :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1782)
<!-- Reviewable:end -->
