### PR TITLE
Add filter option for assignee

### DIFF
--- a/client/components/sidebar/sidebarFilters.jade
+++ b/client/components/sidebar/sidebarFilters.jade
@@ -46,6 +46,24 @@ template(name="filterSidebar")
               i.fa.fa-check
   hr
   ul.sidebar-list
+    li(class="{{#if Filter.assignees.isSelected undefined}}active{{/if}}")
+      a.name.js-toggle-assignee-filter
+        span.sidebar-list-item-description
+          | {{_ 'filter-no-assignee'}}
+        if Filter.assignees.isSelected undefined
+          i.fa.fa-check
+    each currentBoard.activeMembers
+      with getUser userId
+        li(class="{{#if Filter.assignees.isSelected _id}}active{{/if}}")
+          a.name.js-toggle-assignee-filter
+            +userAvatar(userId=this._id)
+            span.sidebar-list-item-description
+              = profile.fullname
+              | (<span class="username">{{ username }}</span>)
+            if Filter.assignees.isSelected _id
+              i.fa.fa-check
+  hr
+  ul.sidebar-list
     li(class="{{#if Filter.customFields.isSelected undefined}}active{{/if}}")
           a.name.js-toggle-custom-fields-filter
             span.sidebar-list-item-description

--- a/client/components/sidebar/sidebarFilters.js
+++ b/client/components/sidebar/sidebarFilters.js
@@ -18,6 +18,11 @@ BlazeComponent.extendComponent({
           Filter.members.toggle(this.currentData()._id);
           Filter.resetExceptions();
         },
+        'click .js-toggle-assignee-filter'(evt) {
+          evt.preventDefault();
+          Filter.assignees.toggle(this.currentData()._id);
+          Filter.resetExceptions();
+        },
         'click .js-toggle-archive-filter'(evt) {
           evt.preventDefault();
           Filter.archive.toggle(this.currentData()._id);

--- a/client/lib/filter.js
+++ b/client/lib/filter.js
@@ -459,13 +459,21 @@ Filter = {
   // before changing the schema.
   labelIds: new SetFilter(),
   members: new SetFilter(),
+  assignees: new SetFilter(),
   archive: new SetFilter(),
   hideEmpty: new SetFilter(),
   customFields: new SetFilter('_id'),
   advanced: new AdvancedFilter(),
   lists: new AdvancedFilter(), // we need the ability to filter list by name as well
 
-  _fields: ['labelIds', 'members', 'archive', 'hideEmpty', 'customFields'],
+  _fields: [
+    'labelIds',
+    'members',
+    'assignees',
+    'archive',
+    'hideEmpty',
+    'customFields',
+  ],
 
   // We don't filter cards that have been added after the last filter change. To
   // implement this we keep the id of these cards in this `_exceptions` fields

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -319,6 +319,7 @@
   "filter-clear": "Clear filter",
   "filter-no-label": "No label",
   "filter-no-member": "No member",
+  "filter-no-assignee": "No assignee",
   "filter-no-custom-fields": "No Custom Fields",
   "filter-show-archive": "Show archived lists",
   "filter-hide-empty": "Hide empty lists",


### PR DESCRIPTION
Implements the filtering for assignees requested in https://github.com/wekan/wekan/issues/2995.
Works like the member filter, but filters for assignees instead.

No filter:
![No Filter](https://user-images.githubusercontent.com/1525711/78793467-bec5e000-79b2-11ea-8d2d-c28f6d77d5cb.png)
Filtering assignee: 
![Assignee Filter](https://user-images.githubusercontent.com/1525711/78793472-bff70d00-79b2-11ea-8f04-f6dd1cfb90fd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/2997)
<!-- Reviewable:end -->
