### PR TITLE
Missing bottom padding on lists

### DIFF
--- a/client/components/main/layouts.styl
+++ b/client/components/main/layouts.styl
@@ -388,10 +388,12 @@ a
   ol
     list-style-type: decimal
     padding-left: 20px
+    padding-bottom: 10px
 
   ul
     list-style-type: initial
     padding-left: 20px
+    padding-bottom: 10px
 
   em
     font-style : italic


### PR DESCRIPTION
Hi again,

I'm adding some padding to the bottom of the list (ul & ol), much better, see results below!

Before:
![before](https://user-images.githubusercontent.com/628926/99155492-988ac000-26b8-11eb-9d50-a276f33b2604.png)

After (result):
![after](https://user-images.githubusercontent.com/628926/99155494-99bbed00-26b8-11eb-8512-fa59339a2a46.png)

I hope you like it as well!

Regards,
Melroy van den Berg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3351)
<!-- Reviewable:end -->
