### PR TITLE
Fix styling issue in notifications drawer

### DIFF
--- a/client/components/notifications/notificationsDrawer.styl
+++ b/client/components/notifications/notificationsDrawer.styl
@@ -10,8 +10,7 @@ section#notifications-drawer
   border-radius: 2px
   max-height: calc(100vh - 28px - 36px)
   color: black
-  padding-top 36px;
-  overflow: scroll
+  padding-top 36px
 
   a:hover
     color: belize !important
@@ -66,3 +65,5 @@ section#notifications-drawer
     display: block
     padding: 0px 16px
     margin: 0
+    height: calc(100vh - 102px)
+    overflow-y: scroll


### PR DESCRIPTION
The header of the notification drawer had a margin to the
right side in Google Chrome caused by overflow: scroll on
the #notifications-drawer element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3012)
<!-- Reviewable:end -->
