### PR TITLE
Rename migration to re run

### DIFF
--- a/server/migrations.js
+++ b/server/migrations.js
@@ -518,7 +518,7 @@ Migrations.add('add-templates', () => {
   });
 });
 
-Migrations.add('fix-circular-reference', () => {
+Migrations.add('fix-circular-reference_', () => {
   Cards.find().forEach((card) => {
     if (card.parentId === card._id) {
       Cards.update(card._id, {$set: {parentId: ''}}, noValidateMulti);


### PR DESCRIPTION
@xet7 Please tell me if this is sufficient to run the migration once more in newest wekan release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2248)
<!-- Reviewable:end -->
