### PR TITLE
Color for swimlanes

### DIFF
--- a/client/components/boards/boardBody.jade
+++ b/client/components/boards/boardBody.jade
@@ -23,6 +23,8 @@ template(name="boardBody")
       if isViewSwimlanes
         each currentBoard.swimlanes
           +swimlane(this)
+        if currentUser.isBoardMember
+          +addSwimlaneForm
       if isViewLists
         +listsGroup
       if isViewCalendar

--- a/client/components/boards/boardBody.jade
+++ b/client/components/boards/boardBody.jade
@@ -23,8 +23,6 @@ template(name="boardBody")
       if isViewSwimlanes
         each currentBoard.swimlanes
           +swimlane(this)
-        if currentUser.isBoardMember
-          +addSwimlaneForm
       if isViewLists
         +listsGroup
       if isViewCalendar

--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -35,6 +35,37 @@ BlazeComponent.extendComponent({
     this._isDragging = false;
     // Used to set the overlay
     this.mouseHasEnterCardDetails = false;
+
+    // fix swimlanes sort field if there are null values
+    const currentBoardData = Boards.findOne(Session.get('currentBoard'));
+    const nullSortSwimlanes = currentBoardData.nullSortSwimlanes();
+    if (nullSortSwimlanes.count() > 0) {
+      const swimlanes = currentBoardData.swimlanes();
+      let count = 0;
+      swimlanes.forEach((s) => {
+        Swimlanes.update(s._id, {
+          $set: {
+            sort: count,
+          },
+        });
+        count += 1;
+      });
+    }
+
+    // fix lists sort field if there are null values
+    const nullSortLists = currentBoardData.nullSortLists();
+    if (nullSortLists.count() > 0) {
+      const lists = currentBoardData.lists();
+      let count = 0;
+      lists.forEach((l) => {
+        Lists.update(l._id, {
+          $set: {
+            sort: count,
+          },
+        });
+        count += 1;
+      });
+    }
   },
   onRendered() {
     const boardComponent = this;

--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -234,7 +234,7 @@ template(name="cardDetailsActionsPopup")
       li: a.js-due-date {{_ 'editCardDueDatePopup-title'}}
       li: a.js-end-date {{_ 'editCardEndDatePopup-title'}}
       li: a.js-spent-time {{_ 'editCardSpentTimePopup-title'}}
-      li: a.js-set-card-color {{_ 'setCardColor-title'}}
+      li: a.js-set-card-color {{_ 'setCardColorPopup-title'}}
     hr
     ul.pop-over-list
       li: a.js-move-card-to-top {{_ 'moveCardToTop-title'}}
@@ -337,9 +337,6 @@ template(name="cardMorePopup")
     a.js-delete(title="{{_ 'card-delete-notice'}}") {{_ 'delete'}}
 
 template(name="setCardColorPopup")
-  p.quiet
-    span.clearfix
-  label {{_ "select-color"}}
   form.edit-label
     .palette-colors: each colors
       span.card-label.palette-color.js-palette-color(class="card-details-{{color}}")

--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -339,9 +339,10 @@ template(name="cardMorePopup")
 template(name="setCardColorPopup")
   form.edit-label
     .palette-colors: each colors
-      span.card-label.palette-color.js-palette-color(class="card-details-{{color}}")
-        if(isSelected color)
-          i.fa.fa-check
+      unless $eq color 'white'
+        span.card-label.palette-color.js-palette-color(class="card-details-{{color}}")
+          if(isSelected color)
+            i.fa.fa-check
     button.primary.confirm.js-submit {{_ 'save'}}
     button.js-remove-color.negate.wide.right {{_ 'unset-color'}}
 

--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -27,7 +27,6 @@ BlazeComponent.extendComponent({
   onCreated() {
     this.currentBoard = Boards.findOne(Session.get('currentBoard'));
     this.isLoaded = new ReactiveVar(false);
-    this.currentColor = new ReactiveVar(this.data().color);
     const boardBody =  this.parentComponent().parentComponent();
     //in Miniview parent is Board, not BoardBody.
     if (boardBody !== null) {

--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -601,6 +601,9 @@ BlazeComponent.extendComponent({
   },
 
   isSelected(color) {
+    if (this.currentColor.get() === null) {
+      return color === 'white';
+    }
     return this.currentColor.get() === color;
   },
 

--- a/client/components/cards/cardDetails.styl
+++ b/client/components/cards/cardDetails.styl
@@ -146,6 +146,10 @@ card-details-color(background, color...)
   if color
     color: color !important //overwrite text for better visibility
 
+.card-details-white
+  card-details-color(unset, #000) //Black text for better visibility
+  border: 1px solid #eee
+
 .card-details-green
   card-details-color(#3cb500, #ffffff) //White text for better visibility
 

--- a/client/components/cards/cardDetails.styl
+++ b/client/components/cards/cardDetails.styl
@@ -144,16 +144,16 @@ input[type="submit"].attachment-add-link-submit
 card-details-color(background, color...)
   background: background !important
   if color
-    color: color //overwrite text for better visibility
+    color: color !important //overwrite text for better visibility
 
 .card-details-green
   card-details-color(#3cb500, #ffffff) //White text for better visibility
 
 .card-details-yellow
-  card-details-color(#fad900)
+  card-details-color(#fad900, #000) //Black text for better visibility
 
 .card-details-orange
-  card-details-color(#ff9f19)
+  card-details-color(#ff9f19, #000) //Black text for better visibility
 
 .card-details-red
   card-details-color(#eb4646, #ffffff) //White text for better visibility
@@ -165,7 +165,7 @@ card-details-color(background, color...)
   card-details-color(#0079bf, #ffffff) //White text for better visibility
 
 .card-details-pink
-  card-details-color(#ff78cb)
+  card-details-color(#ff78cb, #000) //Black text for better visibility
 
 .card-details-sky
   card-details-color(#00c2e0, #ffffff) //White text for better visibility
@@ -174,19 +174,19 @@ card-details-color(background, color...)
   card-details-color(#4d4d4d, #ffffff) //White text for better visibility
 
 .card-details-lime
-  card-details-color(#51e898)
+  card-details-color(#51e898, #000) //Black text for better visibility
 
 .card-details-silver
-  card-details-color(#c0c0c0)
+  card-details-color(#c0c0c0, #000) //Black text for better visibility
 
 .card-details-peachpuff
-  card-details-color(#ffdab9)
+  card-details-color(#ffdab9, #000) //Black text for better visibility
 
 .card-details-crimson
   card-details-color(#dc143c, #ffffff) //White text for better visibility
 
 .card-details-plum
-  card-details-color(#dda0dd)
+  card-details-color(#dda0dd, #000) //Black text for better visibility
 
 .card-details-darkgreen
   card-details-color(#006400, #ffffff) //White text for better visibility
@@ -198,7 +198,7 @@ card-details-color(background, color...)
   card-details-color(#ff00ff, #ffffff) //White text for better visibility
 
 .card-details-gold
-  card-details-color(#ffd700)
+  card-details-color(#ffd700, #000) //Black text for better visibility
 
 .card-details-navy
   card-details-color(#000080, #ffffff) //White text for better visibility
@@ -210,10 +210,10 @@ card-details-color(background, color...)
   card-details-color(#8b4513, #ffffff) //White text for better visibility
 
 .card-details-paleturquoise
-  card-details-color(#afeeee)
+  card-details-color(#afeeee, #000) //Black text for better visibility
 
 .card-details-mistyrose
-  card-details-color(#ffe4e1)
+  card-details-color(#ffe4e1, #000) //Black text for better visibility
 
 .card-details-indigo
   card-details-color(#4b0082, #ffffff) //White text for better visibility

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -3,10 +3,6 @@
 // });
 
 BlazeComponent.extendComponent({
-  onCreated() {
-    this.currentColor = new ReactiveVar(this.data().color);
-  },
-
   template() {
     return 'minicard';
   },

--- a/client/components/lists/list.styl
+++ b/client/components/lists/list.styl
@@ -10,7 +10,6 @@
   // transparent, because that won't work during a list drag.
   background: darken(white, 13%)
   border-left: 1px solid darken(white, 20%)
-  border-bottom: 1px solid #CCC
   padding: 0
   float: left
 

--- a/client/components/rules/actions/cardActions.jade
+++ b/client/components/rules/actions/cardActions.jade
@@ -39,32 +39,15 @@ template(name="cardActions")
     div.trigger-content
       div.trigger-text
         | {{{_'r-set-color'}}}
-      div.trigger-dropdown
-        select(id="color-action")
-          option(value="white")         {{{_'color-white'}}}
-          option(value="green")         {{{_'color-green'}}}
-          option(value="yellow")        {{{_'color-yellow'}}}
-          option(value="orange")        {{{_'color-orange'}}}
-          option(value="red")           {{{_'color-red'}}}
-          option(value="purple")        {{{_'color-purple'}}}
-          option(value="blue")          {{{_'color-blue'}}}
-          option(value="sky")           {{{_'color-sky'}}}
-          option(value="lime")          {{{_'color-lime'}}}
-          option(value="pink")          {{{_'color-pink'}}}
-          option(value="black")         {{{_'color-black'}}}
-          option(value="silver")        {{{_'color-silver'}}}
-          option(value="peachpuff")     {{{_'color-peachpuff'}}}
-          option(value="crimson")       {{{_'color-crimson'}}}
-          option(value="plum")          {{{_'color-plum'}}}
-          option(value="darkgreen")     {{{_'color-darkgreen'}}}
-          option(value="slateblue")     {{{_'color-slateblue'}}}
-          option(value="magenta")       {{{_'color-magenta'}}}
-          option(value="gold")          {{{_'color-gold'}}}
-          option(value="navy")          {{{_'color-navy'}}}
-          option(value="gray")          {{{_'color-gray'}}}
-          option(value="saddlebrown")   {{{_'color-saddlebrown'}}}
-          option(value="paleturquoise") {{{_'color-paleturquoise'}}}
-          option(value="mistyrose")     {{{_'color-mistyrose'}}}
-          option(value="indigo")        {{{_'color-indigo'}}}
+        button.trigger-button.trigger-button-color.card-details-green.js-show-color-palette(id="color-action")
+          | {{{_'color-green'}}}
     div.trigger-button.js-set-color-action.js-goto-rules
       i.fa.fa-plus
+
+template(name="setCardActionsColorPopup")
+  form.edit-label
+    .palette-colors: each colors
+      span.card-label.palette-color.js-palette-color(class="card-details-{{color}}")
+        if(isSelected color)
+          i.fa.fa-check
+    button.primary.confirm.js-submit {{_ 'save'}}

--- a/client/components/rules/rules.styl
+++ b/client/components/rules/rules.styl
@@ -174,6 +174,15 @@
           top:30px
         .trigger-button.trigger-button-person
           right:-40px
+        .trigger-button.trigger-button-color
+          top: unset
+          position: unset
+          transform: unset
+          font-size: 16px
+          width:auto
+          padding-left: 10px
+          padding-right: 10px
+          height:40px
       .trigger-item.trigger-item-mail
         height:300px
   

--- a/client/components/swimlanes/swimlaneHeader.jade
+++ b/client/components/swimlanes/swimlaneHeader.jade
@@ -1,5 +1,5 @@
 template(name="swimlaneHeader")
-  .swimlane-header-wrap.js-swimlane-header
+  .swimlane-header-wrap.js-swimlane-header(class='{{#if colorClass}}swimlane-{{colorClass}}{{/if}}')
     +inlinedForm
       +editSwimlaneTitleForm
     else
@@ -21,6 +21,9 @@ template(name="editSwimlaneTitleForm")
 template(name="swimlaneActionPopup")
   unless currentUser.isCommentOnly
     ul.pop-over-list
+       li: a.js-set-swimlane-color {{_ 'select-color'}}
+    hr
+    ul.pop-over-list
       li: a.js-close-swimlane {{_ 'archive-swimlane'}}
 
 template(name="swimlaneAddPopup")
@@ -30,3 +33,12 @@ template(name="swimlaneAddPopup")
         autocomplete="off" autofocus)
       .edit-controls.clearfix
         button.primary.confirm(type="submit") {{_ 'add'}}
+
+template(name="setSwimlaneColorPopup")
+  form.edit-label
+    .palette-colors: each colors
+      span.card-label.palette-color.js-palette-color(class="card-details-{{color}}")
+        if(isSelected color)
+          i.fa.fa-check
+    button.primary.confirm.js-submit {{_ 'save'}}
+    button.js-remove-color.negate.wide.right {{_ 'unset-color'}}

--- a/client/components/swimlanes/swimlaneHeader.jade
+++ b/client/components/swimlanes/swimlaneHeader.jade
@@ -8,6 +8,7 @@ template(name="swimlaneHeader")
         = title
       .swimlane-header-menu
         unless currentUser.isCommentOnly
+          a.fa.fa-plus.js-open-add-swimlane-menu.swimlane-header-plus-icon
           a.fa.fa-navicon.js-open-swimlane-menu
 
 template(name="editSwimlaneTitleForm")
@@ -21,3 +22,11 @@ template(name="swimlaneActionPopup")
   unless currentUser.isCommentOnly
     ul.pop-over-list
       li: a.js-close-swimlane {{_ 'archive-swimlane'}}
+
+template(name="swimlaneAddPopup")
+  unless currentUser.isCommentOnly
+    form
+      input.swimlane-name-input.full-line(type="text" placeholder="{{_ 'add-swimlane'}}"
+        autocomplete="off" autofocus)
+      .edit-controls.clearfix
+        button.primary.confirm(type="submit") {{_ 'add'}}

--- a/client/components/swimlanes/swimlaneHeader.js
+++ b/client/components/swimlanes/swimlaneHeader.js
@@ -1,5 +1,10 @@
 const { calculateIndexData } = Utils;
 
+let swimlaneColors;
+Meteor.startup(() => {
+  swimlaneColors = Swimlanes.simpleSchema()._schema.color.allowedValues;
+});
+
 BlazeComponent.extendComponent({
   editTitle(evt) {
     evt.preventDefault();
@@ -20,6 +25,7 @@ BlazeComponent.extendComponent({
 }).register('swimlaneHeader');
 
 Template.swimlaneActionPopup.events({
+  'click .js-set-swimlane-color': Popup.open('setSwimlaneColor'),
   'click .js-close-swimlane' (evt) {
     evt.preventDefault();
     this.archive();
@@ -60,3 +66,34 @@ BlazeComponent.extendComponent({
     }];
   },
 }).register('swimlaneAddPopup');
+
+BlazeComponent.extendComponent({
+  onCreated() {
+    this.currentSwimlane = this.currentData();
+    this.currentColor = new ReactiveVar(this.currentSwimlane.color);
+  },
+
+  colors() {
+    return swimlaneColors.map((color) => ({ color, name: '' }));
+  },
+
+  isSelected(color) {
+    return this.currentColor.get() === color;
+  },
+
+  events() {
+    return [{
+      'click .js-palette-color'() {
+        this.currentColor.set(this.currentData().color);
+      },
+      'click .js-submit' () {
+        this.currentSwimlane.setColor(this.currentColor.get());
+        Popup.close();
+      },
+      'click .js-remove-color'() {
+        this.currentSwimlane.setColor(null);
+        Popup.close();
+      },
+    }];
+  },
+}).register('setSwimlaneColorPopup');

--- a/client/components/swimlanes/swimlaneHeader.js
+++ b/client/components/swimlanes/swimlaneHeader.js
@@ -11,6 +11,7 @@ BlazeComponent.extendComponent({
   events() {
     return [{
       'click .js-open-swimlane-menu': Popup.open('swimlaneAction'),
+      'click .js-open-add-swimlane-menu': Popup.open('swimlaneAdd'),
       submit: this.editTitle,
     }];
   },
@@ -23,3 +24,30 @@ Template.swimlaneActionPopup.events({
     Popup.close();
   },
 });
+
+BlazeComponent.extendComponent({
+  events() {
+    return [{
+      submit(evt) {
+        evt.preventDefault();
+        const titleInput = this.find('.swimlane-name-input');
+        const title = titleInput.value.trim();
+        if (title) {
+          Swimlanes.insert({
+            title,
+            boardId: Session.get('currentBoard'),
+            // XXX we should insert the swimlane right after the caller
+            sort: $('.swimlane').length,
+          });
+
+          titleInput.value = '';
+          titleInput.focus();
+        }
+        // XXX ideally, we should move the popup to the newly
+        // created swimlane so a user can add more than one swimlane
+        // with a minimum of interactions
+        Popup.close();
+      },
+    }];
+  },
+}).register('swimlaneAddPopup');

--- a/client/components/swimlanes/swimlaneHeader.js
+++ b/client/components/swimlanes/swimlaneHeader.js
@@ -1,3 +1,5 @@
+const { calculateIndexData } = Utils;
+
 BlazeComponent.extendComponent({
   editTitle(evt) {
     evt.preventDefault();
@@ -26,18 +28,25 @@ Template.swimlaneActionPopup.events({
 });
 
 BlazeComponent.extendComponent({
+  onCreated() {
+    this.currentSwimlane = this.currentData();
+  },
+
   events() {
     return [{
       submit(evt) {
         evt.preventDefault();
+        const currentBoard = Boards.findOne(Session.get('currentBoard'));
+        const nextSwimlane = currentBoard.nextSwimlane(this.currentSwimlane);
         const titleInput = this.find('.swimlane-name-input');
         const title = titleInput.value.trim();
+        const sortValue = calculateIndexData(this.currentSwimlane, nextSwimlane, 1);
+
         if (title) {
           Swimlanes.insert({
             title,
             boardId: Session.get('currentBoard'),
-            // XXX we should insert the swimlane right after the caller
-            sort: $('.swimlane').length,
+            sort: sortValue.base,
           });
 
           titleInput.value = '';

--- a/client/components/swimlanes/swimlanes.jade
+++ b/client/components/swimlanes/swimlanes.jade
@@ -36,20 +36,6 @@ template(name="listsGroup")
       if currentUser.isBoardMember
         +addListForm
 
-template(name="addSwimlaneForm")
-  .list.list-composer.js-list-composer
-    .list-header
-      +inlinedForm(autoclose=false)
-        input.swimlane-name-input.full-line(type="text" placeholder="{{_ 'add-swimlane'}}"
-          autocomplete="off" autofocus)
-        .edit-controls.clearfix
-          button.primary.confirm(type="submit") {{_ 'save'}}
-          a.fa.fa-times-thin.js-close-inlined-form
-      else
-        a.open-list-composer.js-open-inlined-form
-          i.fa.fa-plus
-          | {{_ 'add-swimlane'}}
-
 template(name="addListForm")
   .list.list-composer.js-list-composer
     .list-header

--- a/client/components/swimlanes/swimlanes.jade
+++ b/client/components/swimlanes/swimlanes.jade
@@ -1,21 +1,22 @@
 template(name="swimlane")
   .swimlane.js-lists.js-swimlane
     +swimlaneHeader
-    if isMiniScreen
-      if currentList
-        +list(currentList)
+    .swimlane.list-group.js-lists
+      if isMiniScreen
+        if currentList
+          +list(currentList)
+        else
+          each currentBoard.lists
+            +miniList(this)
+          if currentUser.isBoardMember
+            +addListForm
       else
         each currentBoard.lists
-          +miniList(this)
+          +list(this)
+          if currentCardIsInThisList _id ../_id
+            +cardDetails(currentCard)
         if currentUser.isBoardMember
           +addListForm
-    else
-      each currentBoard.lists
-        +list(this)
-        if currentCardIsInThisList _id ../_id
-          +cardDetails(currentCard)
-      if currentUser.isBoardMember
-        +addListAndSwimlaneForm
 
 template(name="listsGroup")
   .swimlane.list-group.js-lists
@@ -35,19 +36,8 @@ template(name="listsGroup")
       if currentUser.isBoardMember
         +addListForm
 
-template(name="addListAndSwimlaneForm")
+template(name="addSwimlaneForm")
   .list.list-composer.js-list-composer
-    .list-header
-      +inlinedForm(autoclose=false)
-        input.list-name-input.full-line(type="text" placeholder="{{_ 'add-list'}}"
-          autocomplete="off" autofocus)
-        .edit-controls.clearfix
-          button.primary.confirm(type="submit") {{_ 'save'}}
-          a.fa.fa-times-thin.js-close-inlined-form
-      else
-        a.open-list-composer.js-open-inlined-form
-          i.fa.fa-plus
-          | {{_ 'add-list'}}
     .list-header
       +inlinedForm(autoclose=false)
         input.swimlane-name-input.full-line(type="text" placeholder="{{_ 'add-swimlane'}}"

--- a/client/components/swimlanes/swimlanes.js
+++ b/client/components/swimlanes/swimlanes.js
@@ -175,33 +175,6 @@ BlazeComponent.extendComponent({
   },
 }).register('addListForm');
 
-BlazeComponent.extendComponent({
-  // Proxy
-  open() {
-    this.childComponents('inlinedForm')[0].open();
-  },
-
-  events() {
-    return [{
-      submit(evt) {
-        evt.preventDefault();
-        let titleInput = this.find('.swimlane-name-input');
-        const title = titleInput.value.trim();
-        if (title) {
-          Swimlanes.insert({
-            title,
-            boardId: Session.get('currentBoard'),
-            sort: $('.swimlane').length,
-          });
-
-          titleInput.value = '';
-          titleInput.focus();
-        }
-      },
-    }];
-  },
-}).register('addSwimlaneForm');
-
 Template.swimlane.helpers({
   canSeeAddList() {
     return Meteor.user() && Meteor.user().isBoardMember() && !Meteor.user().isCommentOnly();

--- a/client/components/swimlanes/swimlanes.js
+++ b/client/components/swimlanes/swimlanes.js
@@ -185,37 +185,22 @@ BlazeComponent.extendComponent({
     return [{
       submit(evt) {
         evt.preventDefault();
-        let titleInput = this.find('.list-name-input');
-        if (titleInput) {
-          const title = titleInput.value.trim();
-          if (title) {
-            Lists.insert({
-              title,
-              boardId: Session.get('currentBoard'),
-              sort: $('.list').length,
-            });
+        let titleInput = this.find('.swimlane-name-input');
+        const title = titleInput.value.trim();
+        if (title) {
+          Swimlanes.insert({
+            title,
+            boardId: Session.get('currentBoard'),
+            sort: $('.swimlane').length,
+          });
 
-            titleInput.value = '';
-            titleInput.focus();
-          }
-        } else {
-          titleInput = this.find('.swimlane-name-input');
-          const title = titleInput.value.trim();
-          if (title) {
-            Swimlanes.insert({
-              title,
-              boardId: Session.get('currentBoard'),
-              sort: $('.swimlane').length,
-            });
-
-            titleInput.value = '';
-            titleInput.focus();
-          }
+          titleInput.value = '';
+          titleInput.focus();
         }
       },
     }];
   },
-}).register('addListAndSwimlaneForm');
+}).register('addSwimlaneForm');
 
 Template.swimlane.helpers({
   canSeeAddList() {

--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -46,6 +46,10 @@
       position: absolute
       padding: 5px 5px
 
+    .swimlane-header-plus-icon
+      margin-left: 5px
+      margin-right: 10px
+
 .list-group
   flex-direction: row
   height: 100%

--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -5,7 +5,7 @@
   // transparent, because that won't work during a swimlane drag.
   background: darken(white, 13%)
   display: flex
-  flex-direction: row
+  flex-direction: column
   overflow: 0;
   max-height: 100%
 
@@ -27,20 +27,15 @@
   .swimlane-header-wrap
     display: flex;
     flex-direction: row;
-    flex: 0 0 50px;
-    padding-bottom: 30px;
-    border-bottom: 1px solid #CCC
+    flex: 0 0 24px;
+    background-color: #ccc;
 
     .swimlane-header
-      -ms-writing-mode: tb-rl;
-      writing-mode: vertical-rl;
-      transform: rotate(180deg);
       font-size: 14px;
-      line-height: 50px;
-      margin-top: 50px;
+      padding: 5px 5px
       font-weight: bold;
       min-height: 9px;
-      width: 50px;
+      width: 100%;
       overflow: hidden;
       -o-text-overflow: ellipsis;
       text-overflow: ellipsis;
@@ -49,7 +44,8 @@
 
     .swimlane-header-menu
       position: absolute
-      padding: 20px 20px
+      padding: 5px 5px
 
 .list-group
+  flex-direction: row
   height: 100%

--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -53,3 +53,84 @@
 .list-group
   flex-direction: row
   height: 100%
+
+swimlane-color(background, color...)
+  background: background !important
+  if color
+    color: color !important //overwrite text for better visibility
+
+.swimlane-white
+  swimlane-color(#ffffff, #4d4d4d) //Black text for better visibility
+  border: 1px solid #eee
+
+.swimlane-green
+  swimlane-color(#3cb500, #ffffff) //White text for better visibility
+
+.swimlane-yellow
+  swimlane-color(#fad900, #4d4d4d) //Black text for better visibility
+
+.swimlane-orange
+  swimlane-color(#ff9f19, #4d4d4d) //Black text for better visibility
+
+.swimlane-red
+  swimlane-color(#eb4646, #ffffff) //White text for better visibility
+
+.swimlane-purple
+  swimlane-color(#a632db, #ffffff) //White text for better visibility
+
+.swimlane-blue
+  swimlane-color(#0079bf, #ffffff) //White text for better visibility
+
+.swimlane-pink
+  swimlane-color(#ff78cb, #4d4d4d) //Black text for better visibility
+
+.swimlane-sky
+  swimlane-color(#00c2e0, #ffffff) //White text for better visibility
+
+.swimlane-black
+  swimlane-color(#4d4d4d, #ffffff) //White text for better visibility
+
+.swimlane-lime
+  swimlane-color(#51e898, #4d4d4d) //Black text for better visibility
+
+.swimlane-silver
+  swimlane-color(unset, #4d4d4d) //Black text for better visibility
+
+.swimlane-peachpuff
+  swimlane-color(#ffdab9, #4d4d4d) //Black text for better visibility
+
+.swimlane-crimson
+  swimlane-color(#dc143c, #ffffff) //White text for better visibility
+
+.swimlane-plum
+  swimlane-color(#dda0dd, #4d4d4d) //Black text for better visibility
+
+.swimlane-darkgreen
+  swimlane-color(#006400, #ffffff) //White text for better visibility
+
+.swimlane-slateblue
+  swimlane-color(#6a5acd, #ffffff) //White text for better visibility
+
+.swimlane-magenta
+  swimlane-color(#ff00ff, #ffffff) //White text for better visibility
+
+.swimlane-gold
+  swimlane-color(#ffd700, #4d4d4d) //Black text for better visibility
+
+.swimlane-navy
+  swimlane-color(#000080, #ffffff) //White text for better visibility
+
+.swimlane-gray
+  swimlane-color(#808080, #ffffff) //White text for better visibility
+
+.swimlane-saddlebrown
+  swimlane-color(#8b4513, #ffffff) //White text for better visibility
+
+.swimlane-paleturquoise
+  swimlane-color(#afeeee, #4d4d4d) //Black text for better visibility
+
+.swimlane-mistyrose
+  swimlane-color(#ffe4e1, #4d4d4d) //Black text for better visibility
+
+.swimlane-indigo
+  swimlane-color(#4b0082, #ffffff) //White text for better visibility

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -337,6 +337,7 @@
     "list-select-cards": "Select all cards in this list",
     "listActionPopup-title": "List Actions",
     "swimlaneActionPopup-title": "Swimlane Actions",
+    "swimlaneAddPopup-title": "Add a Swimlane below",
     "listImportCardPopup-title": "Import a Trello card",
     "listMorePopup-title": "More",
     "link-list": "Link to this list",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -517,7 +517,7 @@
     "card-end-on": "Ends on",
     "editCardReceivedDatePopup-title": "Change received date",
     "editCardEndDatePopup-title": "Change end date",
-    "setCardColor-title": "Set color",
+    "setCardColorPopup-title": "Set color",
     "assigned-by": "Assigned By",
     "requested-by": "Requested By",
     "board-delete-notice": "Deleting is permanent. You will lose all lists, cards and actions associated with this board.",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -518,6 +518,7 @@
     "editCardReceivedDatePopup-title": "Change received date",
     "editCardEndDatePopup-title": "Change end date",
     "setCardColorPopup-title": "Set color",
+    "setCardActionsColorPopup-title": "Choose a color",
     "assigned-by": "Assigned By",
     "requested-by": "Requested By",
     "board-delete-notice": "Deleting is permanent. You will lose all lists, cards and actions associated with this board.",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -520,6 +520,7 @@
     "editCardEndDatePopup-title": "Change end date",
     "setCardColorPopup-title": "Set color",
     "setCardActionsColorPopup-title": "Choose a color",
+    "setSwimlaneColorPopup-title": "Choose a color",
     "assigned-by": "Assigned By",
     "requested-by": "Requested By",
     "board-delete-notice": "Deleting is permanent. You will lose all lists, cards and actions associated with this board.",

--- a/models/boards.js
+++ b/models/boards.js
@@ -351,6 +351,17 @@ Boards.helpers({
     return Swimlanes.find({ boardId: this._id, archived: false }, { sort: { sort: 1 } });
   },
 
+  nextSwimlane(swimlane) {
+    return Swimlanes.findOne({
+      boardId: this._id,
+      archived: false,
+      sort: { $gte: swimlane.sort },
+      _id: { $ne: swimlane._id },
+    }, {
+      sort: { sort: 1 },
+    });
+  },
+
   hasOvertimeCards(){
     const card = Cards.findOne({isOvertime: true, boardId: this._id, archived: false} );
     return card !== undefined;

--- a/models/boards.js
+++ b/models/boards.js
@@ -347,6 +347,14 @@ Boards.helpers({
     return Lists.find({ boardId: this._id, archived: false }, { sort: { sort: 1 } });
   },
 
+  nullSortLists() {
+    return Lists.find({
+      boardId: this._id,
+      archived: false,
+      sort: { $eq: null },
+    });
+  },
+
   swimlanes() {
     return Swimlanes.find({ boardId: this._id, archived: false }, { sort: { sort: 1 } });
   },
@@ -359,6 +367,14 @@ Boards.helpers({
       _id: { $ne: swimlane._id },
     }, {
       sort: { sort: 1 },
+    });
+  },
+
+  nullSortSwimlanes() {
+    return Swimlanes.find({
+      boardId: this._id,
+      archived: false,
+      sort: { $eq: null },
     });
   },
 

--- a/models/cards.js
+++ b/models/cards.js
@@ -69,7 +69,7 @@ Cards.attachSchema(new SimpleSchema({
     type: String,
     optional: true,
     allowedValues: [
-      'green', 'yellow', 'orange', 'red', 'purple',
+      'white', 'green', 'yellow', 'orange', 'red', 'purple',
       'blue', 'sky', 'lime', 'pink', 'black',
       'silver', 'peachpuff', 'crimson', 'plum', 'darkgreen',
       'slateblue', 'magenta', 'gold', 'navy', 'gray',
@@ -1571,12 +1571,15 @@ if (Meteor.isServer) {
    *
    * @description Edit a card
    *
-   * The color has to be chosen between `green`, `yellow`, `orange`, `red`,
-   * `purple`, `blue`, `sky`, `lime`, `pink`, `black`, `silver`, `peachpuff`,
-   * `crimson`, `plum`, `darkgreen`, `slateblue`, `magenta`, `gold`, `navy`,
-   * `gray`, `saddlebrown`, `paleturquoise`, `mistyrose`, `indigo`:
+   * The color has to be chosen between `white`, `green`, `yellow`, `orange`,
+   * `red`, `purple`, `blue`, `sky`, `lime`, `pink`, `black`, `silver`,
+   * `peachpuff`, `crimson`, `plum`, `darkgreen`, `slateblue`, `magenta`,
+   * `gold`, `navy`, `gray`, `saddlebrown`, `paleturquoise`, `mistyrose`,
+   * `indigo`:
    *
    * <img src="/card-colors.png" width="40%" alt="Wekan card colors" />
+   *
+   * Note: setting the color to white has the same effect than removing it.
    *
    * @param {string} boardId the board ID of the card
    * @param {string} list the list ID of the card

--- a/models/cards.js
+++ b/models/cards.js
@@ -1526,6 +1526,10 @@ if (Meteor.isServer) {
     Authentication.checkUserId(req.userId);
     const paramBoardId = req.params.boardId;
     const paramListId = req.params.listId;
+    const currentCards = Cards.find({
+      listId: paramListId,
+      archived: false,
+    }, { sort: ['sort'] });
     const check = Users.findOne({
       _id: req.body.authorId,
     });
@@ -1538,7 +1542,7 @@ if (Meteor.isServer) {
         description: req.body.description,
         userId: req.body.authorId,
         swimlaneId: req.body.swimlaneId,
-        sort: 0,
+        sort: currentCards.count(),
         members,
       });
       JsonRoutes.sendResult(res, {

--- a/models/lists.js
+++ b/models/lists.js
@@ -314,9 +314,11 @@ if (Meteor.isServer) {
     try {
       Authentication.checkUserId( req.userId);
       const paramBoardId = req.params.boardId;
+      const board = Boards.findOne(paramBoardId);
       const id = Lists.insert({
         title: req.body.title,
         boardId: paramBoardId,
+        sort: board.lists().count(),
       });
       JsonRoutes.sendResult(res, {
         code: 200,

--- a/models/swimlanes.js
+++ b/models/swimlanes.js
@@ -256,9 +256,11 @@ if (Meteor.isServer) {
     try {
       Authentication.checkUserId( req.userId);
       const paramBoardId = req.params.boardId;
+      const board = Boards.findOne(paramBoardId);
       const id = Swimlanes.insert({
         title: req.body.title,
         boardId: paramBoardId,
+        sort: board.swimlanes().count(),
       });
       JsonRoutes.sendResult(res, {
         code: 200,

--- a/models/swimlanes.js
+++ b/models/swimlanes.js
@@ -49,6 +49,21 @@ Swimlanes.attachSchema(new SimpleSchema({
     // XXX We should probably provide a default
     optional: true,
   },
+  color: {
+    /**
+     * the color of the swimlane
+     */
+    type: String,
+    optional: true,
+    // silver is the default, so it is left out
+    allowedValues: [
+      'white', 'green', 'yellow', 'orange', 'red', 'purple',
+      'blue', 'sky', 'lime', 'pink', 'black',
+      'peachpuff', 'crimson', 'plum', 'darkgreen',
+      'slateblue', 'magenta', 'gold', 'navy', 'gray',
+      'saddlebrown', 'paleturquoise', 'mistyrose', 'indigo',
+    ],
+  },
   updatedAt: {
     /**
      * when was the swimlane last edited
@@ -93,6 +108,12 @@ Swimlanes.helpers({
   board() {
     return Boards.findOne(this.boardId);
   },
+
+  colorClass() {
+    if (this.color)
+      return this.color;
+    return '';
+  },
 });
 
 Swimlanes.mutations({
@@ -106,6 +127,17 @@ Swimlanes.mutations({
 
   restore() {
     return { $set: { archived: false } };
+  },
+
+  setColor(newColor) {
+    if (newColor === 'silver') {
+      newColor = null;
+    }
+    return {
+      $set: {
+        color: newColor,
+      },
+    };
   },
 });
 


### PR DESCRIPTION
![screenshot from 2019-01-24 17-02-35](https://user-images.githubusercontent.com/2705518/51690876-ed4bdb00-1ff9-11e9-97c8-5779da0c42db.png)

For being able to correctly add the swimlanes after the current swimlane, I had to fix the `sort` field for the `Swimlanes`. While at it, I did the same for the `Lists` `sort` field.
This was a bug I had when I created a bunch of `Lists` and `Swimlanes` from the API: it was not possible to reorder them (`sort` being null).

~~We should probably do the same for the `Cards` inside a list.~~

This is on top of #2121 and should fix #1688 for the swimlanes part.

Note that I couldn't get the `Add Swimlane` as an inlined form, so I used a popup.

There are still 3 open questions IMO:
- I would think instead of having the `plus` sign to add a new swimlane, it would be better to have 2 entries in the hamburger menu: `Insert a Swimlane above` and `Insert a Swimlane below`
- ~~in the small display view (phone), maybe we should keep the swimlane vertical on the left~~
- ~~Still not sure about how the per-list color would render~~ (see this [comment](https://github.com/wekan/wekan/pull/2126#issuecomment-457533786))

Note: Apache I-CLA signed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2126)
<!-- Reviewable:end -->
