### PR TITLE
fix(oidc): can not log in

### DIFF
--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -13,12 +13,12 @@ OAuth.registerService('oidc', 2, null, function (query) {
   if (debug) console.log('XXX: userinfo:', userinfo);
 
   var serviceData = {};
-  serviceData.id = userinfo[process.env.OAUTH2_ID_MAP] || userinfo[id];
-  serviceData.username = userinfo[process.env.OAUTH2_USERNAME_MAP] || userinfo[uid];
-  serviceData.fullname = userinfo[process.env.OAUTH2_FULLNAME_MAP] || userinfo[displayName];
+  serviceData.id = userinfo[process.env.OAUTH2_ID_MAP] || userinfo["id"];
+  serviceData.username = userinfo[process.env.OAUTH2_USERNAME_MAP] || userinfo["uid"];
+  serviceData.fullname = userinfo[process.env.OAUTH2_FULLNAME_MAP] || userinfo["displayName"];
   serviceData.accessToken = accessToken;
   serviceData.expiresAt = expiresAt;
-  serviceData.email = userinfo[process.env.OAUTH2_EMAIL_MAP] || userinfo[email];
+  serviceData.email = userinfo[process.env.OAUTH2_EMAIL_MAP] || userinfo["email"];
 
   if (accessToken) {
     var tokenContent = getTokenContent(accessToken);
@@ -31,8 +31,8 @@ OAuth.registerService('oidc', 2, null, function (query) {
   if (debug) console.log('XXX: serviceData:', serviceData);
 
   var profile = {};
-  profile.name = userinfo[process.env.OAUTH2_FULLNAME_MAP] || userinfo[displayName];
-  profile.email = userinfo[process.env.OAUTH2_EMAIL_MAP] || userinfo[email];
+  profile.name = userinfo[process.env.OAUTH2_FULLNAME_MAP] || userinfo["displayName"];
+  profile.email = userinfo[process.env.OAUTH2_EMAIL_MAP] || userinfo["email"];
   if (debug) console.log('XXX: profile:', profile);
 
   return {


### PR DESCRIPTION
Trying to configure wekan authenticating against LemonLDAP-NG, I used to read about errors like the following:

```
XXX: getUserInfo response:  { sub: 'demoone' }
XXX: userinfo: { sub: 'demoone' }
{"line":"431","file":"oauth.js","message":"Error in OAuth Server: id is not defined","time":{"$date":1556286530412},"level":"warn"}
Exception while invoking method 'login' { stack: 'ReferenceError: id is not defined\n    at Object.handleOauthRequest (packages/wekan-oidc.js:39:68)\n    at OAuth._requestHandlers.(anonymous function) (packages/oauth2.js:27:31)\n    at middleware (packages/oauth.js:203:5)\n    at packages/oauth.js:176:5',
source: 'method' }
```

Looking at the sources, that error message seems to be right: we have several references to `id`, `uid`, `displayName` or `email`, which are not defined. Probably a typo, assuming we meant these to be strings.

Applying that patch, I confirm I can finally log in:

```
XXX: getUserInfo response:  { sub: 'demoone' }
XXX: userinfo: { sub: 'demoone' }
XXX: serviceData: { id: undefined,
  username: undefined,
  fullname: undefined,
  accessToken: 'e57dc4e9e81cc98c279db3ed08b1c72f',
  expiresAt: 1556298699213,
  email: undefined }
XXX: profile: { name: undefined, email: undefined }
```

All the credit goes to @pcurie .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2385)
<!-- Reviewable:end -->
