### PR TITLE
bump: mongodb -> 3.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "markdown-it": "^11.0.0",
     "markdown-it-emoji": "^1.4.0",
     "meteor-node-stubs": "^1.0.1",
-    "mongodb": "^3.5.7",
+    "mongodb": "^3.6.2",
     "os": "^0.1.1",
     "page": "^1.11.5",
     "papaparse": "^5.2.0",


### PR DESCRIPTION
https://github.com/mongodb/node-mongodb-native/releases

Unfortunately this doesn't bump the transient dependency on `mongodb` of `gridfs-stream`, see: https://github.com/aheckmann/gridfs-stream/pull/150 :confused: 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3268)
<!-- Reviewable:end -->
