### PR TITLE
When searching cards in a board, also use custom fields

### DIFF
--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -440,7 +440,7 @@
   "save": "Save",
   "search": "Search",
   "rules": "Rules",
-  "search-cards": "Search from card/list titles and descriptions on this board",
+  "search-cards": "Search from card/list titles, descriptions and custom fields on this board",
   "search-example": "Text to search for?",
   "select-color": "Select Color",
   "set-wip-limit-value": "Set a limit for the maximum number of tasks in this list",

--- a/models/boards.js
+++ b/models/boards.js
@@ -806,7 +806,11 @@ Boards.helpers({
     if (term) {
       const regex = new RegExp(term, 'i');
 
-      query.$or = [{ title: regex }, { description: regex }];
+      query.$or = [
+        { title: regex },
+        { description: regex },
+        { customFields: { $elemMatch: { value: regex } } },
+      ];
     }
 
     return Cards.find(query, projection);


### PR DESCRIPTION
I believe that the ability to search not just titles and descriptions but also, at least, custom fields is a nice quality of life feature to have. So, I implemented that change. (I also think searching comments would be good, but that's for later)
I hope that you'll agree with me. 

Sorry for any possible mistakes, this is my first contribution to an open-source project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2985)
<!-- Reviewable:end -->
