### PR TITLE
Swimlanes ID missing in new boards

### DIFF
--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -77,7 +77,7 @@ BlazeComponent.extendComponent({
       else if (
         Utils.boardView() === 'board-view-lists' ||
         Utils.boardView() === 'board-view-cal' ||
-        !Utils.boardView
+        !Utils.boardView()
       )
         swimlaneId = board.getDefaultSwimline()._id;
 


### PR DESCRIPTION
when creating a new card in a new board there were and error on console. Result: card was not created. adding this parenthesis it works now.
Just for info. without this change if you want to create a card you need to change view to swimlines and go back to list view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3088)
<!-- Reviewable:end -->
