### PR TITLE
Update oidc_server.js

### DIFF
--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -9,7 +9,20 @@ OAuth.registerService('oidc', 2, null, function (query) {
   var accessToken = token.access_token || token.id_token;
   var expiresAt = (+new Date) + (1000 * parseInt(token.expires_in, 10));
 
-  var userinfo = getUserInfo(accessToken);
+  var claimsInAccessToken = process.env.OAUTH2_ADFS || false; 
+  
+  var userinfo; 
+  if(claimsInAccessToken)
+  {
+    // hack when using custom claims in the accessToken. On premise ADFS
+    userinfo = getTokenContent(accessToken);
+  }
+  else
+  {
+    // normal behaviour, getting the claims from UserInfo endpoint.
+    userinfo = getUserInfo(accessToken);
+  }
+  
   if (userinfo.ocs) userinfo = userinfo.ocs.data; // Nextcloud hack
   if (userinfo.metadata) userinfo = userinfo.metadata // Openshift hack
   if (debug) console.log('XXX: userinfo:', userinfo);


### PR DESCRIPTION
added hack for getting the claims in the accessToken instead of the /adfs/oauth2/userinfo endpoint 

https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-faq#i-am-trying-to-get-additional-claims-on-the-user-info-endpoint-but-its-only-returning-subject-how-can-i-get-additional-claims

Environment variable needed set
OAUTH2_ADFS=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3269)
<!-- Reviewable:end -->
