### PR TITLE
Fix showing only the cards of the current board in calendar view

### DIFF
--- a/models/boards.js
+++ b/models/boards.js
@@ -372,6 +372,7 @@ Boards.helpers({
 
   cardsInInterval(start, end) {
     return Cards.find({
+      boardId: this._id,
       $or: [
         {
           startAt: {


### PR DESCRIPTION
Before this change, when opening the calendar view in one board, all cards of all boards are also shown.
It could be a nice feature to have a global calendar (with board filter). But currently, seeing foreign cards is quite disturbing.

This changes add the selector `boardId` in the card search query.
