### PR TITLE
customFields: fix leftover from lint

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -1412,7 +1412,7 @@ function cardCustomFields(userId, doc, fieldNames, modifier) {
 
         // only individual changes are registered
         if (dotNotation.length > 1) {
-          const customFieldId = doc.customFields[dot_notation[1]]._id;
+          const customFieldId = doc.customFields[dotNotation[1]]._id;
           const act = {
             userId,
             customFieldId,


### PR DESCRIPTION
Looks like I forgot to use the camelCase notation here, and this leads to an exception while updating a custom field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2244)
<!-- Reviewable:end -->
