### PR TITLE
add card color to calendar event (#2651)

### DIFF
--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -326,6 +326,7 @@ BlazeComponent.extendComponent({
                 slug: currentBoard.slug,
                 cardId: card._id,
               }),
+              className: card.color ? `calendar-event-${card.color}` : null,
             });
           });
         callback(events);

--- a/client/components/boards/boardBody.styl
+++ b/client/components/boards/boardBody.styl
@@ -53,3 +53,81 @@ position()
         padding: 0 0px 0px 0
         overflow-x: hidden
         overflow-y: auto
+
+calendar-event-color(background, borderColor, color...)
+  background: background !important
+  border-color: borderColor
+  if color
+    color: color !important //overwrite text for better visibility
+
+.calendar-event-green
+  calendar-event-color(#3cb500, #2a8000, #ffffff) //White text for better visibility
+
+.calendar-event-yellow
+  calendar-event-color(#fad900, #c7ac00, #000) //Black text for better visibility
+
+.calendar-event-orange
+  calendar-event-color(#ff9f19, #cc7c14, #000) //Black text for better visibility
+
+.calendar-event-red
+  calendar-event-color(#eb4646, #b83737, #ffffff) //White text for better visibility
+
+.calendar-event-purple
+  calendar-event-color(#a632db, #7d26a6, #ffffff) //White text for better visibility
+
+.calendar-event-blue
+  calendar-event-color(#0079bf, #005a8a, #ffffff) //White text for better visibility
+
+.calendar-event-pink
+  calendar-event-color(#ff78cb, #cc62a3, #000) //Black text for better visibility
+
+.calendar-event-sky
+  calendar-event-color(#00c2e0, #0094ab, #ffffff) //White text for better visibility
+
+.calendar-event-black
+  calendar-event-color(#4d4d4d, #1a1a1a, #ffffff) //White text for better visibility
+
+.calendar-event-lime
+  calendar-event-color(#51e898, #3eb375, #000) //Black text for better visibility
+
+.calendar-event-silver
+  calendar-event-color(#c0c0c0, #8c8c8c, #000) //Black text for better visibility
+
+.calendar-event-peachpuff
+  calendar-event-color(#ffdab9, #ccaf95, #000) //Black text for better visibility
+
+.calendar-event-crimson
+  calendar-event-color(#dc143c, #a8112f, #ffffff) //White text for better visibility
+
+.calendar-event-plum
+  calendar-event-color(#dda0dd, #a87ba8, #000) //Black text for better visibility
+
+.calendar-event-darkgreen
+  calendar-event-color(#006400, #003000, #ffffff) //White text for better visibility
+
+.calendar-event-slateblue
+  calendar-event-color(#6a5acd, #4f4399, #ffffff) //White text for better visibility
+
+.calendar-event-magenta
+  calendar-event-color(#ff00ff, #cc00cc, #ffffff) //White text for better visibility
+
+.calendar-event-gold
+  calendar-event-color(#ffd700, #ccaa00, #000) //Black text for better visibility
+
+.calendar-event-navy
+  calendar-event-color(#000080, #000033, #ffffff) //White text for better visibility
+
+.calendar-event-gray
+  calendar-event-color(#808080, #333333, #ffffff) //White text for better visibility
+
+.calendar-event-saddlebrown
+  calendar-event-color(#8b4513, #572b0c, #ffffff) //White text for better visibility
+
+.calendar-event-paleturquoise
+  calendar-event-color(#afeeee, #8ababa, #000) //Black text for better visibility
+
+.calendar-event-mistyrose
+  calendar-event-color(#ffe4e1, #ccb8b6, #000) //Black text for better visibility
+
+.calendar-event-indigo
+  calendar-event-color(#4b0082, #2b004d, #ffffff) //White text for better visibility


### PR DESCRIPTION
This adds basic support of colored calendar events. The color of the calendar event will match the card color.
One remark regarding the styles: there're a lot of *-$COLOR classes around the project. It might make sense to consolidate them in some kind of util function that can create classes for all available colors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2664)
<!-- Reviewable:end -->
