### PR TITLE
fix error when the sidebar is not visible

### DIFF
--- a/client/components/sidebar/sidebar.js
+++ b/client/components/sidebar/sidebar.js
@@ -47,8 +47,11 @@ BlazeComponent.extendComponent({
   },
 
   calculateNextPeak() {
-    const altitude = this.find('.js-board-sidebar-content').scrollHeight;
-    this.callFirstWith(this, 'setNextPeak', altitude);
+    const sidebarElement = this.find('.js-board-sidebar-content');
+    if (sidebarElement) {
+      const altitude = sidebarElement.scrollHeight;
+      this.callFirstWith(this, 'setNextPeak', altitude);
+    }
   },
 
   reachNextPeak() {


### PR DESCRIPTION
When the sidebar is not visible there is an error thrown when accessing the scrollHeight, this PR fixes this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2609)
<!-- Reviewable:end -->
