### PR TITLE
Make sure that the board header buttons fit into one line

### DIFF
--- a/client/components/main/header.styl
+++ b/client/components/main/header.styl
@@ -175,7 +175,7 @@
       .board-header-btn
         height: 32px
         line-height: @height
-        font-size: 16px
+        font-size: 15px
 
         i.fa
           line-height: 32px


### PR DESCRIPTION
...even for devices with 360px width resolution.

See https://gs.statcounter.com/screen-resolution-stats/mobile/worldwide for mobile screen resolution statistics.

Before:
![360px](https://user-images.githubusercontent.com/12081346/80323863-2e9aee00-882e-11ea-9f98-6e8b9772c38e.png)

After:
![fixed](https://user-images.githubusercontent.com/12081346/80323867-30fd4800-882e-11ea-90be-fcf9b0622d2f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3052)
<!-- Reviewable:end -->
