### PR TITLE
Fix ldap background sync documentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -442,9 +442,8 @@ services:
       #
       # At which interval does the background task sync in milliseconds.
       # The format must be as specified in:
-      # http://bunkat.github.io/later/parsers.html#text
-      # The default is "every 1 hour"
-      - LDAP_BACKGROUND_SYNC_INTERVAL=''
+      # https://bunkat.github.io/later/parsers.html#text
+      - LDAP_BACKGROUND_SYNC_INTERVAL='every 1 hour'
       #
       #- LDAP_BACKGROUND_SYNC_KEEP_EXISTANT_USERS_UPDATED=false
       #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -441,8 +441,9 @@ services:
       #- LDAP_BACKGROUND_SYNC=false
       #
       # At which interval does the background task sync in milliseconds.
-      # Leave this unset, so it uses default, and does not crash.
-      # https://github.com/wekan/wekan/issues/2354#issuecomment-515305722
+      # The format must be as specified in:
+      # http://bunkat.github.io/later/parsers.html#text
+      # The default is "every 1 hour"
       - LDAP_BACKGROUND_SYNC_INTERVAL=''
       #
       #- LDAP_BACKGROUND_SYNC_KEEP_EXISTANT_USERS_UPDATED=false


### PR DESCRIPTION
I updated the info on the LDAP_BACKGROUND_SYNC_INTERVAl setting in docker-compose.yml to match the following comment by @pshunter in https://github.com/wekan/wekan/issues/2570#issuecomment-515752572

> @xet7 
> No, if LDAP_BACKGROUND_SYNC is set to true, then it checks for LDAP_BACKGROUND_SYNC_INTERVAL. If the latter is unset, then the hardcoded "every 1 hour" rule will be used. If LDAP_BACKGROUND_SYNC_INTERVAL is set, it must be set to something valid. What can be put here is explained there : http://bunkat.github.io/later/parsers.html#text
> For example, you can use "every 1 hour" or "every 20 minute". You can get very creative, like so : "at 10:15 am also at 5:15pm except on Tuesday".

Related to #2354 and #2570.

Someone with access to the wiki should also update this page:
https://github.com/wekan/wekan/wiki/LDAP
It currently states
```
# LDAP_BACKGROUND_SYNC_INTERVAL : At which interval does the background task sync in milliseconds
# example : LDAP_BACKGROUND_SYNC_INTERVAL=12345
- LDAP_BACKGROUND_SYNC_INTERVAL=100
```
I would suggest e.g.
```
# LDAP_BACKGROUND_SYNC_INTERVAL : At which interval does the background task sync
# example : LDAP_BACKGROUND_SYNC_INTERVAL='every 15 minutes'
# for more info: http://bunkat.github.io/later/parsers.html#text
- LDAP_BACKGROUND_SYNC_INTERVAL='every 1 hour'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2855)
<!-- Reviewable:end -->
