### PR TITLE
Fix infinite scroll

### DIFF
--- a/client/components/lists/listBody.jade
+++ b/client/components/lists/listBody.jade
@@ -13,14 +13,7 @@ template(name="listBody")
               class="{{#if MultiSelection.isSelected _id}}is-checked{{/if}}")
           +minicard(this)
       if (showSpinner (idOrNull ../../_id))
-        .sk-spinner.sk-spinner-wave.sk-spinner-list(
-          class=currentBoard.colorClass
-          id="showMoreResults")
-          .sk-rect1
-          .sk-rect2
-          .sk-rect3
-          .sk-rect4
-          .sk-rect5
+        +spinnerList
 
       if canSeeAddCard
         +inlinedForm(autoclose=false position="bottom")
@@ -29,6 +22,16 @@ template(name="listBody")
           a.open-minicard-composer.js-card-composer.js-open-inlined-form
             i.fa.fa-plus
             | {{_ 'add-card'}}
+
+template(name="spinnerList")
+  .sk-spinner.sk-spinner-wave.sk-spinner-list(
+    class=currentBoard.colorClass
+    id="showMoreResults")
+    .sk-rect1
+    .sk-rect2
+    .sk-rect3
+    .sk-rect4
+    .sk-rect5
 
 template(name="addCardForm")
   .minicard.minicard-composer.js-composer

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -5,35 +5,6 @@ BlazeComponent.extendComponent({
   onCreated() {
     // for infinite scrolling
     this.cardlimit = new ReactiveVar(InfiniteScrollIter);
-    this.spinnerShown = false;
-  },
-
-  onRendered() {
-    const spinner = this.find('.sk-spinner-list');
-
-    if (spinner) {
-      const options = {
-        root: null, // we check if the spinner is on the current viewport
-        rootMargin: '0px',
-        threshold: 0.25,
-      };
-
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach((entry) => {
-          this.spinnerShown = entry.isIntersecting;
-          this.updateList();
-        });
-      }, options);
-
-      observer.observe(spinner);
-    }
-  },
-
-  updateList() {
-    if (this.spinnerShown) {
-      this.cardlimit.set(this.cardlimit.get() + InfiniteScrollIter);
-      window.requestIdleCallback(() => this.updateList());
-    }
   },
 
   mixins() {
@@ -641,3 +612,39 @@ BlazeComponent.extendComponent({
     }];
   },
 }).register('searchElementPopup');
+
+BlazeComponent.extendComponent({
+  onCreated() {
+    this.spinnerShown = false;
+    this.cardlimit = this.parentComponent().cardlimit;
+  },
+
+  onRendered() {
+    const spinner = this.find('.sk-spinner-list');
+
+    if (spinner) {
+      const options = {
+        root: null, // we check if the spinner is on the current viewport
+        rootMargin: '0px',
+        threshold: 0.25,
+      };
+
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          this.spinnerShown = entry.isIntersecting;
+          this.updateList();
+        });
+      }, options);
+
+      observer.observe(spinner);
+    }
+  },
+
+  updateList() {
+    if (this.spinnerShown) {
+      this.cardlimit.set(this.cardlimit.get() + InfiniteScrollIter);
+      window.requestIdleCallback(() => this.updateList());
+    }
+  },
+
+}).register('spinnerList');

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -629,15 +629,19 @@ BlazeComponent.extendComponent({
         threshold: 0.25,
       };
 
-      const observer = new IntersectionObserver((entries) => {
+      this.observer = new IntersectionObserver((entries) => {
         entries.forEach((entry) => {
           this.spinnerShown = entry.isIntersecting;
           this.updateList();
         });
       }, options);
 
-      observer.observe(spinner);
+      this.observer.observe(spinner);
     }
+  },
+
+  onDestroyed() {
+    this.observer.disconnect();
   },
 
   updateList() {

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -5,6 +5,7 @@ BlazeComponent.extendComponent({
   onCreated() {
     // for infinite scrolling
     this.cardlimit = new ReactiveVar(InfiniteScrollIter);
+    this.spinnerShown = false;
   },
 
   onRendered() {
@@ -19,13 +20,19 @@ BlazeComponent.extendComponent({
 
       const observer = new IntersectionObserver((entries) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            this.cardlimit.set(this.cardlimit.get() + InfiniteScrollIter);
-          }
+          this.spinnerShown = entry.isIntersecting;
+          this.updateList();
         });
       }, options);
 
       observer.observe(spinner);
+    }
+  },
+
+  updateList() {
+    if (this.spinnerShown) {
+      this.cardlimit.set(this.cardlimit.get() + InfiniteScrollIter);
+      window.requestIdleCallback(() => this.updateList());
     }
   },
 


### PR DESCRIPTION
Few bugs/features fixed by this PR:
- #2250 -> the spinner could be shown on startup and never goes away
- the code will now only load extra cards that will be in the current viewport
- when 2 users were interacting on the same board, there was a situation where the spinner could show up on the other user, without being able to load the extra cards

The code is now much simpler, thanks to the `IntersectionObserver`, and all of this for fewer lines of code :)

Note: Apache I-CLA signed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2287)
<!-- Reviewable:end -->
