### PR TITLE
fix: use current boardId when a worker moves a card

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -668,7 +668,11 @@ Template.moveCardPopup.events({
     // instead from a “component” state.
     const card = Cards.findOne(Session.get('currentCard'));
     const bSelect = $('.js-select-boards')[0];
-    const boardId = bSelect.options[bSelect.selectedIndex].value;
+    let boardId;
+    // if we are a worker, we won't have a board select so we just use the
+    // current boardId of the card.
+    if (bSelect) boardId = bSelect.options[bSelect.selectedIndex].value;
+    else boardId = card.boardId;
     const lSelect = $('.js-select-lists')[0];
     const listId = lSelect.options[lSelect.selectedIndex].value;
     const slSelect = $('.js-select-swimlanes')[0];


### PR DESCRIPTION
@xet7 

sorry about the second PR...

My previous change that revealed the move card menu functionality to a worker was broken because the worker didn't have a board select from which to retrieve the `boardId`... this fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3323)
<!-- Reviewable:end -->
