### PR TITLE
Remove top and bottom margin for hidden checklist items

### DIFF
--- a/client/components/cards/checklists.styl
+++ b/client/components/cards/checklists.styl
@@ -112,6 +112,8 @@ textarea.js-add-checklist-item, textarea.js-edit-checklist-item
     opacity: 0
     height: 0
     transition: height 0ms 0ms, opacity 600ms 0ms
+    margin-top: 0
+    margin-bottom: 0
 
   &.placeholder
     background: darken(white, 20%)


### PR DESCRIPTION
Remove top and bottom margin for hidden checklist items, otherwise there could
be a gap between unchecked items if multiple hidden/checked items were between
them.

## Without the changes:
![Screenshot from 2020-06-14 21-41-15](https://user-images.githubusercontent.com/12081346/84602458-f0ae6380-ae87-11ea-8104-cbf63da846f0.png)

## With the changes:
![Screenshot from 2020-06-14 21-41-20](https://user-images.githubusercontent.com/12081346/84602461-f310bd80-ae87-11ea-9ff0-ce8ff8a78b4a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3172)
<!-- Reviewable:end -->
