### PR TITLE
Small api fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,6 +136,7 @@ ENV BUILD_DEPS="apt-utils bsdtar gnupg gosu wget curl bzip2 build-essential pyth
 COPY ${SRC_PATH} /home/wekan/app
 
 RUN \
+    set -o xtrace && \
     # Add non-root user wekan
     useradd --user-group --system --home-dir /home/wekan wekan && \
     \

--- a/models/boards.js
+++ b/models/boards.js
@@ -823,9 +823,9 @@ if (Meteor.isServer) {
     }
   });
 
-  JsonRoutes.add('GET', '/api/boards/:id', function (req, res) {
+  JsonRoutes.add('GET', '/api/boards/:boardId', function (req, res) {
     try {
-      const id = req.params.id;
+      const id = req.params.boardId;
       Authentication.checkBoardAccess(req.userId, id);
 
       JsonRoutes.sendResult(res, {
@@ -878,10 +878,10 @@ if (Meteor.isServer) {
     }
   });
 
-  JsonRoutes.add('DELETE', '/api/boards/:id', function (req, res) {
+  JsonRoutes.add('DELETE', '/api/boards/:boardId', function (req, res) {
     try {
       Authentication.checkUserId(req.userId);
-      const id = req.params.id;
+      const id = req.params.boardId;
       Boards.remove({ _id: id });
       JsonRoutes.sendResult(res, {
         code: 200,
@@ -898,9 +898,9 @@ if (Meteor.isServer) {
     }
   });
 
-  JsonRoutes.add('PUT', '/api/boards/:id/labels', function (req, res) {
+  JsonRoutes.add('PUT', '/api/boards/:boardId/labels', function (req, res) {
     Authentication.checkUserId(req.userId);
-    const id = req.params.id;
+    const id = req.params.boardId;
     try {
       if (req.body.hasOwnProperty('label')) {
         const board = Boards.findOne({ _id: id });

--- a/models/boards.js
+++ b/models/boards.js
@@ -276,6 +276,10 @@ Boards.helpers({
     return Users.find({ _id: { $in: _.pluck(this.members, 'userId') } });
   },
 
+  getMember(id) {
+    return _.findWhere(this.members, { userId: id });
+  },
+
   getLabel(name, color) {
     return _.findWhere(this.labels, { name, color });
   },
@@ -836,6 +840,34 @@ if (Meteor.isServer) {
     catch (error) {
       JsonRoutes.sendResult(res, {
         code: 200,
+        data: error,
+      });
+    }
+  });
+
+  JsonRoutes.add('PUT', '/api/boards/:boardId/members', function (req, res) {
+    Authentication.checkUserId(req.userId);
+    try {
+      const boardId = req.params.boardId;
+      const board = Boards.findOne({ _id: boardId });
+      const userId = req.body.userId;
+      const user = Users.findOne({ _id: userId });
+
+      if (!board.getMember(userId)) {
+        user.addInvite(boardId);
+        board.addMember(userId);
+        JsonRoutes.sendResult(res, {
+          code: 200,
+          data: id,
+        });
+      } else {
+        JsonRoutes.sendResult(res, {
+          code: 200,
+        });
+      }
+    }
+    catch (error) {
+      JsonRoutes.sendResult(res, {
         data: error,
       });
     }

--- a/models/cards.js
+++ b/models/cards.js
@@ -1514,6 +1514,11 @@ if (Meteor.isServer) {
       Cards.direct.update({_id: paramCardId, listId: paramListId, boardId: paramBoardId, archived: false},
         {$set: {customFields: newcustomFields}});
     }
+    if (req.body.hasOwnProperty('members')) {
+      const newmembers = req.body.members;
+      Cards.direct.update({_id: paramCardId, listId: paramListId, boardId: paramBoardId, archived: false},
+        {$set: {members: newmembers}});
+    }
     JsonRoutes.sendResult(res, {
       code: 200,
       data: {

--- a/models/cards.js
+++ b/models/cards.js
@@ -1519,6 +1519,11 @@ if (Meteor.isServer) {
       Cards.direct.update({_id: paramCardId, listId: paramListId, boardId: paramBoardId, archived: false},
         {$set: {members: newmembers}});
     }
+    if (req.body.hasOwnProperty('swimlaneId')) {
+      const newParamSwimlaneId = req.body.swimlaneId;
+      Cards.direct.update({_id: paramCardId, listId: paramListId, boardId: paramBoardId, archived: false},
+        {$set: {swimlaneId: newParamSwimlaneId}});
+    }
     JsonRoutes.sendResult(res, {
       code: 200,
       data: {

--- a/models/customFields.js
+++ b/models/customFields.js
@@ -87,7 +87,13 @@ if (Meteor.isServer) {
     const paramBoardId = req.params.boardId;
     JsonRoutes.sendResult(res, {
       code: 200,
-      data: CustomFields.find({ boardId: paramBoardId }),
+      data: CustomFields.find({ boardId: paramBoardId }).map(function (cf) {
+        return {
+          _id: cf._id,
+          name: cf.name,
+          type: cf.type,
+        };
+      }),
     });
   });
 

--- a/models/export.js
+++ b/models/export.js
@@ -48,7 +48,7 @@ class Exporter {
 
   build() {
     const byBoard = { boardId: this._boardId };
-    const byBoardNoLinked = { boardId: this._boardId, linkedId: '' };
+    const byBoardNoLinked = { boardId: this._boardId, linkedId: {$in: ['', null] } };
     // we do not want to retrieve boardId in related elements
     const noBoardId = {
       fields: {

--- a/models/users.js
+++ b/models/users.js
@@ -713,10 +713,10 @@ if (Meteor.isServer) {
     }
   });
 
-  JsonRoutes.add('GET', '/api/users/:id', function (req, res) {
+  JsonRoutes.add('GET', '/api/users/:userId', function (req, res) {
     try {
       Authentication.checkUserId(req.userId);
-      const id = req.params.id;
+      const id = req.params.userId;
       JsonRoutes.sendResult(res, {
         code: 200,
         data: Meteor.users.findOne({ _id: id }),
@@ -730,10 +730,10 @@ if (Meteor.isServer) {
     }
   });
 
-  JsonRoutes.add('PUT', '/api/users/:id', function (req, res) {
+  JsonRoutes.add('PUT', '/api/users/:userId', function (req, res) {
     try {
       Authentication.checkUserId(req.userId);
-      const id = req.params.id;
+      const id = req.params.userId;
       const action = req.body.action;
       let data = Meteor.users.findOne({ _id: id });
       if (data !== undefined) {
@@ -872,10 +872,10 @@ if (Meteor.isServer) {
     }
   });
 
-  JsonRoutes.add('DELETE', '/api/users/:id', function (req, res) {
+  JsonRoutes.add('DELETE', '/api/users/:userId', function (req, res) {
     try {
       Authentication.checkUserId(req.userId);
-      const id = req.params.id;
+      const id = req.params.userId;
       Meteor.users.remove({ _id: id });
       JsonRoutes.sendResult(res, {
         code: 200,


### PR DESCRIPTION
A small batch of updates to provide a few fixes for the REST API:
- also export the cards created with an older wekan instance (without linked cards) (related to #1873)
- fix the GET customFields API that was failing
- allow to directly overwrite the members of cards and boards with a PUT call (this avoids to do multiple calls to `add` and `remove` users)
- allow to change the swimlane of a card from the API

Note: I signed an Apache like CLA and directly sent to @xet7, as my employer didn't want me to sign the current wekan CLA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1962)
<!-- Reviewable:end -->
