### PR TITLE
dont remove boardoverlay when mouse leaves carddetails

### DIFF
--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -243,11 +243,6 @@ BlazeComponent.extendComponent({
       {
         // XXX The board-overlay div should probably be moved to the parent
         // component.
-        'mouseenter .board-overlay'() {
-          if (this.mouseHasEnterCardDetails) {
-            this.showOverlay.set(false);
-          }
-        },
         mouseup() {
           if (this._isDragging) {
             this._isDragging = false;


### PR DESCRIPTION
closes #2529

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2540)
<!-- Reviewable:end -->
