### PR TITLE
Checklist Mini-Screen, appendTo: 'parent' not necessary anymore

### DIFF
--- a/client/components/cards/checklists.js
+++ b/client/components/cards/checklists.js
@@ -59,7 +59,6 @@ BlazeComponent.extendComponent({
         if (Utils.isMiniScreenOrShowDesktopDragHandles()) {
           $(self.itemsDom).sortable({
             handle: 'span.fa.checklistitem-handle',
-            appendTo: 'parent',
           });
         }
       }


### PR DESCRIPTION
- obsolete since commit c7808c5c03f98eae709e5ef89e8e17af4689cb2e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3405)
<!-- Reviewable:end -->
