### PR TITLE
Swimlane + and = Icons resized for better handling at mobile view

### DIFF
--- a/client/components/swimlanes/swimlaneHeader.jade
+++ b/client/components/swimlanes/swimlaneHeader.jade
@@ -17,12 +17,11 @@ template(name="swimlaneFixedHeader")
     unless currentUser.isCommentOnly
       if currentUser.isBoardAdmin
         a.fa.fa-plus.js-open-add-swimlane-menu.swimlane-header-plus-icon
-        a.fa.fa-navicon.js-open-swimlane-menu
-      unless isMiniScreen
-        if showDesktopDragHandles
-          a.swimlane-header-handle.handle.fa.fa-arrows.js-swimlane-header-handle
-      if isMiniScreen
+        a.fa.fa-navicon.js-open-swimlane-menu.swimlane-header-menu-icon
+      if isMiniScreenOrShowDesktopDragHandles
         a.swimlane-header-miniscreen-handle.handle.fa.fa-arrows.js-swimlane-header-handle
+      else
+        a.swimlane-header-handle.handle.fa.fa-arrows.js-swimlane-header-handle
 
 template(name="editSwimlaneTitleForm")
   .list-composer

--- a/client/components/swimlanes/swimlanes.styl
+++ b/client/components/swimlanes/swimlanes.styl
@@ -88,7 +88,12 @@
 
     .swimlane-header-plus-icon
       margin-left: 5px
-      margin-right: 10px
+      padding-right: 20px
+      font-size: 22px
+
+    .swimlane-header-menu-icon
+      padding-right: 20px
+      font-size: 22px
 
     .swimlane-header-handle
       position: absolute


### PR DESCRIPTION
Suggestion of @xet7 at this comment:
https://github.com/wekan/wekan/issues/3402#issuecomment-751704203

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3412)
<!-- Reviewable:end -->
