### PR TITLE
Card url fixed

### DIFF
--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -147,6 +147,13 @@ BlazeComponent.extendComponent({
     });
   },
 
+  scrollTop(position = 0) {
+    const swimlanes = this.$('.js-swimlanes');
+    swimlanes && swimlanes.animate({
+      scrollTop: position,
+    });
+  },
+
 }).register('boardBody');
 
 BlazeComponent.extendComponent({

--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -69,6 +69,20 @@ BlazeComponent.extendComponent({
     if (offset) {
       bodyBoardComponent.scrollLeft(cardContainerScroll + offset);
     }
+
+    //Scroll top
+    const cardViewStartTop = $cardView.offset().top;
+    const cardContainerScrollTop = $cardContainer.scrollTop();
+    let topOffset = false;
+    if(cardViewStartTop < 0){
+      topOffset = 0;
+    } else if(cardViewStartTop - cardContainerScrollTop > 100) {
+      topOffset = cardViewStartTop - cardContainerScrollTop - 100;
+    }
+    if(topOffset !== false) {
+      bodyBoardComponent.scrollTop(topOffset);
+    }
+
   },
 
   presentParentTask() {
@@ -96,7 +110,11 @@ BlazeComponent.extendComponent({
   },
 
   onRendered() {
-    if (!Utils.isMiniScreen()) this.scrollParentContainer();
+    if (!Utils.isMiniScreen()){
+      Meteor.setTimeout(() => {
+        this.scrollParentContainer();
+      }, 500);
+    }
     const $checklistsDom = this.$('.card-checklist-items');
 
     $checklistsDom.sortable({

--- a/client/components/main/editor.js
+++ b/client/components/main/editor.js
@@ -38,8 +38,11 @@ Blaze.Template.registerHelper('mentions', new Template('mentions', function() {
   const view = this;
   const currentBoard = Boards.findOne(Session.get('currentBoard'));
   const knowedUsers = currentBoard.members.map((member) => {
-    member.username = Users.findOne(member.userId).username;
-    return member;
+    const u = Users.findOne(member.userId);
+    if(u){
+      member.username = u.username;
+    }
+    return member;    
   });
   const mentionRegex = /\B@([\w.]*)/gi;
   let content = Blaze.toHTML(view.templateContentBlock);


### PR DESCRIPTION
There was an issue with displaying card by url. 3 issues found:

1. If a user was deleted from the system but he was assigned to board this piece of code fails:
`member.username = Users.findOne(member.userId).username;`
So I've replaced it with a check for user to exist:
```javascript
const u = Users.findOne(member.userId);
    if(u){
      member.username = u.username;
    }
```

2. The scrolling was not working as Parent component was not loaded when `scrollParentContainer` function was called so this function should be called after rendering is finished (I've simply added a timeout to exit the rendering function scope and execute it in separate loop):
```javascript
if (!Utils.isMiniScreen()){
      Meteor.setTimeout(() => {
        this.scrollParentContainer();
      }, 500);
    }
```

3. In swimlanes mode with lots of cards the top scrolling is required to scroll the screen to the card view:
```javascript
scrollTop(position = 0) {
    const swimlanes = this.$('.js-swimlanes');
    swimlanes && swimlanes.animate({
      scrollTop: position,
    });
  },
```

And a code to calculate the scroll in `scrollParentContainer`:
```javascript
//Scroll top
    const cardViewStartTop = $cardView.offset().top;
    const cardContainerScrollTop = $cardContainer.scrollTop();
    let topOffset = false;
    if(cardViewStartTop < 0){
      topOffset = 0;
    } else if(cardViewStartTop - cardContainerScrollTop > 100) {
      topOffset = cardViewStartTop - cardContainerScrollTop - 100;
    }
    if(topOffset !== false) {
      bodyBoardComponent.scrollTop(topOffset);
    }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1932)
<!-- Reviewable:end -->
