### PR TITLE
Minicard, reduce space after assignees label

### DIFF
--- a/client/components/cards/minicard.jade
+++ b/client/components/cards/minicard.jade
@@ -85,7 +85,6 @@ template(name="minicard")
       .minicard-assignees.js-minicard-assignees
         each getAssignees
           +userAvatar(userId=this)
-        hr
 
     if getMembers
       .minicard-members.js-minicard-members

--- a/client/components/cards/minicard.styl
+++ b/client/components/cards/minicard.styl
@@ -165,7 +165,7 @@
   .minicard-members,
   .minicard-assignees
     float: right
-    margin: 2px -8px 12px 0
+    margin: 2px -8px 2px 0
 
     .member
       float: right


### PR DESCRIPTION
I saw that there is a lot of space after the assignees label on the minicard if an assignee is set.

Before:
![grafik](https://user-images.githubusercontent.com/13166201/101514626-c5f82000-397d-11eb-993f-aad87319b848.png)

After:
![grafik](https://user-images.githubusercontent.com/13166201/101514724-e1632b00-397d-11eb-80ac-30cacf25c36b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3385)
<!-- Reviewable:end -->
