### PR TITLE
set flexbox to "auto"

### DIFF
--- a/client/components/lists/list.styl
+++ b/client/components/lists/list.styl
@@ -4,7 +4,7 @@
   box-sizing: border-box
   display: flex
   flex-direction: column
-  flex: 0 0 270px
+  flex: auto
   position: relative
   // Even if this background color is the same as the body we can't leave it
   // transparent, because that won't work during a list drag.


### PR DESCRIPTION
I believe this addresses #1266 (feature request - adjustable width of lists).

The flexboxes in the "list" CSS class were set to a hard-coded width of 270px.  Setting this instead to "auto" appears to resolve the issue.

Please note that I'm not a web developer and I'm unable to test this locally.  However, this seems to be really straightforward.  See additional comments at linked issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2175)
<!-- Reviewable:end -->
