### PR TITLE
avatar-image class fix

### DIFF
--- a/client/components/cards/cardDetails.styl
+++ b/client/components/cards/cardDetails.styl
@@ -37,6 +37,8 @@ avatar-radius = 50%
       position: absolute
 
     &.avatar-image
+      object-fit: cover;
+      object-position: center;
       height: 100%
       width: @height
 

--- a/client/components/users/userAvatar.styl
+++ b/client/components/users/userAvatar.styl
@@ -29,6 +29,8 @@ avatar-radius = 50%
       position: absolute
 
     &.avatar-image
+      object-fit: cover;
+      object-position: center;
       height: 100%
       width: @height
 


### PR DESCRIPTION
I noticed some profile images (if not a perfect square or circle) were rendered wrongly. With this two lines of css we can fix them. :D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3083)
<!-- Reviewable:end -->
