### PR TITLE
Fix default value of `sort`

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -278,7 +278,7 @@ Cards.attachSchema(
        */
       type: Number,
       decimal: true,
-      defaultValue: '',
+      defaultValue: 0,
     },
     subtaskSort: {
       /**


### PR DESCRIPTION
The default has to be a numeric value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3122)
<!-- Reviewable:end -->
