### PR TITLE
Fixed group filtering bug

### DIFF
--- a/snap-src/bin/config
+++ b/snap-src/bin/config
@@ -340,7 +340,7 @@ KEY_LDAP_GROUP_FILTER_GROUP_MEMBER_FORMAT="ldap-group-filter-member-format"
 
 DESCRIPTION_LDAP_GROUP_FILTER_GROUP_NAME="ldap-group-filter-group-name. Default: ''"
 DEFAULT_LDAP_GROUP_FILTER_GROUP_NAME=""
-KEY_LDAP_GROUP_FILTER_GROUP_NAME="ldap-group-filter-member-name"
+KEY_LDAP_GROUP_FILTER_GROUP_NAME="ldap-group-filter-group-name"
 
 DESCRIPTION_LDAP_UNIQUE_IDENTIFIER_FIELD="This field is sometimes class GUID (Globally Unique Identifier)"
 DEFAULT_LDAP_UNIQUE_IDENTIFIER_FIELD=""


### PR DESCRIPTION
To make the LDAP authentication work in our installation with group filtering, we had to set `KEY_LDAP_GROUP_FILTER_GROUP_NAME` to `ldap-group-filter-group-name`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2584)
<!-- Reviewable:end -->
