### PR TITLE
Set '*' as default value for swimlane and list name in card move action

### DIFF
--- a/client/components/rules/actions/boardActions.js
+++ b/client/components/rules/actions/boardActions.js
@@ -68,8 +68,8 @@ BlazeComponent.extendComponent({
           const ruleName = this.data().ruleName.get();
           const trigger = this.data().triggerVar.get();
           const actionSelected = this.find('#move-spec-action').value;
-          const swimlaneName = this.find('#swimlaneName').value;
-          const listName = this.find('#listName').value;
+          const swimlaneName = this.find('#swimlaneName').value || '*';
+          const listName = this.find('#listName').value || '*';
           const boardId = Session.get('currentBoard');
           const destBoardId = this.find('#board-id').value;
           const desc = Utils.getTriggerActionDesc(event, this);


### PR DESCRIPTION
This is the same default as `Utils.getTriggerActionDesc` has. This commit fixes
https://github.com/wekan/wekan/issues/3107.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3109)
<!-- Reviewable:end -->
