### PR TITLE
Allow Sandstorm to serve Wekan HTTP API

### DIFF
--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -226,7 +226,7 @@ const pkgdef :Spk.PackageDefinition = (
         verbPhrase = (defaultText = "removed from card"),
       ), ],
     ),
-
+    apiPath = "/api",
     saveIdentityCaps = true,
   ),
 );


### PR DESCRIPTION
This is probably not a "whole" fix, but this may be a missing piece.

According to https://docs.sandstorm.io/en/latest/developing/http-apis/ an apiPath of "" disallows any API requests, an apiPath of "/" allows the entire app to be served over the API, and an apiPath of "/api" would just allow the API to use the /api subfolder, which is I believe what we want here.

Perhaps @ertanalytics can help test what difference this change makes, if any. My hope is this may bring us into the sandbox where we only have to deal with making sure Wekan's API accepts users authorized in this manner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1851)
<!-- Reviewable:end -->
