### PR TITLE
Fix vertical text for swimlanes in IE11

### DIFF
--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -32,6 +32,7 @@
     border-bottom: 1px solid #CCC
 
     .swimlane-header
+      -ms-writing-mode: tb-rl;
       writing-mode: vertical-rl;
       transform: rotate(180deg);
       font-size: 14px;


### PR DESCRIPTION
**Fixes:** #1798

Internet Explorer supports different values for `writing-mode` from an earlier version of the spec, which originated from SVG. For this reason, you need to use writing mode with the `-ms` prefix (`-ms-writing-mode`) and use the deprecated value `tb-rl`.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/24863179/46907962-22349600-cf13-11e8-92ef-20a08759c15c.png)

### After

![after](https://user-images.githubusercontent.com/24863179/46907964-25c81d00-cf13-11e8-9b3f-e36e0f901125.png)

## References

- [-ms-writing-mode property - Microsoft TechNet](<https://technet.microsoft.com/en-us/ms531187(v=vs.71)>)
- [writing-mode - MDN web docs](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode)
- [CSS writing-mode property - Can I Use](https://caniuse.com/#search=-ms-writing)
