### PR TITLE
fix: expose moving cards on mobile to workers

### DIFF
--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -381,17 +381,18 @@ template(name="cardDetailsActionsPopup")
         a.js-move-card-to-bottom
           i.fa.fa-arrow-down
           | {{_ 'moveCardToBottom-title'}}
-    unless currentUser.isWorker
       hr
-      ul.pop-over-list
-        li
-          a.js-move-card
-            i.fa.fa-arrow-right
-            | {{_ 'moveCardPopup-title'}}
+    ul.pop-over-list
+      li
+        a.js-move-card
+          i.fa.fa-arrow-right
+          | {{_ 'moveCardPopup-title'}}
+      unless currentUser.isWorker
         li
           a.js-copy-card
             i.fa.fa-copy
             | {{_ 'copyCardPopup-title'}}
+    unless currentUser.isWorker
       hr
       ul.pop-over-list
         li
@@ -430,13 +431,14 @@ template(name="copyChecklistToManyCardsPopup")
   +boardsAndLists
 
 template(name="boardsAndLists")
-  label {{_ 'boards'}}:
-  select.js-select-boards(autofocus)
-    each boards
-      if $eq _id currentBoard._id
-        option(value="{{_id}}" selected) {{_ 'current'}}
-      else
-        option(value="{{_id}}") {{title}}
+  unless currentUser.isWorker
+    label {{_ 'boards'}}:
+    select.js-select-boards(autofocus)
+      each boards
+        if $eq _id currentBoard._id
+          option(value="{{_id}}" selected) {{_ 'current'}}
+        else
+          option(value="{{_id}}") {{title}}
 
   label {{_ 'swimlanes'}}:
   select.js-select-swimlanes


### PR DESCRIPTION
this fix also hides the move to another board functionality in the
submenu (only from the worker) so that the worker is still constrained
to a single board.


see issue #3314

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3315)
<!-- Reviewable:end -->
