### PR TITLE
Fix issues when duplicating board

### DIFF
--- a/models/import.js
+++ b/models/import.js
@@ -42,9 +42,23 @@ Meteor.methods({
     check(currentBoardId, Match.Maybe(String));
     const exporter = new Exporter(sourceBoardId);
     const data = exporter.build();
-    const addData = {};
-    addData.membersMapping = getMembersToMap(data);
-    const creator = new WekanCreator(addData);
+    const additionalData = {};
+
+    //get the members to map
+    const membersMapping = getMembersToMap(data);
+
+    //now mirror the mapping done in finishImport in client/components/import/import.js:
+    if (membersMapping) {
+      const mappingById = {};
+      membersMapping.forEach(member => {
+        if (member.wekanId) {
+          mappingById[member.id] = member.wekanId;
+        }
+      });
+      additionalData.membersMapping = mappingById;
+    }
+
+    const creator = new WekanCreator(additionalData);
     //data.title = `${data.title  } - ${  TAPi18n.__('copy-tag')}`;
     data.title = `${data.title}`;
     return creator.create(data, currentBoardId);

--- a/models/wekanCreator.js
+++ b/models/wekanCreator.js
@@ -355,6 +355,25 @@ export class WekanCreator {
           cardToCreate.members = wekanMembers;
         }
       }
+      // add assignees
+      if (card.assignees) {
+        const wekanAssignees = [];
+        // we can't just map, as some members may not have been mapped
+        card.assignees.forEach(sourceMemberId => {
+          if (this.members[sourceMemberId]) {
+            const wekanId = this.members[sourceMemberId];
+            // we may map multiple Wekan members to the same wekan user
+            // in which case we risk adding the same user multiple times
+            if (!wekanAssignees.find(wId => wId === wekanId)) {
+              wekanAssignees.push(wekanId);
+            }
+          }
+          return true;
+        });
+        if (wekanAssignees.length > 0) {
+          cardToCreate.assignees = wekanAssignees;
+        }
+      }
       // set color
       if (card.color) {
         cardToCreate.color = card.color;


### PR DESCRIPTION
Fixes the following issues when cloning/importing a board as listed in #3336 :
- Custom fields missing in board and on cards
- Member assignments missing on cards
- Assignee assignments missing on cards
- Subtask/Parent task missing on cards
  - Note: this only fixes scenarios that are possible with the current subtask structure:
    - Cloning boards within the same instance 
    - Importing a backup into the same instance
    - Importing boards where parent and child task board are the same
  - That means, if you have a separate parent and child task board and you import them, the connection between parent and subtask will be lost. There is no way around this the way the importer and subtasks currently work, because card IDs change once the first board is imported, and there is no (good) way to map once you import the second board. 

I could not reproduce the issues with comments and checklist items described in https://github.com/wekan/wekan/issues/3336#issuecomment-728798212 
Both comments and checklist items work correctly when duplicating and when importing on Wekan 4.57 
Happy to provide a fix in a separate PR if someone can provide a repro of the bug. 

Closes #3336

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3387)
<!-- Reviewable:end -->
