### PR TITLE
Route template added to helm chart

### DIFF
--- a/helm/wekan/README.md
+++ b/helm/wekan/README.md
@@ -56,3 +56,10 @@ mongodb-replicaset:
 This section controls the scale of the MongoDB redundant Replica Set.
 
 **replicas:** This is the number of MongoDB instances to include in the set. You can set this to 1 for a single server - this will still allow you to scale-up later with a helm upgrade.
+
+### Install OCP route
+If you use this chart to deploy Wekan on an OCP cluster, you can create route instead of ingress with following command:
+
+``` bash
+$ helm template --set route.enabled=true,ingress.enabled=false values.yaml . | oc apply -f-
+```

--- a/helm/wekan/templates/route.yaml
+++ b/helm/wekan/templates/route.yaml
@@ -1,7 +1,5 @@
 {{- if .Values.route.enabled -}}
 {{- $fullName := include "wekan.fullname" . -}}
-{{- $servicePort := .Values.service.port -}}
-{{- $ingressPath := .Values.ingress.path -}}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/helm/wekan/templates/route.yaml
+++ b/helm/wekan/templates/route.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.route.enabled -}}
+{{- $fullName := include "wekan.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 4m
+    openshift.io/host.generated: "true"
+  labels:
+    app: {{ template "wekan.name" . }}
+    service: {{ template "wekan.name" . }}
+  name: {{ template "wekan.name" . }}
+spec:
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: {{ template "wekan.name" . }}
+    weight: 100
+  wildcardPolicy: None
+  {{- end }}

--- a/helm/wekan/values.yaml
+++ b/helm/wekan/values.yaml
@@ -60,7 +60,7 @@ ingress:
   #      - wekan-example.local
 
   route:
-    enabled: true
+    enabled: false
 
 resources: 
   requests:

--- a/helm/wekan/values.yaml
+++ b/helm/wekan/values.yaml
@@ -59,6 +59,9 @@ ingress:
   #    hosts:
   #      - wekan-example.local
 
+  route:
+    enabled: true
+
 resources: 
   requests:
     memory: 128Mi


### PR DESCRIPTION
When I'd like to use the upstream helm chart to deploy Wekan on an Openshift v4x cluster, I need a route definition. So I added one and updated values yaml and documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2996)
<!-- Reviewable:end -->
