### PR TITLE
Add white-space:normal to copy-to-clipboard button in card details

### DIFF
--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -519,7 +519,7 @@ template(name="cardMorePopup")
       = ' '
       i.fa.colorful(class="{{#if board.isPublic}}fa-globe{{else}}fa-lock{{/if}}")
       input.inline-input(type="text" id="cardURL" readonly value="{{ absoluteUrl }}" autofocus="autofocus")
-      button.js-copy-card-link-to-clipboard(class="btn") {{_ 'copy-card-link-to-clipboard'}}
+      button.js-copy-card-link-to-clipboard(class="btn" id="clipboard") {{_ 'copy-card-link-to-clipboard'}}
     span.clearfix
     br
     h2 {{_ 'change-card-parent'}}

--- a/client/components/cards/cardDetails.styl
+++ b/client/components/cards/cardDetails.styl
@@ -10,6 +10,9 @@ avatar-radius = 50%
   left: -2000px
   top: 0px
 
+#clipboard
+  white-space: normal
+
 .assignee
   border-radius: 3px
   display: block


### PR DESCRIPTION
This PR resolves #2993 issue.
Added clipboard id with white-space:normal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3075)
<!-- Reviewable:end -->
