### PR TITLE
Reactivate the touch event fix for the boards list

### DIFF
--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -1,5 +1,5 @@
 const subManager = new SubsManager();
-const { calculateIndex } = Utils;
+const { calculateIndex, enableClickOnTouch } = Utils;
 
 Template.boardListHeaderBar.events({
   'click .js-open-archived-board'() {
@@ -67,6 +67,9 @@ BlazeComponent.extendComponent({
         board.move(sortIndex.base);
       },
     });
+
+    // ugly touch event hotfix
+    enableClickOnTouch(itemsSelector);
 
     // Disable drag-dropping if the current user is not a board member or is comment only
     this.autorun(() => {


### PR DESCRIPTION
For now, let's reactivate the touch event fix for the boards list. This fixes https://github.com/wekan/wekan/issues/3049.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3051)
<!-- Reviewable:end -->
