### PR TITLE
Cards, custom fields are displayed in alphabetic order

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -650,7 +650,7 @@ Cards.helpers({
 
     // match right definition to each field
     if (!this.customFields) return [];
-    return this.customFields.map(customField => {
+    let ret = this.customFields.map(customField => {
       const definition = definitions.find(definition => {
         return definition._id === customField._id;
       });
@@ -676,6 +676,8 @@ Cards.helpers({
         definition,
       };
     });
+    ret.sort((a, b) => a.definition.name.localeCompare(b.definition.name));
+    return ret;
   },
 
   colorClass() {


### PR DESCRIPTION
- until now the order is undefined, it's different from card to card,
  it's the order in which the custom fields were added to the card.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3417)
<!-- Reviewable:end -->
