### PR TITLE
WIP/Preview:Add user option to group finished checklist items

### DIFF
--- a/client/components/cards/checklists.jade
+++ b/client/components/cards/checklists.jade
@@ -1,7 +1,17 @@
 template(name="checklists")
-  h3
-    i.fa.fa-check
-    | {{_ 'checklists'}}
+  .checklists-title
+    h3
+      i.fa.fa-check
+      | {{_ 'checklists'}}
+    if currentUser.isBoardMember
+      .material-toggle-switch
+        span.toggle-switch-title {{_ 'group-checklist-by-is-finished'}}
+        if groupChecklistByIsFinished
+          input.toggle-switch(type="checkbox" id="toggleGroupChecklistButton" checked="checked")
+        else
+          input.toggle-switch(type="checkbox" id="toggleGroupChecklistButton")
+        label.toggle-label(for="toggleGroupChecklistButton")
+
   if toggleDeleteDialog.get
     .board-overlay#card-details-overlay
     +checklistDeleteDialog(checklist = checklistToDelete)
@@ -72,7 +82,7 @@ template(name="editChecklistItemForm")
 
 template(name="checklistItems")
   .checklist-items.js-checklist-items
-    each item in checklist.items
+    each item in checklist.items groupChecklistByIsFinished
       +inlinedForm(classNames="js-edit-checklist-item" item = item checklist = checklist)
         +editChecklistItemForm(type = 'item' item = item checklist = checklist)
       else

--- a/client/components/cards/checklists.js
+++ b/client/components/cards/checklists.js
@@ -193,6 +193,9 @@ BlazeComponent.extendComponent({
         }
         this.toggleDeleteDialog.set(!this.toggleDeleteDialog.get());
       },
+      'click #toggleGroupChecklistButton'() {
+        Meteor.call('toggleGroupChecklistByIsFinished');
+      },
     };
 
     return [
@@ -210,6 +213,14 @@ BlazeComponent.extendComponent({
     ];
   },
 }).register('checklists');
+
+Template.checklists.helpers({
+  groupChecklistByIsFinished() {
+    const user = Meteor.user();
+    if (user) return user.hasGroupChecklistByIsFinished();
+    return false;
+  },
+});
 
 Template.checklistDeleteDialog.onCreated(() => {
   const $cardDetails = this.$('.card-details');
@@ -264,3 +275,11 @@ BlazeComponent.extendComponent({
     ];
   },
 }).register('checklistItemDetail');
+
+Template.checklistItems.helpers({
+  groupChecklistByIsFinished() {
+    const currentUser = Meteor.user();
+    if (currentUser) return currentUser.hasGroupChecklistByIsFinished();
+    return false;
+  },
+});

--- a/client/components/cards/checklists.styl
+++ b/client/components/cards/checklists.styl
@@ -16,6 +16,10 @@ textarea.js-add-checklist-item, textarea.js-edit-checklist-item
   &:hover
     color: inherit
 
+.checklists-title
+  display: flex
+  justify-content: space-between
+
 .checklist-title
   .checkbox
     float: left

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -808,5 +808,6 @@
   "voting": "Voting",
   "archived": "Archived",
   "delete-linked-card-before-this-card": "You can not delete this card before first deleting linked card that has",
-  "delete-linked-cards-before-this-list": "You can not delete this list before first deleting linked cards that are pointing to cards in this list"
+  "delete-linked-cards-before-this-list": "You can not delete this list before first deleting linked cards that are pointing to cards in this list",
+  "group-checklist-by-is-finished": "Group checklist items by state"
 }

--- a/models/checklists.js
+++ b/models/checklists.js
@@ -83,12 +83,19 @@ Checklists.helpers({
   itemCount() {
     return ChecklistItems.find({ checklistId: this._id }).count();
   },
-  items() {
+  items(groupByIsFinished = false) {
+    let sort;
+    if (groupByIsFinished) {
+      sort = { isFinished: 1, sort: 1 };
+    } else {
+      sort = { sort: 1 };
+    }
+
     return ChecklistItems.find(
       {
         checklistId: this._id,
       },
-      { sort: ['sort'] },
+      { sort },
     );
   },
   finishedCount() {

--- a/models/users.js
+++ b/models/users.js
@@ -128,6 +128,15 @@ Users.attachSchema(
       type: Boolean,
       optional: true,
     },
+    'profile.groupChecklistByIsFinished': {
+      /**
+       * does the user want the checklist items to be grouped depending on
+       * whether they have been finished?
+       */
+      type: Boolean,
+      optional: true,
+    },
+
     'profile.hiddenSystemMessages': {
       /**
        * does the user want to hide system messages?
@@ -483,6 +492,11 @@ Users.helpers({
     return profile.showDesktopDragHandles || false;
   },
 
+  hasGroupChecklistByIsFinished() {
+    const profile = this.profile || {};
+    return profile.groupChecklistByIsFinished || false;
+  },
+
   hasHiddenSystemMessages() {
     const profile = this.profile || {};
     return profile.hiddenSystemMessages || false;
@@ -612,6 +626,15 @@ Users.mutations({
     };
   },
 
+  toggleGroupChecklistByIsFinished() {
+    const value = this.hasGroupChecklistByIsFinished();
+    return {
+      $set: {
+        'profile.groupChecklistByIsFinished': !value,
+      },
+    };
+  },
+
   toggleSystem(value = false) {
     return {
       $set: {
@@ -689,6 +712,10 @@ Meteor.methods({
   toggleDesktopDragHandles() {
     const user = Meteor.user();
     user.toggleDesktopHandles(user.hasShowDesktopDragHandles());
+  },
+  toggleGroupChecklistByIsFinished() {
+    const user = Meteor.user();
+    user.toggleGroupChecklistByIsFinished();
   },
   toggleSystemMessages() {
     const user = Meteor.user();

--- a/public/api/wekan.yml
+++ b/public/api/wekan.yml
@@ -3071,6 +3071,11 @@ definitions:
         description: |
            does the user want to hide system messages?
         type: boolean
+      groupChecklistByIsFinished:
+        description: |
+          does the user want the checklist items to be grouped depending on
+          whether they have been finished?
+        type: boolean
       hiddenSystemMessages:
         description: |
            does the user want to hide system messages?


### PR DESCRIPTION
Add a user option to group finished and unfinished items in a checklist.

Disabled:
![Screenshot from 2020-06-09 20-21-39](https://user-images.githubusercontent.com/12081346/84185952-0f7bb700-aa90-11ea-88df-2e318d0b713d.png)

Enabled:
![Screenshot from 2020-06-09 20-21-36](https://user-images.githubusercontent.com/12081346/84185948-0d195d00-aa90-11ea-8974-c938d1730c6a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3166)
<!-- Reviewable:end -->
