### PR TITLE
support scopes in oauth

### DIFF
--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -49,7 +49,12 @@ if (Meteor.release) {
 var getToken = function (query) {
   var debug = process.env.DEBUG || false;
   var config = getConfiguration();
-  var serverTokenEndpoint = config.serverUrl + config.tokenEndpoint;
+  if(config.tokenEndpoint.includes('https://')){
+    var serverTokenEndpoint = config.tokenEndpoint;
+  }else{
+    var serverTokenEndpoint = config.serverUrl + config.tokenEndpoint;
+  }
+  var requestPermissions = config.requestPermissions;
   var response;
 
   try {
@@ -66,6 +71,7 @@ var getToken = function (query) {
           client_secret: OAuth.openSecret(config.secret),
           redirect_uri: OAuth._redirectUri('oidc', config),
           grant_type: 'authorization_code',
+          scope: requestPermissions,
           state: query.state
         }
       }


### PR DESCRIPTION
with this fix, Authentication via OAuth2 with Google is possible.
1.) token endpoint and userinfo-endpoint in Google are different, so you have to check that,
2.) request the scopes of the environment variable "process.env.OAUTH2_REQUEST_PERMISSIONS"
with this small little fix the login with google in oauth2-protocol gets possible :-)
I would be very happy about a master-merge

thank you in advance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2483)
<!-- Reviewable:end -->
