### PR TITLE
Fix invites

### DIFF
--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -82,13 +82,13 @@ BlazeComponent.extendComponent({
         },
         'click .js-accept-invite'() {
           const boardId = this.currentData()._id;
-          Meteor.user().removeInvite(boardId);
+          Meteor.call('acceptInvite', boardId);
         },
         'click .js-decline-invite'() {
           const boardId = this.currentData()._id;
           Meteor.call('quitBoard', boardId, (err, ret) => {
             if (!err && ret) {
-              Meteor.user().removeInvite(boardId);
+              Meteor.call('acceptInvite', boardId);
               FlowRouter.go('home');
             }
           });

--- a/models/boards.js
+++ b/models/boards.js
@@ -952,6 +952,19 @@ if (Meteor.isServer) {
         } else throw new Meteor.Error('error-board-notAMember');
       } else throw new Meteor.Error('error-board-doesNotExist');
     },
+    acceptInvite(boardId) {
+      check(boardId, String);
+      const board = Boards.findOne(boardId);
+      if (!board) {
+        throw new Meteor.Error('error-board-doesNotExist');
+      }
+
+      Meteor.users.update(Meteor.userId(), {
+        $pull: {
+          'profile.invitedBoards': boardId,
+        },
+      });
+    },
   });
 
   Meteor.methods({


### PR DESCRIPTION
Some users don't have permissions to accept their own invites due to the `allow` code for Meteor.users only allowing admins to modify the user record: https://github.com/wekan/wekan/blob/master/models/users.js#L256

This means the user cannot modify their own record from the client-side and will get access denied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2549)
<!-- Reviewable:end -->
