### PR TITLE
Update attachments.js

### DIFF
--- a/client/components/cards/attachments.js
+++ b/client/components/cards/attachments.js
@@ -131,6 +131,8 @@ Template.previewClipboardImagePopup.onRendered(() => {
             direct(results);
           },
         });
+       } else {
+        direct(results);
       }
     }
   };


### PR DESCRIPTION
added else condition to check if MAX_IMAGE_PIXEL is not set, so that it is possible to  upload attachments using drag-and-drop or Ctrl+V without setting the environmental-variable.
If this change is not allowed, please document in the wiki, that this is necessary for a fully-running wekan-instance

If the changes are ok, please integrate it in the snap-build @xet7 

Thank you very much in advance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2754)
<!-- Reviewable:end -->
