### PR TITLE
Fix getStartDayOfWeek function

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -530,7 +530,8 @@ Users.helpers({
 
   getStartDayOfWeek() {
     const profile = this.profile || {};
-    return profile.startDayOfWeek || 1;
+    // default is 'Monday' (1)
+    return profile.startDayOfWeek ?? 1;
   },
 
   getTemplatesBoardId() {


### PR DESCRIPTION
In case profile.startDayOfWeek is 0 it's evaluated to false and 1 is returned.
Let's fix this by differentiating between undefined and an actual value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3038)
<!-- Reviewable:end -->
