### PR TITLE
make emails for invitations lowercase, compatible with AccountsTemplates

### DIFF
--- a/client/components/settings/settingBody.js
+++ b/client/components/settings/settingBody.js
@@ -90,7 +90,7 @@ BlazeComponent.extendComponent({
   },
 
   inviteThroughEmail() {
-    const emails = $('#email-to-invite').val().trim().split('\n').join(',').split(',');
+    const emails = $('#email-to-invite').val().toLowerCase().trim().split('\n').join(',').split(',');
     const boardsToInvite = [];
     $('.js-toggle-board-choose .materialCheckBox.is-checked').each(function () {
       boardsToInvite.push($(this).data('id'));


### PR DESCRIPTION
Email addresses for invitations are stored case sensitive in mongo,
together with the invitation codes. When someone tries to sign up due to
an invitation, in the sign up form, due to AccountsTemplates defaults,
the email address is lowercased on blur of the textbox. When they then
try to sign in, they get an error about the invitation code not existing.
This makes it impossible to successfully invite people using
non-lowercased email addresses.

This patch lowercases the emails on the client side when inviting them.

Other possibilities would be to lowercase them on the server side before
storing them to mongodb, making a case insensitive search on mongodb, or
making the email input field in the sign up form not lowercase the email
string.

This patch was chosen in favor of the other possibilities because of its
simplicity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2263)
<!-- Reviewable:end -->
