### PR TITLE
make the attributes that the webhook sends configurable

### DIFF
--- a/server/notifications/outgoing.js
+++ b/server/notifications/outgoing.js
@@ -8,6 +8,8 @@ const postCatchError = Meteor.wrapAsync((url, options, resolve) => {
   });
 });
 
+let webhooksAtbts = ( (process.env.WEBHOOKS_ATTRIBUTES && process.env.WEBHOOKS_ATTRIBUTES.split(',') ) || ['cardId', 'listId', 'oldListId', 'boardId', 'comment', 'user', 'card', 'commentId']);
+
 Meteor.methods({
   outgoingWebhooks(integrations, description, params) {
     check(integrations, Array);
@@ -19,7 +21,7 @@ Meteor.methods({
       if (quoteParams[key]) quoteParams[key] = `"${params[key]}"`;
     });
 
-    const userId = (params.userId)?params.userId:integrations[0].userId;
+    const userId = (params.userId) ? params.userId : integrations[0].userId;
     const user = Users.findOne(userId);
     const text = `${params.user} ${TAPi18n.__(description, quoteParams, user.getLanguage())}\n${params.url}`;
 
@@ -29,10 +31,7 @@ Meteor.methods({
       text: `${text}`,
     };
 
-    [   'cardId', 'listId', 'oldListId',
-      'boardId', 'comment', 'user',
-      'card', 'commentId',
-    ].forEach((key) => {
+    webhooksAtbts.forEach((key) => {
       if (params[key]) value[key] = params[key];
     });
     value.description = description;


### PR DESCRIPTION
We can choose what attributes the webhook send by adding this   "WEBHOOKS_ATTRIBUTES=att1,att2,att3" in the env variables. When we don't have "WEBHOOKS_ATTRIBUTES" environnement variables; webhook send this data : ['cardId', 'listId', 'oldListId', 'boardId', 'comment', 'user', 'card', 'commentId'].