### PR TITLE
When adding a user to a board that has subtasks, also add user to the subtask board

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -814,6 +814,16 @@ if (Meteor.isServer) {
       board.addMember(user._id);
       user.addInvite(boardId);
 
+      //Check if there is a subtasks board
+      if (board.subtasksDefaultBoardId){
+        const subBoard = Boards.findOne(board.subtasksDefaultBoardId);
+        //If there is, also add user to that board
+        if (subBoard) {
+          subBoard.addMember(user._id);
+          user.addInvite(subBoard._id);
+        }
+      }
+      
       try {
         const params = {
           user: user.username,


### PR DESCRIPTION
If a board has subtasks and a user is added to it, he will only have access to the main board, and not to the subtask one. He would have to be manually invited to the subtask board.
I think the user should automatically be added to both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3004)
<!-- Reviewable:end -->
