### PR TITLE
Allow to remove the full list of labels/members through the API

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -1457,7 +1457,10 @@ if (Meteor.isServer) {
       });
     }
     if (req.body.hasOwnProperty('labelIds')) {
-      const newlabelIds = req.body.labelIds;
+      let newlabelIds = req.body.labelIds;
+      if (_.isString(newlabelIds)) {
+        newlabelIds = [newlabelIds];
+      }
       Cards.direct.update({
         _id: paramCardId,
         listId: paramListId,
@@ -1515,7 +1518,10 @@ if (Meteor.isServer) {
         {$set: {customFields: newcustomFields}});
     }
     if (req.body.hasOwnProperty('members')) {
-      const newmembers = req.body.members;
+      let newmembers = req.body.members;
+      if (_.isString(newmembers)) {
+        newmembers = [newmembers];
+      }
       Cards.direct.update({_id: paramCardId, listId: paramListId, boardId: paramBoardId, archived: false},
         {$set: {members: newmembers}});
     }

--- a/models/cards.js
+++ b/models/cards.js
@@ -1459,7 +1459,12 @@ if (Meteor.isServer) {
     if (req.body.hasOwnProperty('labelIds')) {
       let newlabelIds = req.body.labelIds;
       if (_.isString(newlabelIds)) {
-        newlabelIds = [newlabelIds];
+        if (newlabelIds === '') {
+          newlabelIds = null;
+        }
+        else {
+          newlabelIds = [newlabelIds];
+        }
       }
       Cards.direct.update({
         _id: paramCardId,
@@ -1520,7 +1525,12 @@ if (Meteor.isServer) {
     if (req.body.hasOwnProperty('members')) {
       let newmembers = req.body.members;
       if (_.isString(newmembers)) {
-        newmembers = [newmembers];
+        if (newmembers === '') {
+          newmembers = null;
+        }
+        else {
+          newmembers = [newmembers];
+        }
       }
       Cards.direct.update({_id: paramCardId, listId: paramListId, boardId: paramBoardId, archived: false},
         {$set: {members: newmembers}});


### PR DESCRIPTION
When using x-www-form-urlencoded, we can't really set the member or label field with just one value or even remove it. Allow to do so by tweaking the input value.

Note: Apache I-CLA signed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/1968)
<!-- Reviewable:end -->
