### PR TITLE
Add missing modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prettier-eslint": "^8.8.2"
   },
   "dependencies": {
-    "@babel/runtime": "^7.5.4",
+    "@babel/runtime": "^7.5.5",
     "ajv": "^5.0.0",
     "babel-runtime": "^6.26.0",
     "bcrypt": "^3.0.2",


### PR DESCRIPTION
I encountered the issue #2652.

I fixed it by running `meteor npm install --save @babel/runtime xss meteor-node-stubs`. This command was shown in the output of meteor command when I wanted to run Wekan on development mode.

I notice that package-lock.json file is ignored by Git. I encourage adding this file to source control in order to be able to install the exact versions of the project's dependencies

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2653)
<!-- Reviewable:end -->
