### PR TITLE
Checklist Item PUT API: boolean cast on isFinished

### DIFF
--- a/models/checklistItems.js
+++ b/models/checklistItems.js
@@ -302,10 +302,18 @@ if (Meteor.isServer) {
 
       const paramItemId = req.params.itemId;
 
+      function isTrue(data) {
+        try {
+          return data.toLowerCase() === 'true';
+        } catch (error) {
+          return data;
+        }
+      }
+
       if (req.body.hasOwnProperty('isFinished')) {
         ChecklistItems.direct.update(
           { _id: paramItemId },
-          { $set: { isFinished: req.body.isFinished } },
+          { $set: { isFinished: isTrue(req.body.isFinished) } },
         );
       }
       if (req.body.hasOwnProperty('title')) {


### PR DESCRIPTION
With this PR I fix a BUG that prevents any update on isFinished flag of a checklist item via API.
I simply copied the isTrue() function from others API as It should work fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3211)
<!-- Reviewable:end -->
