### PR TITLE
oidc server is updated to work with OCP OAuth

### DIFF
--- a/helm/wekan/templates/deployment.yaml
+++ b/helm/wekan/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
               value: {{ .Values.root_url | default "https://wekan.local" | quote }}
             - name: MONGO_URL
               value: "{{ template "mongodb-replicaset.url" . }}"
+          {{- range $key := .Values.env }}
+          {{- if .value }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm/wekan/templates/serviceaccount.yaml
+++ b/helm/wekan/templates/serviceaccount.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.serviceAccounts.annotations }}
+  annotations:
+{{ .Values.serviceAccounts.annotations | indent 4}}
+{{- end }}
   labels:
     app: {{ template "wekan.name" . }}
     chart: {{ template "wekan.chart" . }}

--- a/helm/wekan/values.yaml
+++ b/helm/wekan/values.yaml
@@ -30,7 +30,9 @@ credentials:
 
 ## Specify additional environmental variables for the Deployment
 ##
-env: {}
+env:
+  - name: ""
+    value: ""
 
 service:
   type: NodePort

--- a/helm/wekan/values.yaml
+++ b/helm/wekan/values.yaml
@@ -8,6 +8,7 @@
 serviceAccounts:
   create: true
   name: ""
+  annotations: ""
 
 ## Wekan image configuration
 ##
@@ -59,10 +60,10 @@ ingress:
   #    hosts:
   #      - wekan-example.local
 
-  route:
-    enabled: false
+route:
+  enabled: false
 
-resources: 
+resources:
   requests:
     memory: 128Mi
     cpu: 300m

--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -11,6 +11,7 @@ OAuth.registerService('oidc', 2, null, function (query) {
 
   var userinfo = getUserInfo(accessToken);
   if (userinfo.ocs) userinfo = userinfo.ocs.data; // Nextcloud hack
+  if (userinfo.metadata) userinfo = userinfo.metadata // Openshift hack
   if (debug) console.log('XXX: userinfo:', userinfo);
 
   var serviceData = {};


### PR DESCRIPTION
Hi,

Since Openshift 4.x userinfo is nested (just like in this [issue](https://github.com/wekan/wekan/issues/1874#issuecomment-475580905)), I couldn't make OAuth work with Openshift. 

userinfo from Openshift:

```
{
  "kind": "User",
  "apiVersion": "user.openshift.io/v1",
  "metadata": {
    "name": "testuser",
    "selfLink": "/apis/user.openshift.io/v1/users/testuser",
    "uid": "dbf9f6a2-547s-11ea-bcb0-0a550a820106",
    "resourceVersion": "",
    "creationTimestamp": ""
  }
}
```
So I had to add `if (userinfo.metadata) userinfo = userinfo.metadata` 

Also updated deploymentconfig template to be able to set environment parameters during deployment and serviceaccounts template to be able to add annotations (which is required to make OAuth work), and updated values file accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3020)
<!-- Reviewable:end -->
