### PR TITLE
fix: k8s templates update for helm

### DIFF
--- a/helm/wekan/requirements.yaml
+++ b/helm/wekan/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mongodb-replicaset
-  version: 3.6.x
+  version: 3.11.x
   repository: "https://kubernetes-charts.storage.googleapis.com/"
   condition: mongodb-replicaset.enabled

--- a/helm/wekan/templates/_helpers.tpl
+++ b/helm/wekan/templates/_helpers.tpl
@@ -75,7 +75,7 @@ else use user-provided URL.
 {{- if (index .Values "mongodb-replicaset" "enabled") -}}
 {{- $count := (int (index .Values "mongodb-replicaset" "replicas")) -}}
 {{- $release := .Release.Name -}}
-mongodb://{{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}?replicaSet={{ index .Values "mongodb-replicaset" "replicaSetName" }}
+mongodb://{{ $release }}-mongodb-replicaset:27017/admin?replicaSet={{ index .Values "mongodb-replicaset" "replicaSetName" }}
 {{- else -}}
 {{- index .Values "mongodb-replicaset" "url" -}}
 {{- end -}}

--- a/helm/wekan/templates/ingress.yaml
+++ b/helm/wekan/templates/ingress.yaml
@@ -35,6 +35,6 @@ spec:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: http
+              servicePort: 80
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Why:

This change addresses the need by:

1. upgrade mongo replica version
2. access mongo via service url
3. change the expose servicePort to numeric 

Signed-off-by: Jiang Yitao <jiangyt.cn@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2867)
<!-- Reviewable:end -->
