### PR TITLE
Fix app hang when Meteor.user() is null and list spinner is loaded bug

### DIFF
--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -701,12 +701,16 @@ BlazeComponent.extendComponent({
     this.listId = this.parentComponent().data()._id;
     this.swimlaneId = '';
 
-    const boardView = (Meteor.user().profile || {}).boardView;
-    if (boardView === 'board-view-swimlanes')
-      this.swimlaneId = this.parentComponent()
-        .parentComponent()
-        .parentComponent()
-        .data()._id;
+    let user = Meteor.user();
+    if (user) {
+      const boardView = (Meteor.user().profile || {}).boardView;
+      if (boardView === 'board-view-swimlanes') {
+        this.swimlaneId = this.parentComponent()
+          .parentComponent()
+          .parentComponent()
+          .data()._id;
+      }
+    }
   },
 
   onRendered() {


### PR DESCRIPTION
On the Sandstorm platform sometimes `Meteor.user()` will not login in time, and ignoring checking nullity will make the app stop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2654)
<!-- Reviewable:end -->
