### PR TITLE
Fix swimlanes sorting

### DIFF
--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -53,6 +53,9 @@
 .list-group
   height: 100%
 
+.moving-swimlane
+  display: none
+
 swimlane-color(background, color...)
   background: background !important
   if color


### PR DESCRIPTION
Since 7cc185ac "Properly fix horizontal rendering on Chrome and Firefox", the rendering of the new design of the swimlanes was correct, but this commit broke the reordering capability. Having the swimlane header at the same level than the lists of cards makes the whole sortable
pattern fail.

2 solutions:
- revert to only have 1 div per swimlane. But this introduces the firefox bug mentioned in 7cc185ac, so not ideal
- force the sortable pattern to do what we want.

To force the sortable pattern, we need:
- add in the helper a clone of the list of cards (to not just move the header)
- make sure the placeholder never get placed between the header and the list of cards in a swimlane
- fix the finding of the next and previous list of cards.

For all of this to be successful, we need to resize the swimlanes to a known value. This can lead to some visual jumps with scrolling when you drag or drop the swimlanea. I tried to remedy that by computing the new scroll value. Still not ideal however, as there are still some jumps when dropping.

There are still some stability issues, I guess because sortable tries to force the position of the placeholder, but I couldn't really find a way to remove them entirely. Still this is better than nothing.

Fixes #2159 

Note: Apache I-CLA signed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2174)
<!-- Reviewable:end -->
