### PR TITLE
Dark theme button background fix

### DIFF
--- a/client/components/boards/boardColors.styl
+++ b/client/components/boards/boardColors.styl
@@ -15,7 +15,8 @@ setBoardColor(color)
   .is-selected .minicard
     border-left: 3px solid color
 
-  button[type=submit].primary, input[type=submit].primary
+  button[type=submit].primary, input[type=submit].primary,
+  .sidebar .sidebar-content .sidebar-btn
     background-color: darken(color, 20%)
 
   &.pop-over .pop-over-list li a:not(.disabled):hover,


### PR DESCRIPTION
Steps to find problem:
1) Switch to Dark theme.
2) Click on Multi-Selection
3) Note that the "Move Selection" and "Move Selection to Archive" buttons are unreadable until you hover over them.

This small change will make the buttons readable while preserving the visual hover behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3401)
<!-- Reviewable:end -->
