### PR TITLE
Helm: Introduce secretEnv for secret value provisioning

### DIFF
--- a/helm/wekan/Chart.yaml
+++ b/helm/wekan/Chart.yaml
@@ -1,5 +1,5 @@
 name: wekan
-version: 1.0.1
+version: 1.0.2
 apiVersion: v1
 description: Open Source kanban
 home: https://wekan.github.io/

--- a/helm/wekan/templates/deployment.yaml
+++ b/helm/wekan/templates/deployment.yaml
@@ -43,6 +43,12 @@ spec:
               value: {{ .value | quote }}
           {{- end }}
           {{- end }}
+          {{- range $key := .Values.secretEnv }}
+          {{- if .value }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm/wekan/values.yaml
+++ b/helm/wekan/values.yaml
@@ -28,6 +28,14 @@ env:
   - name: ""
     value: ""
 
+## Specify additional secret environmental variables for the
+## Deployment. These can e.g. be provided by a Secret and allow
+## to store passwords separately
+##
+secretEnv:
+  - name: ""
+    value: ""
+
 service:
   type: NodePort
   port: 8080


### PR DESCRIPTION
As lined out in #3381 this change allows to introduce environment variables from a second (possibly secret) source without lists being replaced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3382)
<!-- Reviewable:end -->
