### PR TITLE
Add Features: allowing wekan master to set where the attachments stor…

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -95,3 +95,4 @@ wekan-markdown
 konecty:mongo-counter
 percolate:synced-cron
 easylogic:summernote
+cfs:filesystem

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -30,6 +30,7 @@ cfs:collection@0.5.5
 cfs:collection-filters@0.2.4
 cfs:data-man@0.0.6
 cfs:file@0.1.17
+cfs:filesystem@0.1.2
 cfs:gridfs@0.0.34
 cfs:http-methods@0.0.32
 cfs:http-publish@0.0.13

--- a/client/components/cards/attachments.js
+++ b/client/components/cards/attachments.js
@@ -66,6 +66,9 @@ Template.cardAttachmentsPopup.events({
         file.cardId = card._id;
       }
       file.userId = Meteor.userId();
+      if (file.original) {
+        file.original.name = f.name;
+      }
       const attachment = Attachments.insert(file);
 
       if (attachment && attachment._id && attachment.isImage()) {

--- a/snap-src/bin/config
+++ b/snap-src/bin/config
@@ -88,6 +88,10 @@ DESCRIPTION_ACCOUNTS_LOCKOUT_UNKNOWN_USERS_FAILURE_WINDOW="Accounts lockout unkn
 DEFAULT_ACCOUNTS_LOCKOUT_UNKNOWN_USERS_FAILURE_WINDOW="15"
 KEY_ACCOUNTS_LOCKOUT_UNKNOWN_USERS_FAILURE_WINDOW="accounts-lockout-unknown-users-failure-window"
 
+DESCRIPTION_ATTACHMENTS_STORE_PATH="Allow wekan ower to specify where uploaded files to store on the server instead of the mongodb"
+DEFAULT_ATTACHMENTS_STORE_PATH=""
+KEY_ATTACHMENTS_STORE_PATH="attachments-store-path"
+
 DESCRIPTION_MAX_IMAGE_PIXEL="Max image pixel: Allow to shrink attached/pasted image https://github.com/wekan/wekan/pull/2544"
 DEFAULT_MAX_IMAGE_PIXEL=""
 KEY_MAX_IMAGE_PIXEL="max-image-pixel"


### PR DESCRIPTION
allowing wekan master to specify the attachments to be uploaded to server file system instead of mongodb by specifying a system env var: ATTACHMENTS_STORE_PATH

The only caveat for this is if it's not a brand new wekan, if the wekan master switch to this setting, their old attachments won't be available anymore, unless someone make a script to export them out to the filesystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2603)
<!-- Reviewable:end -->
