### PR TITLE
ldap: sync email address

### DIFF
--- a/packages/wekan-ldap/server/sync.js
+++ b/packages/wekan-ldap/server/sync.js
@@ -247,6 +247,22 @@ export function syncUserData(user, ldapUser) {
     }
   }
 
+  if (LDAP.settings_get('LDAP_EMAIL_FIELD') !== '') {
+    const email = getLdapEmail(ldapUser);
+    log_debug('email=', email);
+
+    if (user && user._id && email !== '') {
+      log_info('Syncing user email:', email);
+      Meteor.users.update({
+        _id: user._id
+      }, {
+        $set: {
+          'emails.0.address': email,
+        }
+      });
+    }
+  }
+
 }
 
 export function addLdapUser(ldapUser, username, password) {


### PR DESCRIPTION
The periodic sync cron currently only syncs the username and full name from LDAP. With this change. the email address is synced as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3329)
<!-- Reviewable:end -->
