### PR TITLE
Treat any 2xx webhook response status code as success

### DIFF
--- a/server/notifications/outgoing.js
+++ b/server/notifications/outgoing.js
@@ -124,7 +124,7 @@ Meteor.methods({
     const url = integration.url;
     const response = postCatchError(url, options);
 
-    if (response && response.statusCode && response.statusCode === 200) {
+    if (response && response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
       if (is2way) {
         const cid = params.commentId;
         const tooSoon = Lock.has(cid); // if an activity happens to fast, notification shouldn't fire with the same id


### PR DESCRIPTION
Currently, if Wekan fires a webhook, and the server responds with any status code other than "200 OK", wekan treats this as an error. This causes the change that triggered the webhook to be aborted. This is not strictly correct, as per the HTTP spec any 2xx response code should be treated as success.

More concretely, I am trying to implement a webhook handler using [OpenFaaS](https://www.openfaas.com/). If I configure Wekan to fire the webhook using the OpenFaaS [async-function route](https://docs.openfaas.com/reference/async/#how-it-works) OpenFaaS receives the webhook, queues it for processing and responds with `202 Accepted` - which Wekan treats as an error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2683)
<!-- Reviewable:end -->
