### PR TITLE
hide password auth with PASSWORD_LOGIN_ENABLED variable

### DIFF
--- a/client/components/main/layouts.js
+++ b/client/components/main/layouts.js
@@ -31,6 +31,11 @@ Template.userFormsLayout.onCreated(function() {
       return this.stop();
     },
   });
+  Meteor.call('isPasswordDisabled', (_, result) => {
+    if (result) {
+      $('.at-pwd-form').hide();
+    }
+  });
 });
 
 Template.userFormsLayout.onRendered(() => {

--- a/models/settings.js
+++ b/models/settings.js
@@ -334,6 +334,11 @@ if (Meteor.isServer) {
     getDefaultAuthenticationMethod() {
       return process.env.DEFAULT_AUTHENTICATION_METHOD;
     },
+
+    isPasswordDisabled() {
+      return process.env.PASSWORD_LOGIN_ENABLED === 'false';
+    },
+
   });
 }
 


### PR DESCRIPTION
Hi, 
Here is a workaround to disable/hide the password login form. It coult be use when ldap,cas or Oauth2 methods are used.
I looked to completely disable password meteor account but it seems pretty difficult... 

Regards