### PR TITLE
openapi: fix jsdoc/operation matching

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -2749,7 +2749,7 @@ if (Meteor.isServer) {
    * @return_type [{_id: string,
    *                title: string,
    *                description: string,
-   *                listId: string
+   *                listId: string,
    *                swinlaneId: string}]
    */
   JsonRoutes.add(

--- a/openapi/generate_openapi.py
+++ b/openapi/generate_openapi.py
@@ -814,13 +814,21 @@ def parse_schemas(schemas_dir):
                                                        for d in data]
                                 entry_points.extend(schema_entry_points)
 
+                                end_of_previous_operation = -1
+
                                 # try to match JSDoc to the operations
                                 for entry_point in schema_entry_points:
                                     operation = entry_point.method  # POST/GET/PUT/DELETE
+
+                                    # find all jsdocs that end before the current operation,
+                                    # the last item in the list is the one we need
                                     jsdoc = [j for j in jsdocs
-                                             if j.loc.end.line + 1 == operation.loc.start.line]
+                                             if j.loc.end.line + 1 <= operation.loc.start.line and
+                                                j.loc.start.line > end_of_previous_operation]
                                     if bool(jsdoc):
-                                        entry_point.doc = jsdoc[0]
+                                        entry_point.doc = jsdoc[-1]
+
+                                    end_of_previous_operation = operation.loc.end.line
             except TypeError:
                 logger.warning(context.txt_for(statement))
                 logger.error('{}:{}-{} can not parse {}'.format(path,

--- a/openapi/generate_openapi.py
+++ b/openapi/generate_openapi.py
@@ -249,7 +249,10 @@ class EntryPoint(object):
 
                 if name.startswith('{'):
                     param_type = name.strip('{}')
-                    if param_type not in ['string', 'number', 'boolean', 'integer', 'array', 'file']:
+                    if param_type == 'Object':
+                        # hope for the best
+                        param_type = 'object'
+                    elif param_type not in ['string', 'number', 'boolean', 'integer', 'array', 'file']:
                         self.warn('unknown type {}\n allowed values: string, number, boolean, integer, array, file'.format(param_type))
                     try:
                         name, desc = desc.split(maxsplit=1)


### PR DESCRIPTION
The script was considering that the operation associated to a jsdoc was declared on the line
just after the end of the jsdoc.

Turns out that adding new lines makes the code clearer, but the python script was then ignoring
some jsdocs.

Change the behaviour to consider that the jsdoc associated with an operation is the last one
declared after the end of the previous operation.

Fixes #3169

Note: I was able to check on the proper generation of the openapi definition, but not on the html generation (got a new setup and couldn't really get the npm part of the generation working).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3171)
<!-- Reviewable:end -->
