### PR TITLE
Bugfix: style kbd font color became white after introduced summernote

### DIFF
--- a/client/components/main/layouts.styl
+++ b/client/components/main/layouts.styl
@@ -232,6 +232,7 @@ kbd
   background: darken(white, 2%)
   border-radius: 3px
   border: 1px solid darken(white, 10%)
+  color: unset
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.15)
 
 .clear


### PR DESCRIPTION
attachment ctrl-v window font color became white, so became invisible.

style kbd font color became white after introduced summernote

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2600)
<!-- Reviewable:end -->
