### PR TITLE
Fix list header height when cards count is shown

### DIFF
--- a/client/components/lists/list.styl
+++ b/client/components/lists/list.styl
@@ -43,9 +43,6 @@
       background: white
       margin: -3px 0 8px
 
-.list-header-card-count
-  height: 35px
-
 .list-header-add
   flex: 0 0 auto
   padding: 20px 12px 4px
@@ -60,6 +57,9 @@
   background-color: #e4e4e4;
   border-bottom: 6px solid #e4e4e4;
 
+  &.list-header-card-count
+    min-height: 35px
+    height: auto
 
   &.ui-sortable-handle
     cursor: grab


### PR DESCRIPTION
Before:
![height_broken](https://user-images.githubusercontent.com/12081346/80371847-d9dd8e80-8892-11ea-81c2-9511cebca426.png)

After:
![height_fixed](https://user-images.githubusercontent.com/12081346/80371850-dba75200-8892-11ea-959a-c2e7db9dab8d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3056)
<!-- Reviewable:end -->
