### PR TITLE
fix(oidc): wekan/wekan#3299

### DIFF
--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -1,4 +1,15 @@
 Oidc = {};
+httpCa = false;
+
+if (process.env.OAUTH2_CA_CERT !== undefined) {
+    try {
+        const fs = Npm.require('fs');
+	httpCa = fs.readFileSync(process.env.OAUTH2_CA_CERT);
+    } catch(e) {
+	console.log('WARNING: failed loading: ' + process.env.OAUTH2_CA_CERT);
+	console.log(e);
+    }
+}
 
 OAuth.registerService('oidc', 2, null, function (query) {
 
@@ -86,9 +97,7 @@ if (process.env.ORACLE_OIM_ENABLED !== 'true' && process.env.ORACLE_OIM_ENABLED 
     var response;
 
     try {
-      response = HTTP.post(
-        serverTokenEndpoint,
-        {
+      var postOptions = {
           headers: {
             Accept: 'application/json',
             "User-Agent": userAgent
@@ -101,8 +110,11 @@ if (process.env.ORACLE_OIM_ENABLED !== 'true' && process.env.ORACLE_OIM_ENABLED 
             grant_type: 'authorization_code',
             state: query.state
           }
-        }
-      );
+        };
+      if (httpCa) {
+	postOptions['npmRequestOptions'] = { ca: httpCa };
+      }
+      response = HTTP.post(serverTokenEndpoint, postOptions);
     } catch (err) {
       throw _.extend(new Error("Failed to get token from OIDC " + serverTokenEndpoint + ": " + err.message),
         { response: err.response });
@@ -143,9 +155,7 @@ if (process.env.ORACLE_OIM_ENABLED === 'true' || process.env.ORACLE_OIM_ENABLED 
     if (debug) console.log('Basic Token: ', strBasicToken64);
 
     try {
-      response = HTTP.post(
-        serverTokenEndpoint,
-        {
+      var postOptions = {
           headers: {
             Accept: 'application/json',
             "User-Agent": userAgent,
@@ -159,8 +169,11 @@ if (process.env.ORACLE_OIM_ENABLED === 'true' || process.env.ORACLE_OIM_ENABLED 
             grant_type: 'authorization_code',
             state: query.state
           }
-        }
-      );
+        };
+      if (httpCa) {
+	postOptions['npmRequestOptions'] = { ca: httpCa };
+      }
+      response = HTTP.post(serverTokenEndpoint, postOptions);
     } catch (err) {
       throw _.extend(new Error("Failed to get token from OIDC " + serverTokenEndpoint + ": " + err.message),
         { response: err.response });
@@ -188,15 +201,16 @@ var getUserInfo = function (accessToken) {
   }
   var response;
   try {
-    response = HTTP.get(
-      serverUserinfoEndpoint,
-      {
+    var getOptions = {
         headers: {
           "User-Agent": userAgent,
           "Authorization": "Bearer " + accessToken
         }
-      }
-    );
+      };
+    if (httpCa) {
+      getOptions['npmRequestOptions'] = { ca: httpCa };
+    }
+    response = HTTP.get(serverUserinfoEndpoint, getOptions);
   } catch (err) {
     throw _.extend(new Error("Failed to fetch userinfo from OIDC " + serverUserinfoEndpoint + ": " + err.message),
                    {response: err.response});


### PR DESCRIPTION
FYI, this commit is based on the following:

[wekan-oidc.js.txt](https://github.com/wekan/wekan/files/5471644/wekan-oidc.js.txt)

File above was tested against a 4.46. LemonLDAP-NG as Oauth2 server, certificate signed by a custom CA.

The `OAUTH2_CA_CERT` env var may be set, pointing to a CA file. If unset, the default would be to use NodeJS default trust store.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3325)
<!-- Reviewable:end -->
