### PR TITLE
Activities: register customFields changes in the activities

### DIFF
--- a/client/components/activities/activities.jade
+++ b/client/components/activities/activities.jade
@@ -114,6 +114,12 @@ template(name="boardActivities")
         if($eq activityType 'removedLabel')
           | {{{_ 'activity-removed-label' lastLabel cardLink}}}.
 
+        if($eq activityType 'setCustomField')
+          | {{{_ 'activity-set-customfield' lastCustomField lastCustomFieldValue cardLink}}}.
+
+        if($eq activityType 'unsetCustomField')
+          | {{{_ 'activity-unset-customfield' lastCustomField cardLink}}}.
+
         if($eq activityType 'unjoinMember')
           if($eq user._id member._id)
             | {{{_ 'activity-unjoined' cardLink}}}.

--- a/client/components/activities/activities.js
+++ b/client/components/activities/activities.js
@@ -82,6 +82,24 @@ BlazeComponent.extendComponent({
     }
   },
 
+  lastCustomField(){
+    const lastCustomField = CustomFields.findOne(this.currentData().customFieldId);
+    return lastCustomField.name;
+  },
+
+  lastCustomFieldValue(){
+    const lastCustomField = CustomFields.findOne(this.currentData().customFieldId);
+    const value = this.currentData().value;
+    if (lastCustomField.settings.dropdownItems && lastCustomField.settings.dropdownItems.length > 0) {
+      const dropDownValue = _.find(lastCustomField.settings.dropdownItems, (item) => {
+        return item._id === value;
+      });
+      if (dropDownValue)
+        return dropDownValue.name;
+    }
+    return value;
+  },
+
   listLabel() {
     return this.currentData().list().title;
   },

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -567,6 +567,8 @@
     "activity-added-label-card": "added label '%s'",
     "activity-removed-label-card": "removed label '%s'",
     "activity-delete-attach-card": "deleted an attachment",
+    "activity-set-customfield": "set custom field '%s' to '%s' in %s",
+    "activity-unset-customfield": "unset custom field '%s' in %s",
     "r-rule": "Rule",
     "r-add-trigger": "Add trigger",
     "r-add-action": "Add action",


### PR DESCRIPTION
Foreword: I am not entirely sure this is the *correct* thing to do.

My use case is: We have a bunch of cards to track our progress in various projects. On these cards, we do have some custom fields to track the amount of work. We do not want to track the actual time in hours, but we use an abstract relative number.

Among the numbers is the total estimated size of the project. This estimate is subject to being re-evaluated during the project and I want to get the variations of this number. This is useful for projects that gets re-evaluated during a long period of time. We also register how much work has been done during a period of time, and we want to track the efforts towards each project during the period.

So 2 options:
- we dump the db at each milestone, and then compare with the previous versions
- we store in the activities the incremental changes of the custom fields to be able to recreate the history of the cards.

This PR implements the second option.

I would think custom fields are special enough that we can store their history in the activities without exploding the size of the DB.

Only manual updates to the custom fields are currently registered.

Note: Apache I-CLA signed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2239)
<!-- Reviewable:end -->
