### PR TITLE
Patch for customFields when deleting them https://github.com/wekan/wekan/issues/1872

### DIFF
--- a/models/customFields.js
+++ b/models/customFields.js
@@ -71,6 +71,12 @@ if (Meteor.isServer) {
     Activities.remove({
       customFieldId: doc._id,
     });
+
+    Cards.update(
+      {'boardId': doc.boardId, 'customFields._id': doc._id},
+      {$pull: {'customFields': {'_id': doc._id}}},
+      {multi: true}
+    );
   });
 }
 


### PR DESCRIPTION
A solution to this issue: https://github.com/wekan/wekan/issues/1872
- Now when deleting a customField, all reference of this one are deleted also on cards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1950)
<!-- Reviewable:end -->
