### PR TITLE
Horizontal fixes

### DIFF
--- a/client/components/swimlanes/swimlanes.jade
+++ b/client/components/swimlanes/swimlanes.jade
@@ -1,22 +1,22 @@
 template(name="swimlane")
-  .swimlane.js-lists.js-swimlane
+  .swimlane
     +swimlaneHeader
-    .swimlane.list-group.js-lists
-      if isMiniScreen
-        if currentList
-          +list(currentList)
-        else
-          each currentBoard.lists
-            +miniList(this)
-          if currentUser.isBoardMember
-            +addListForm
+  .swimlane.js-lists.js-swimlane
+    if isMiniScreen
+      if currentList
+        +list(currentList)
       else
         each currentBoard.lists
-          +list(this)
-          if currentCardIsInThisList _id ../_id
-            +cardDetails(currentCard)
+          +miniList(this)
         if currentUser.isBoardMember
           +addListForm
+    else
+      each currentBoard.lists
+        +list(this)
+        if currentCardIsInThisList _id ../_id
+          +cardDetails(currentCard)
+      if currentUser.isBoardMember
+        +addListForm
 
 template(name="listsGroup")
   .swimlane.list-group.js-lists

--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -5,7 +5,7 @@
   // transparent, because that won't work during a swimlane drag.
   background: darken(white, 13%)
   display: flex
-  flex-direction: column
+  flex-direction: row
   overflow: 0;
   max-height: 100%
 
@@ -27,7 +27,7 @@
   .swimlane-header-wrap
     display: flex;
     flex-direction: row;
-    flex: 0 0 24px;
+    flex: 1 0 100%;
     background-color: #ccc;
 
     .swimlane-header
@@ -51,18 +51,7 @@
       margin-right: 10px
 
 .list-group
-  flex-direction: row
   height: 100%
-
-// Firefox fix for cards behind swimlane to overflow-y
-// https://github.com/wekan/wekan/pull/2132/commits/f7c6b7fce237a6dbdbbd6d728cfb11ad3f4378eb
-// and enable Firefox left-right scroll https://github.com/wekan/wekan/issues/2137
-@-moz-document url-prefix() {
-  .list-group {
-    overflow-y: hidden;
-    overflow: -moz-scrollbars-vertical;
-  }
-}
 
 swimlane-color(background, color...)
   background: background !important

--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -7,7 +7,7 @@
   display: flex
   flex-direction: row
   overflow: 0;
-  max-height: 100%
+  max-height: calc(100% - 26px)
 
   &.placeholder
     background-color: rgba(0, 0, 0, .2)


### PR DESCRIPTION
@xet7 

So I think I got this right now. This reverts most of the UI code to v2.02, but keeps the horizontal header for the swimlanes.

I liked the fact that the swimlane header was not moving when scrolling horizontally, but I guess fixing bugs is more important :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2139)
<!-- Reviewable:end -->
