### PR TITLE
Fixed #2338 -> Slow opening of big boards with too many archived items

### DIFF
--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -14,7 +14,7 @@ BlazeComponent.extendComponent({
       const currentBoardId = Session.get('currentBoard');
       if (!currentBoardId)
         return;
-      const handle = subManager.subscribe('board', currentBoardId);
+      const handle = subManager.subscribe('board', currentBoardId, false);
       Tracker.nonreactive(() => {
         Tracker.autorun(() => {
           this.isBoardReady.set(handle.ready());

--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -33,12 +33,12 @@ BlazeComponent.extendComponent({
   },
 
   hasOvertimeCards() {
-    subManager.subscribe('board', this.currentData()._id);
+    subManager.subscribe('board', this.currentData()._id, false);
     return this.currentData().hasOvertimeCards();
   },
 
   hasSpentTimeCards() {
-    subManager.subscribe('board', this.currentData()._id);
+    subManager.subscribe('board', this.currentData()._id, false);
     return this.currentData().hasSpentTimeCards();
   },
 

--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -424,7 +424,7 @@ Template.moveCardPopup.events({
 });
 BlazeComponent.extendComponent({
   onCreated() {
-    subManager.subscribe('board', Session.get('currentBoard'));
+    subManager.subscribe('board', Session.get('currentBoard'), false);
     this.selectedBoardId = new ReactiveVar(Session.get('currentBoard'));
   },
 
@@ -453,7 +453,7 @@ BlazeComponent.extendComponent({
     return [{
       'change .js-select-boards'(evt) {
         this.selectedBoardId.set($(evt.currentTarget).val());
-        subManager.subscribe('board', this.selectedBoardId.get());
+        subManager.subscribe('board', this.selectedBoardId.get(), false);
       },
     }];
   },
@@ -676,7 +676,7 @@ BlazeComponent.extendComponent({
         if (selection === 'none') {
           this.parentBoard.set(null);
         } else {
-          subManager.subscribe('board', $(evt.currentTarget).val());
+          subManager.subscribe('board', $(evt.currentTarget).val(), false);
           this.parentBoard.set(selection);
           list.prop('disabled', false);
         }

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -348,7 +348,7 @@ BlazeComponent.extendComponent({
 
     this.boardId = Session.get('currentBoard');
     // In order to get current board info
-    subManager.subscribe('board', this.boardId);
+    subManager.subscribe('board', this.boardId, false);
     this.board = Boards.findOne(this.boardId);
     // List where to insert card
     const list = $(Popup._getTopStack().openerElement).closest('.js-list');
@@ -414,7 +414,7 @@ BlazeComponent.extendComponent({
   events() {
     return [{
       'change .js-select-boards'(evt) {
-        subManager.subscribe('board', $(evt.currentTarget).val());
+        subManager.subscribe('board', $(evt.currentTarget).val(), false);
         this.selectedBoardId.set($(evt.currentTarget).val());
       },
       'change .js-select-swimlanes'(evt) {
@@ -500,13 +500,13 @@ BlazeComponent.extendComponent({
     }
     const boardId = board._id;
     // Subscribe to this board
-    subManager.subscribe('board', boardId);
+    subManager.subscribe('board', boardId, false);
     this.selectedBoardId = new ReactiveVar(boardId);
 
     if (!this.isBoardTemplateSearch) {
       this.boardId = Session.get('currentBoard');
       // In order to get current board info
-      subManager.subscribe('board', this.boardId);
+      subManager.subscribe('board', this.boardId, false);
       this.swimlaneId = '';
       // Swimlane where to insert card
       const swimlane = $(Popup._getTopStack().openerElement).parents('.js-swimlane');
@@ -547,7 +547,7 @@ BlazeComponent.extendComponent({
     } else if (this.isBoardTemplateSearch) {
       const boards = board.searchBoards(this.term.get());
       boards.forEach((board) => {
-        subManager.subscribe('board', board.linkedId);
+        subManager.subscribe('board', board.linkedId, false);
       });
       return boards;
     } else {
@@ -558,7 +558,7 @@ BlazeComponent.extendComponent({
   events() {
     return [{
       'change .js-select-boards'(evt) {
-        subManager.subscribe('board', $(evt.currentTarget).val());
+        subManager.subscribe('board', $(evt.currentTarget).val(), false);
         this.selectedBoardId.set($(evt.currentTarget).val());
       },
       'submit .js-search-term-form'(evt) {

--- a/client/components/sidebar/sidebarArchives.jade
+++ b/client/components/sidebar/sidebarArchives.jade
@@ -1,54 +1,56 @@
 template(name="archivesSidebar")
-  +basicTabs(tabs=tabs)
-
-   +tabContent(slug="cards")
-    p.quiet
-      a.js-restore-all-cards {{_ 'restore-all'}}
-      | -
-      a.js-delete-all-cards {{_ 'delete-all'}}
-    each archivedCards
-      .minicard-wrapper.js-minicard
-        +minicard(this)
-      if currentUser.isBoardMember
+  if isArchiveReady.get
+    +basicTabs(tabs=tabs)
+      +tabContent(slug="cards")
         p.quiet
-          a.js-restore-card {{_ 'restore'}}
+          a.js-restore-all-cards {{_ 'restore-all'}}
           | -
-          a.js-delete-card {{_ 'delete'}}
-        if cardIsInArchivedList
-          p.quiet.small ({{_ 'warn-list-archived'}})
-    else
-      p.no-items-message {{_ 'no-archived-cards'}}
-
-   +tabContent(slug="lists")
-    p.quiet
-      a.js-restore-all-lists {{_ 'restore-all'}}
-      | -
-      a.js-delete-all-lists {{_ 'delete-all'}}
-    ul.archived-lists
-      each archivedLists
-        li.archived-lists-item
-          = title
+          a.js-delete-all-cards {{_ 'delete-all'}}
+        each archivedCards
+          .minicard-wrapper.js-minicard
+            +minicard(this)
           if currentUser.isBoardMember
             p.quiet
-              a.js-restore-list {{_ 'restore'}}
+              a.js-restore-card {{_ 'restore'}}
               | -
-              a.js-delete-list {{_ 'delete'}}
-      else
-        li.no-items-message {{_ 'no-archived-lists'}}
+              a.js-delete-card {{_ 'delete'}}
+            if cardIsInArchivedList
+              p.quiet.small ({{_ 'warn-list-archived'}})
+        else
+          p.no-items-message {{_ 'no-archived-cards'}}
 
-   +tabContent(slug="swimlanes")
-    p.quiet
-      a.js-restore-all-swimlanes {{_ 'restore-all'}}
-      | -
-      a.js-delete-all-swimlanes {{_ 'delete-all'}}
-    ul.archived-lists
-      each archivedSwimlanes
-        li.archived-lists-item
-          = title
-          if currentUser.isBoardMember
-            p.quiet
-              a.js-restore-swimlane {{_ 'restore'}}
-              | -
-              a.js-delete-swimlane {{_ 'delete'}}
-      else
-        li.no-items-message {{_ 'no-archived-swimlanes'}}
+      +tabContent(slug="lists")
+        p.quiet
+          a.js-restore-all-lists {{_ 'restore-all'}}
+          | -
+          a.js-delete-all-lists {{_ 'delete-all'}}
+        ul.archived-lists
+          each archivedLists
+            li.archived-lists-item
+              = title
+              if currentUser.isBoardMember
+                p.quiet
+                  a.js-restore-list {{_ 'restore'}}
+                  | -
+                  a.js-delete-list {{_ 'delete'}}
+          else
+            li.no-items-message {{_ 'no-archived-lists'}}
+
+      +tabContent(slug="swimlanes")
+        p.quiet
+          a.js-restore-all-swimlanes {{_ 'restore-all'}}
+          | -
+          a.js-delete-all-swimlanes {{_ 'delete-all'}}
+        ul.archived-lists
+          each archivedSwimlanes
+            li.archived-lists-item
+              = title
+              if currentUser.isBoardMember
+                p.quiet
+                  a.js-restore-swimlane {{_ 'restore'}}
+                  | -
+                  a.js-delete-swimlane {{_ 'delete'}}
+          else
+            li.no-items-message {{_ 'no-archived-swimlanes'}}
+  else
+    +spinner

--- a/client/components/sidebar/sidebarArchives.js
+++ b/client/components/sidebar/sidebarArchives.js
@@ -1,4 +1,26 @@
+const subManager = new SubsManager();
+
 BlazeComponent.extendComponent({
+  onCreated() {
+    this.isArchiveReady = new ReactiveVar(false);
+
+    // The pattern we use to manually handle data loading is described here:
+    // https://kadira.io/academy/meteor-routing-guide/content/subscriptions-and-data-management/using-subs-manager
+    // XXX The boardId should be readed from some sort the component "props",
+    // unfortunatly, Blaze doesn't have this notion.
+    this.autorun(() => {
+      const currentBoardId = Session.get('currentBoard');
+      if (!currentBoardId)
+        return;
+      const handle = subManager.subscribe('board', currentBoardId, true);
+      Tracker.nonreactive(() => {
+        Tracker.autorun(() => {
+          this.isArchiveReady.set( handle.ready() );
+        });
+      });
+    });
+  },
+
   tabs() {
     return [
       { name: TAPi18n.__('cards'), slug: 'cards' },

--- a/server/publications/fast-render.js
+++ b/server/publications/fast-render.js
@@ -5,5 +5,5 @@ FastRender.onAllRoutes(function() {
 });
 
 FastRender.route('/b/:id/:slug', function({ id }) {
-  this.subscribe('board', id);
+  this.subscribe('board', id, false);
 });


### PR DESCRIPTION
**Some notes:**
1.  By this change, loading of archived items to client is deferred until the user clicks on Archive. 
2.  An infinite scrolling to Archive may also be added later to make it perfect.
3.  Search will only work for non-archived board elements at first. If the user clicks on Archive, the loading of archived elements will also be triggered. That means search will also work for archived items if the user searches after clicking on archive.

**Test steps:**
1. This step is needed to see the effect of this change. Insert bulk test data to your mongodb with a script like the following. Replace listId, boardId, swimlaneId, userId with the valid values in your mongodb database:
```
   for (var i = 1; i <= 1000; i++) {
   db.cards.insert( 
   {
    "title" : "archived card" + "-" +  i,
    "members" : [],
    "labelIds" : [],
    "customFields" : [],
    "listId" : "zx4dKAob9ubzBmZGc",
    "boardId" : "AEBwdcAC4r4yX3m2m",
    "sort" : 0,
    "swimlaneId" : "qrbcnBg3EfhQC9wsG",
    "type" : "cardType-card",
    "archived" : true,
    "parentId" : "",
    "coverId" : "",
    "createdAt" : Date(),
    "dateLastActivity" : Date(),
    "description" : "",
    "requestedBy" : "",
    "assignedBy" : "",
    "spentTime" : 0,
    "isOvertime" : false,
    "userId" : "2f2ErQrH7fY9C8Rdc",
    "subtaskSort" : -1,
    "linkedId" : ""
   })
}

2. Load the board with the current version of Meteor and note the time needed to load the board.
3. Apply this PR. 
4. Load the board again and see how long it takes to load the board.  (It takes 6-8 seconds less after this code change in my configuration. ) 
5. If the performance is better and there is no functionality loss then the test is a PASS.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2402)
<!-- Reviewable:end -->
