### PR TITLE
Create card does not allow an empty member list

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -2156,7 +2156,7 @@ if (Meteor.isServer) {
     const check = Users.findOne({
       _id: req.body.authorId,
     });
-    const members = req.body.members || [req.body.authorId];
+    const members = req.body.members;
     const assignees = req.body.assignees;
     if (typeof check !== 'undefined') {
       const id = Cards.direct.insert({


### PR DESCRIPTION
When I create a card via the API I always have the authorId in members, even if I pass an empty string as member list. Workaround: I can empty the member list by passing an empty string in a PUT request. This pull request proposes to not add the authorId to the member list when creating a card and the member list is empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3084)
<!-- Reviewable:end -->
