### PR TITLE
Fix not all checklist items being imported/cloned

### DIFF
--- a/models/wekanCreator.js
+++ b/models/wekanCreator.js
@@ -716,18 +716,24 @@ export class WekanCreator {
 
   createChecklistItems(wekanChecklistItems) {
     wekanChecklistItems.forEach((checklistitem, checklistitemIndex) => {
-      // Create the checklistItem
-      const checklistItemTocreate = {
-        title: checklistitem.title,
-        checklistId: this.checklists[checklistitem.checklistId],
-        cardId: this.cards[checklistitem.cardId],
-        sort: checklistitem.sort ? checklistitem.sort : checklistitemIndex,
-        isFinished: checklistitem.isFinished,
-      };
-      const checklistItemId = ChecklistItems.direct.insert(
-        checklistItemTocreate,
-      );
-      this.checklistItems[checklistitem._id] = checklistItemId;
+      //Check if the checklist for this item (still) exists
+      //If a checklist was deleted, but items remain, the import would error out here
+      //Leading to no further checklist items being imported
+      if (this.checklists[checklistitem.checklistId]) {
+        // Create the checklistItem
+        const checklistItemTocreate = {
+          title: checklistitem.title,
+          checklistId: this.checklists[checklistitem.checklistId],
+          cardId: this.cards[checklistitem.cardId],
+          sort: checklistitem.sort ? checklistitem.sort : checklistitemIndex,
+          isFinished: checklistitem.isFinished,
+        };
+
+        const checklistItemId = ChecklistItems.direct.insert(
+          checklistItemTocreate,
+        );
+        this.checklistItems[checklistitem._id] = checklistItemId;
+      }
     });
   }
 


### PR DESCRIPTION
Closes #3388

`createChecklistItems` now skips the import of "dangling" checklist items that belong to an already deleted checklist.
Before it would crash when hitting a parentless checklist item, and therefore all further checklist items would not be imported

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3389)
<!-- Reviewable:end -->
