### PR TITLE
Add Features: limit the board list to 2 or 1 for mobile clients

### DIFF
--- a/client/components/boards/boardsList.styl
+++ b/client/components/boards/boardsList.styl
@@ -183,10 +183,11 @@ $spaceBetweenTiles = 16px
     overflow: scroll
 
     li
-      width: 33.3%
+      width: 50% 
 
     .board-list-item
       overflow: hidden
+      height: 8rem
 
     .board-list-item-sub-name
       position: relative
@@ -195,4 +196,4 @@ $spaceBetweenTiles = 16px
 
 @media screen and (max-width: 360px)
     li
-      width: 50%
+      width: 100%


### PR DESCRIPTION
As a mobile user, the board size of in the home page too small, so the user is easily to click on archive or copy button by accident. 

Increase the board size to 50% for pixel greater than 360 and lesser than 800 and height to 8rem,
100% for any screen is even smaller. 

which will reduce the accident much more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2542)
<!-- Reviewable:end -->
