### PR TITLE
Fix: Translate and add colors to IFTTT Rules dropdown."

### DIFF
--- a/client/components/rules/triggers/cardTriggers.js
+++ b/client/components/rules/triggers/cardTriggers.js
@@ -8,6 +8,8 @@ BlazeComponent.extendComponent({
       if (labels[i].name === '' || labels[i].name === undefined) {
         labels[i].name = labels[i].color;
         labels[i].translatedname = `${TAPi18n.__(`color-${  labels[i].color}`)}`;
+      } else {
+        labels[i].translatedname = labels[i].name;
       }
     }
     return labels;


### PR DESCRIPTION
This fixes commit 44e4df2492b95226f1297e7f556d61b1afaab714.

When the label has a name, not setting `translatedname` results in a blank item in the IFTTT label trigger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2119)
<!-- Reviewable:end -->
