### PR TITLE
Fix: Error when retrieve token from some OIDC due to not necessary sc…

### DIFF
--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -72,7 +72,6 @@ var getToken = function (query) {
           client_secret: OAuth.openSecret(config.secret),
           redirect_uri: OAuth._redirectUri('oidc', config),
           grant_type: 'authorization_code',
-          scope: requestPermissions,
           state: query.state
         }
       }


### PR DESCRIPTION
## Bug
Due to the following error:
```
Exception while invoking method 'login' Error: Failed to get token from OIDC https://sso.example.com/openam/oauth2/access_token: failed [400] {"error_description":"Scope parameter is not supported on an authorization code access_token exchange request. Scope parameter should be supplied to the authorize request.","state":"[...]","error":"invalid_request"}
```
`scope` is not a required or optional parameter for the access token request. See [Section 4.1.3 of RFC 6749](https://tools.ietf.org/html/rfc6749#section-4.1.3). This cause no particular problem with some identity providers but cause errors on others.

## Fix
Remove `scope` parameter from the request to keep parameters as describe in the RFC. Tested with our enterprise identity provider (that was not working before), RocketChat and Github Oauth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2955)
<!-- Reviewable:end -->
