### PR TITLE
automatic scroll: fix vertical automatic scrolling when opening a card

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -78,14 +78,13 @@ BlazeComponent.extendComponent({
     //Scroll top
     const cardViewStartTop = $cardView.offset().top;
     const cardContainerScrollTop = $cardContainer.scrollTop();
+
     let topOffset = false;
-    if(cardViewStartTop < 0){
-      topOffset = 0;
-    } else if(cardViewStartTop - cardContainerScrollTop > 100) {
-      topOffset = cardViewStartTop - cardContainerScrollTop - 100;
+    if(cardViewStartTop !== 100){
+      topOffset = cardViewStartTop - 100;
     }
     if(topOffset !== false) {
-      bodyBoardComponent.scrollTop(topOffset);
+      bodyBoardComponent.scrollTop(cardContainerScrollTop + topOffset);
     }
 
   },


### PR DESCRIPTION
We actually want the vertical scrolling to be fixed at potion `100`  when opening the card details.
I am not sure where the `100` value comes from, but this makes the scrolling happy on the swimlane view and on the lists view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2140)
<!-- Reviewable:end -->
