### PR TITLE
Enhancement: set card times more sensible using the 'Today' button in…

### DIFF
--- a/client/components/cards/cardDate.js
+++ b/client/components/cards/cardDate.js
@@ -105,7 +105,7 @@ Template.dateBadge.helpers({
 // editCardReceivedDatePopup
 (class extends DatePicker {
   onCreated() {
-    super.onCreated();
+    super.onCreated(moment().format("YYYY-MM-DD HH:mm"));
     this.data().getReceived() &&
       this.date.set(moment(this.data().getReceived()));
   }
@@ -122,7 +122,7 @@ Template.dateBadge.helpers({
 // editCardStartDatePopup
 (class extends DatePicker {
   onCreated() {
-    super.onCreated();
+    super.onCreated(moment().format("YYYY-MM-DD HH:mm"));
     this.data().getStart() && this.date.set(moment(this.data().getStart()));
   }
 
@@ -148,7 +148,7 @@ Template.dateBadge.helpers({
 // editCardDueDatePopup
 (class extends DatePicker {
   onCreated() {
-    super.onCreated();
+    super.onCreated('1970-01-01 17:00:00');
     this.data().getDue() && this.date.set(moment(this.data().getDue()));
   }
 
@@ -171,7 +171,7 @@ Template.dateBadge.helpers({
 // editCardEndDatePopup
 (class extends DatePicker {
   onCreated() {
-    super.onCreated();
+    super.onCreated(moment().format("YYYY-MM-DD HH:mm"));
     this.data().getEnd() && this.date.set(moment(this.data().getEnd()));
   }
 

--- a/client/components/cards/cardDate.js
+++ b/client/components/cards/cardDate.js
@@ -105,7 +105,7 @@ Template.dateBadge.helpers({
 // editCardReceivedDatePopup
 (class extends DatePicker {
   onCreated() {
-    super.onCreated(moment().format("YYYY-MM-DD HH:mm"));
+    super.onCreated(moment().format('YYYY-MM-DD HH:mm'));
     this.data().getReceived() &&
       this.date.set(moment(this.data().getReceived()));
   }
@@ -122,7 +122,7 @@ Template.dateBadge.helpers({
 // editCardStartDatePopup
 (class extends DatePicker {
   onCreated() {
-    super.onCreated(moment().format("YYYY-MM-DD HH:mm"));
+    super.onCreated(moment().format('YYYY-MM-DD HH:mm'));
     this.data().getStart() && this.date.set(moment(this.data().getStart()));
   }
 
@@ -171,7 +171,7 @@ Template.dateBadge.helpers({
 // editCardEndDatePopup
 (class extends DatePicker {
   onCreated() {
-    super.onCreated(moment().format("YYYY-MM-DD HH:mm"));
+    super.onCreated(moment().format('YYYY-MM-DD HH:mm'));
     this.data().getEnd() && this.date.set(moment(this.data().getEnd()));
   }
 

--- a/client/lib/datepicker.js
+++ b/client/lib/datepicker.js
@@ -3,7 +3,7 @@ DatePicker = BlazeComponent.extendComponent({
     return 'datepicker';
   },
 
-  onCreated(defaultTime='1970-01-01 08:00:00') {
+  onCreated(defaultTime = '1970-01-01 08:00:00') {
     this.error = new ReactiveVar('');
     this.card = this.data();
     this.date = new ReactiveVar(moment.invalid());

--- a/client/lib/datepicker.js
+++ b/client/lib/datepicker.js
@@ -3,10 +3,11 @@ DatePicker = BlazeComponent.extendComponent({
     return 'datepicker';
   },
 
-  onCreated() {
+  onCreated(defaultTime='1970-01-01 08:00:00') {
     this.error = new ReactiveVar('');
     this.card = this.data();
     this.date = new ReactiveVar(moment.invalid());
+    this.defaultTime = defaultTime;
   },
 
   onRendered() {
@@ -26,7 +27,7 @@ DatePicker = BlazeComponent.extendComponent({
           if (!timeInput.value) {
             const currentHour = evt.date.getHours();
             const defaultMoment = moment(
-              currentHour > 0 ? evt.date : '1970-01-01 08:00:00',
+              currentHour > 0 ? evt.date : this.defaultTime,
             ); // default to 8:00 am local time
             timeInput.value = defaultMoment.format('LT');
           }


### PR DESCRIPTION
The 'Today' button in the datepicker component uses 08:00 as the default time value. IMHO it would be more sensible to use the current time for the *received*, *start* and *end* fields. For the *due* field it might be more reasonable to use a time in the afternoon (hard-coded 17:00).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2763)
<!-- Reviewable:end -->
