### PR TITLE
Drag handle checklistitem

### DIFF
--- a/client/components/cards/checklists.jade
+++ b/client/components/cards/checklists.jade
@@ -103,6 +103,8 @@ template(name='checklistItemDetail')
       .check-box-container
         .check-box.materialCheckBox(class="{{#if item.isFinished }}is-checked{{/if}}")
       .item-title.js-open-inlined-form.is-editable(class="{{#if item.isFinished }}is-checked{{/if}}")
+        if isMiniScreenOrShowDesktopDragHandles
+          span.fa.checklistitem-handle(class="fa-arrows" title="{{_ 'dragChecklistItem'}}")
         +viewer
           = item.title
     else

--- a/client/components/cards/checklists.js
+++ b/client/components/cards/checklists.js
@@ -58,8 +58,14 @@ BlazeComponent.extendComponent({
         $(self.itemsDom).sortable(
           'option',
           'disabled',
-          !userIsMember() || Utils.isMiniScreen(),
+          !userIsMember(),
         );
+        if (Utils.isMiniScreenOrShowDesktopDragHandles()) {
+          $(self.itemsDom).sortable({
+            handle: 'span.fa.checklistitem-handle',
+            appendTo: 'parent',
+          });
+        }
       }
     });
   },

--- a/client/components/cards/checklists.styl
+++ b/client/components/cards/checklists.styl
@@ -156,6 +156,9 @@ textarea.js-add-checklist-item, textarea.js-edit-checklist-item
         word-wrap: break-word
         max-width: 420px
 
+  span.fa.checklistitem-handle
+    float: right
+
 .js-delete-checklist-item
   margin: 0 0 0.5em 1.33em
   @extends .delete-text


### PR DESCRIPTION
Add drag handles for checklist items.

At desktop version with enabled drag handles it works fine at checklist items, but in mobile view i get an javascript error in the file mquandalle_jquery-ui-drag-drop-sort.js

![grafik](https://user-images.githubusercontent.com/13166201/98746190-47778500-23b5-11eb-98cd-b75282e6ed0a.png)

Does anyone have an idea about the error at mobile view? Is it an error at the third-party library or an error at jade / html ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3342)
<!-- Reviewable:end -->
