### PR TITLE
Treat unknown attachment types as binary on board import/clone

### DIFF
--- a/models/wekanCreator.js
+++ b/models/wekanCreator.js
@@ -474,6 +474,12 @@ export class WekanCreator {
                 }
               });
             } else if (att.file) {
+              //If attribute type is null or empty string is set, assume binary stream
+              att.type =
+                !att.type || att.type.trim().length === 0
+                  ? 'application/octet-stream'
+                  : att.type;
+
               file.attachData(
                 Buffer.from(att.file, 'base64'),
                 {


### PR DESCRIPTION
Fixes missing attachments and comments when importing/cloning a board that contains attachments without mime type (e.g. Java .class files and presumably other binary files).

Fixes the issue described in https://github.com/wekan/wekan/issues/3336#issuecomment-746273612

Note regarding #3336: there might be additional issues with comments that are unrelated to attachments, I will provide a separate PR if reporter @lezioul finds further errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3395)
<!-- Reviewable:end -->
