### PR TITLE
Improve authentication

### DIFF
--- a/client/components/main/layouts.jade
+++ b/client/components/main/layouts.jade
@@ -23,10 +23,8 @@ template(name="userFormsLayout")
         br
     section.auth-dialog
       +Template.dynamic(template=content)
-      +connectionMethod
-      if isCas
-        .at-form
-          button#cas(class='at-btn submit' type='submit') {{casSignInLabel}}
+      if currentSetting.displayAuthenticationMethod
+        +connectionMethod
       div.at-form-lang
         select.select-lang.js-userform-set-language
           each languages

--- a/client/components/settings/settingBody.jade
+++ b/client/components/settings/settingBody.jade
@@ -142,6 +142,16 @@ template(name='layoutSettings')
         input.form-control#hide-logo(type="radio" name="hideLogo" value="false" checked="{{#unless currentSetting.hideLogo}}checked{{/unless}}")
         span {{_ 'no'}}
     li.layout-form
+      .title {{_ 'display-authentication-method'}}
+      .form-group.flex
+        input.form-control#display-authentication-method(type="radio" name="displayAuthenticationMethod" value="true" checked="{{#if currentSetting.displayAuthenticationMethod}}checked{{/if}}")
+        span {{_ 'yes'}}
+        input.form-control#display-authentication-method(type="radio" name="displayAuthenticationMethod" value="false" checked="{{#unless currentSetting.displayAuthenticationMethod}}checked{{/unless}}")
+        span {{_ 'no'}}
+    li.layout-form
+      .title {{_ 'default-authentication-method'}}
+      +selectAuthenticationMethod(authenticationMethod=currentSetting.defaultAuthenticationMethod)
+    li.layout-form
       .title {{_ 'custom-product-name'}}
       .form-group
         input.form-control#product-name(type="text", placeholder="Wekan" value="{{currentSetting.productName}}")
@@ -153,3 +163,12 @@ template(name='layoutSettings')
       textarea#customHTMLbeforeBodyEnd.form-control= currentSetting.customHTMLbeforeBodyEnd
     li
       button.js-save-layout.primary {{_ 'save'}}
+
+
+template(name='selectAuthenticationMethod')
+  select#defaultAuthenticationMethod
+    each authentications
+      if isSelected value
+        option(value="{{value}}" selected) {{_ value}}
+      else
+        option(value="{{value}}") {{_ value}}

--- a/client/components/settings/settingBody.js
+++ b/client/components/settings/settingBody.js
@@ -62,6 +62,9 @@ BlazeComponent.extendComponent({
   toggleHideLogo() {
     $('#hide-logo').toggleClass('is-checked');
   },
+  toggleDisplayAuthenticationMethod() {
+    $('#display-authentication-method').toggleClass('is-checked');
+  },
   switchMenu(event) {
     const target = $(event.target);
     if (!target.hasClass('active')) {
@@ -140,17 +143,20 @@ BlazeComponent.extendComponent({
 
     const productName = $('#product-name').val().trim();
     const hideLogoChange = ($('input[name=hideLogo]:checked').val() === 'true');
+    const displayAuthenticationMethod = ($('input[name=displayAuthenticationMethod]:checked').val() === 'true');
+    const defaultAuthenticationMethod = $('#defaultAuthenticationMethod').val();
     const customHTMLafterBodyStart = $('#customHTMLafterBodyStart').val().trim();
     const customHTMLbeforeBodyEnd = $('#customHTMLbeforeBodyEnd').val().trim();
 
     try {
-
       Settings.update(Settings.findOne()._id, {
         $set: {
           productName,
           hideLogo: hideLogoChange,
           customHTMLafterBodyStart,
           customHTMLbeforeBodyEnd,
+          displayAuthenticationMethod,
+          defaultAuthenticationMethod
         },
       });
     } catch (e) {
@@ -190,6 +196,7 @@ BlazeComponent.extendComponent({
       'click button.js-send-smtp-test-email': this.sendSMTPTestEmail,
       'click a.js-toggle-hide-logo': this.toggleHideLogo,
       'click button.js-save-layout': this.saveLayout,
+      'click a.js-toggle-display-authentication-method': this.toggleDisplayAuthenticationMethod
     }];
   },
 }).register('setting');
@@ -262,3 +269,31 @@ BlazeComponent.extendComponent({
     }];
   },
 }).register('announcementSettings');
+
+
+Template.selectAuthenticationMethod.onCreated(function() {
+  this.authenticationMethods = new ReactiveVar([]);
+
+  Meteor.call('getAuthenticationsEnabled', (_, result) => {
+    if (result) {
+      // TODO : add a management of different languages
+      // (ex {value: ldap, text: TAPi18n.__('ldap', {}, T9n.getLanguage() || 'en')})
+      this.authenticationMethods.set([
+        {value: 'password'},
+        // Gets only the authentication methods availables
+        ...Object.entries(result).filter((e) => e[1]).map((e) => ({value: e[0]})),
+      ]);
+    }
+  });
+});
+
+Template.selectAuthenticationMethod.helpers({
+  authentications() {
+    return Template.instance().authenticationMethods.get();
+  },
+  isSelected(match) {
+    console.log('this : ', this);
+    console.log('instance : ', Template.instance());
+    return Template.instance().data.authenticationMethod === match;
+  }
+});

--- a/models/settings.js
+++ b/models/settings.js
@@ -40,6 +40,14 @@ Settings.attachSchema(new SimpleSchema({
     type: String,
     optional: true,
   },
+  displayAuthenticationMethod: {
+    type: Boolean,
+    optional: true,
+  },
+  defaultAuthenticationMethod: {
+    type: String,
+    optional: false,
+  },
   hideLogo: {
     type: Boolean,
     optional: true,
@@ -85,7 +93,8 @@ if (Meteor.isServer) {
       const from = `Boards Support <support@${domain}>`;
       const defaultSetting = {disableRegistration: false, mailServer: {
         username: '', password: '', host: '', port: '', enableTLS: false, from,
-      }, createdAt: now, modifiedAt: now};
+      }, createdAt: now, modifiedAt: now, displayAuthenticationMethod: true, 
+      defaultAuthenticationMethod: 'password'};
       Settings.insert(defaultSetting);
     }
     const newSetting = Settings.findOne();

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -398,3 +398,27 @@ Migrations.add('add-custom-html-before-body-end', () => {
     },
   }, noValidateMulti);
 });
+
+Migrations.add('add-displayAuthenticationMethod', () => {
+  Settings.update({
+    displayAuthenticationMethod: {
+      $exists: false,
+    },
+  }, {
+    $set: {
+      displayAuthenticationMethod: true,
+    },
+  }, noValidateMulti)
+});
+
+Migrations.add('add-defaultAuthenticationMethod', () => {
+  Settings.update({
+    defaultAuthenticationMethod: {
+      $exists: false,
+    },
+  }, {
+    $set: {
+      defaultAuthenticationMethod: 'password',
+    },
+  }, noValidateMulti)
+});

--- a/server/publications/settings.js
+++ b/server/publications/settings.js
@@ -1,5 +1,15 @@
 Meteor.publish('setting', () => {
-  return Settings.find({}, {fields:{disableRegistration: 1, productName: 1, hideLogo: 1, customHTMLafterBodyStart: 1, customHTMLbeforeBodyEnd: 1}});
+  return Settings.find({}, {
+    fields:{
+      disableRegistration: 1,
+      productName: 1,
+      hideLogo: 1,
+      customHTMLafterBodyStart: 1,
+      customHTMLbeforeBodyEnd: 1,
+      displayAuthenticationMethod: 1,
+      defaultAuthenticationMethod: 1
+    }
+  });
 });
 
 Meteor.publish('mailServer', function () {


### PR DESCRIPTION
Adding 2 configuration options in the admin panel
One for enable/disable the dropdown in the sign-in page to chose the authentication method.
The other for selecting the default authentication method used to perform the registration and log in the user when his first time on the site.
![image](https://user-images.githubusercontent.com/32392661/52141171-2668f880-2655-11e9-8f52-4f99bccf8eef.png)
Need i18n for the titles.

The default page:
![image](https://user-images.githubusercontent.com/32392661/52141237-5adcb480-2655-11e9-94f2-7802df56a739.png)

And the page with the display authentication method set to no:
![image](https://user-images.githubusercontent.com/32392661/52141298-8b245300-2655-11e9-97f7-21c7a71bb4a1.png)

Following the various problems caused by the removal of this dropdown, I have chosen to make it optional and configurable in the admin panel. I also make some test with, but if you have a problem, don't hesitate to contact me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2153)
<!-- Reviewable:end -->
