### PR TITLE
REST API: fix handling of members property on card creation

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -1852,8 +1852,15 @@ if (Meteor.isServer) {
     const check = Users.findOne({
       _id: req.body.authorId,
     });
-    const members = req.body.members || [req.body.authorId];
     if (typeof check !== 'undefined') {
+      let members = req.body.members || [];
+      if (_.isString(members)) {
+        if (members === '') {
+          members = [];
+        } else {
+          members = [members];
+        }
+      }
       const id = Cards.direct.insert({
         title: req.body.title,
         boardId: paramBoardId,


### PR DESCRIPTION
Creating a card via REST API does set the user accessing the API as card member if no `members` property has passed. If no `members` where given the card should have no members assigned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2751)
<!-- Reviewable:end -->
