### PR TITLE
Alignment and spacing of minicard labels

### DIFF
--- a/client/components/cards/minicard.styl
+++ b/client/components/cards/minicard.styl
@@ -87,7 +87,9 @@
       width: 11px
       height: @width
       border-radius: 2px
-      margin-left: 3px
+      margin-right: 3px
+      margin-bottom: 3px
+      
   .minicard-custom-fields
     display:block;
   .minicard-custom-field


### PR DESCRIPTION
Change alignment and spacing of tag labels for cards when "Hide minicard label text" is enabled.

<img width="555" alt="screenshot" src="https://user-images.githubusercontent.com/3796374/84687107-2b0d1480-af0b-11ea-8767-3ad8029ff788.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3174)
<!-- Reviewable:end -->
