### PR TITLE
Allows for use of checklist on mobile

### DIFF
--- a/client/components/cards/checklists.jade
+++ b/client/components/cards/checklists.jade
@@ -88,7 +88,8 @@ template(name="checklistItems")
 template(name='checklistItemDetail')
   .js-checklist-item.checklist-item
     if canModifyCard
-      .check-box.materialCheckBox(class="{{#if item.isFinished }}is-checked{{/if}}")
+      .check-box-container
+        .check-box.materialCheckBox(class="{{#if item.isFinished }}is-checked{{/if}}")
       .item-title.js-open-inlined-form.is-editable(class="{{#if item.isFinished }}is-checked{{/if}}")
         +viewer
           = item.title

--- a/client/components/cards/checklists.js
+++ b/client/components/cards/checklists.js
@@ -250,7 +250,7 @@ BlazeComponent.extendComponent({
   events() {
     return [
       {
-        'click .js-checklist-item .check-box': this.toggleItem,
+        'click .js-checklist-item .check-box-container': this.toggleItem,
       },
     ];
   },

--- a/client/components/cards/checklists.styl
+++ b/client/components/cards/checklists.styl
@@ -113,6 +113,9 @@ textarea.js-add-checklist-item, textarea.js-edit-checklist-item
   &:hover
     background-color: darken(white, 8%)
 
+  .check-box-container
+    padding-right: 1px;
+
   .check-box
     margin: 0.1em 0 0 0;
     &.is-checked
@@ -121,7 +124,7 @@ textarea.js-add-checklist-item, textarea.js-edit-checklist-item
 
   .item-title
     flex: 1
-    padding-left: 10px;
+    margin-left: 10px;
     &.is-checked
       color: #8c8c8c
       font-style: italic

--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,7 +3835,7 @@
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {


### PR DESCRIPTION
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22419909/79285716-32fcf980-7e73-11ea-880b-82df6094c34d.gif)

As seen above, previously the checklist was not mobile friendly. The above gif was created using Chrome's developer tools to simulate the use of Wekan on an iPad. It is nearly impossible to check off an item. If the finger is not in exactly the correct location, instead of the item being checked off when the user taps, the input box to edit the checklist item opens.

This commit fixes that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3019)
<!-- Reviewable:end -->
