### PR TITLE
REST API: fix deletion of a single board card (closes wekan#2624)

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -2398,13 +2398,13 @@ if (Meteor.isServer) {
       const paramListId = req.params.listId;
       const paramCardId = req.params.cardId;
 
+      const card = Cards.findOne({
+        _id: paramCardId,
+      });
       Cards.direct.remove({
         _id: paramCardId,
         listId: paramListId,
         boardId: paramBoardId,
-      });
-      const card = Cards.find({
-        _id: paramCardId,
       });
       cardRemover(req.body.authorId, card);
       JsonRoutes.sendResult(res, {


### PR DESCRIPTION
This fixes the deletion of all board cards when using the REST API to delete a single board card (wekan#2624).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2778)
<!-- Reviewable:end -->
