### PR TITLE
Use multi stage build based on Node images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,42 @@
-FROM quay.io/wekan/ubuntu:groovy-20201125.2
+FROM node:12 AS builder
+# This is our builder image. It will take the Wekan meteor code and
+# build it into a standalone NodeJS package
+
 LABEL maintainer="wekan"
 
-# 2020-12-03:
-# - Above Ubuntu base image copied from Docker Hub ubuntu:groovy-20201125.2
-#   to Quay to avoid Docker Hub rate limits.
+# Allow Meteor to run inside the container as container runs as root
+ENV METEOR_ALLOW_SUPERUSER=true
 
-# Set the environment variables (defaults where required)
-# DOES NOT WORK: paxctl fix for alpine linux: https://github.com/wekan/wekan/issues/1303
-# ENV BUILD_DEPS="paxctl"
-ARG DEBIAN_FRONTEND=noninteractive
+# Copy our source code into the container
+COPY . /usr/src/app
 
-ENV BUILD_DEPS="apt-utils libarchive-tools gnupg gosu wget curl bzip2 g++ build-essential git ca-certificates python3" \
-    DEBUG=false \
-    NODE_VERSION=v12.20.1 \
-    METEOR_RELEASE=1.10.2 \
-    USE_EDGE=false \
-    METEOR_EDGE=1.5-beta.17 \
-    NPM_VERSION=latest \
-    FIBERS_VERSION=4.0.1 \
-    ARCHITECTURE=linux-x64 \
-    SRC_PATH=./ \
-    WITH_API=true \
+# Allow the user accounts package to work with more Meteor versions
+RUN sed -i 's/api\.versionsFrom/\/\/api.versionsFrom/' /usr/src/app/packages/meteor-useraccounts-core/package.js
+
+# Move our current working directory
+WORKDIR /usr/src/app
+
+# Install our NPM packages
+RUN npm install
+
+# Install Meteor
+RUN curl "https://install.meteor.com/" | sh
+
+# Build our Meteor package into a standalone NodeJS package
+RUN meteor build --directory /build
+
+# Include the fix for CFS
+RUN cp /usr/src/app/fix-download-unicode/cfs_access-point.txt /build/bundle/programs/server/packages/cfs_access-point.js
+
+# Remove the legacy web browser bundle, so that Wekan works in Android Firefox, iOS Safari, etc.
+RUN rm -rf /build/bundle/programs/web.browser.legacy
+
+
+FROM node:12-slim as app
+# This is our runtime image. It takes the built NodeJS package and runs it using
+# the lighter Alpine NodeJS base image to keep image size down
+
+ENV WITH_API=true \
     ACCOUNTS_LOCKOUT_KNOWN_USERS_FAILURES_BEFORE=3 \
     ACCOUNTS_LOCKOUT_KNOWN_USERS_PERIOD=60 \
     ACCOUNTS_LOCKOUT_KNOWN_USERS_FAILURE_WINDOW=15 \
@@ -138,182 +154,19 @@ ENV BUILD_DEPS="apt-utils libarchive-tools gnupg gosu wget curl bzip2 g++ build-
     SAML_ATTRIBUTES="" \
     ORACLE_OIM_ENABLED=false
 
-# Copy the app to the image
-COPY ${SRC_PATH} /home/wekan/app
+# Copy our built NodeJS package to this image
+COPY --from=builder /build/bundle /bundle
 
-RUN \
-    set -o xtrace && \
-    # Add non-root user wekan
-    useradd --user-group --system --home-dir /home/wekan wekan && \
-    \
-    # OS dependencies
-    apt-get update -y && apt-get install -y --no-install-recommends ${BUILD_DEPS} && \
-    #pip3 install -U pip setuptools wheel && \
-    \
-    # Meteor installer doesn't work with the default tar binary, so using bsdtar while installing.
-    # https://github.com/coreos/bugs/issues/1095#issuecomment-350574389
-    cp $(which tar) $(which tar)~ && \
-    ln -sf $(which bsdtar) $(which tar) && \
-    \
-    # Download nodejs
-    wget https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
-    wget https://nodejs.org/dist/${NODE_VERSION}/SHASUMS256.txt.asc && \
-    #---------------------------------------------------------------------------------------------
-    # Node Fibers 100% CPU usage issue:
-    # https://github.com/wekan/wekan-mongodb/issues/2#issuecomment-381453161
-    # https://github.com/meteor/meteor/issues/9796#issuecomment-381676326
-    # https://github.com/sandstorm-io/sandstorm/blob/0f1fec013fe7208ed0fd97eb88b31b77e3c61f42/shell/server/00-startup.js#L99-L129
-    # Also see beginning of wekan/server/authentication.js
-    #   import Fiber from "fibers";
-    #   Fiber.poolSize = 1e9;
-    # OLD: Download node version 8.12.0 prerelease that has fix included, => Official 8.12.0 has been released
-    # Description at https://releases.wekan.team/node.txt
-    #wget https://releases.wekan.team/node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
-    #echo "1ed54adb8497ad8967075a0b5d03dd5d0a502be43d4a4d84e5af489c613d7795  node-v8.12.0-linux-x64.tar.gz" >> SHASUMS256.txt.asc && \
-    \
-    # Verify nodejs authenticity
-    grep ${NODE_VERSION}-${ARCHITECTURE}.tar.gz SHASUMS256.txt.asc | shasum -a 256 -c - && \
-    #export GNUPGHOME="$(mktemp -d)" && \
-    #\
-    # Try other key servers if ha.pool.sks-keyservers.net is unreachable
-    # Code from https://github.com/chorrell/docker-node/commit/2b673e17547c34f17f24553db02beefbac98d23c
-    # gpg keys listed at https://github.com/nodejs/node#release-team
-    # and keys listed here from previous version of this Dockerfile
-    #for key in \
-    #9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    #94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    #FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    #71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    #DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    #C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    #B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    #; do \
-    #gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    #gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    #gpg --keyserver keyserver.pgp.com --recv-keys "$key" ; \
-    #done && \
-    #gpg --verify SHASUMS256.txt.asc && \
-    # Ignore socket files then delete files then delete directories
-    #find "$GNUPGHOME" -type f | xargs rm -f && \
-    #find "$GNUPGHOME" -type d | xargs rm -fR && \
-    rm -f SHASUMS256.txt.asc && \
-    \
-    # Install Node
-    tar xvzf node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
-    rm node-${NODE_VERSION}-${ARCHITECTURE}.tar.gz && \
-    mv node-${NODE_VERSION}-${ARCHITECTURE} /opt/nodejs && \
-    ln -s /opt/nodejs/bin/node /usr/bin/node && \
-    ln -s /opt/nodejs/bin/npm /usr/bin/npm && \
-    mkdir -p /opt/nodejs/lib/node_modules/fibers/.node-gyp /root/.node-gyp/8.16.1 /home/wekan/.config && \
-    chown wekan --recursive /home/wekan/.config && \
-    \
-    #DOES NOT WORK: paxctl fix for alpine linux: https://github.com/wekan/wekan/issues/1303
-    #paxctl -mC `which node` && \
-    \
-    # Install Node dependencies. Python path for node-gyp.
-    npm install -g npm@${NPM_VERSION} && \
-    #npm config set python python2.7 && \
-    #npm install -g node-gyp && \
-    #npm install -g fibers@${FIBERS_VERSION} && \
-    \
-    # Change user to wekan and install meteor
-    cd /home/wekan/ && \
-    chown wekan --recursive /home/wekan && \
-    #curl "https://install.meteor.com" -o /home/wekan/install_meteor.sh && \
-    #curl "https://install.meteor.com/?release=${METEOR_RELEASE}" -o /home/wekan/install_meteor.sh && \
-    # OLD: sed -i "s|RELEASE=.*|RELEASE=${METEOR_RELEASE}\"\"|g" ./install_meteor.sh && \
-    # Install Meteor forcing its progress
-    #sed -i 's/VERBOSITY="--silent"/VERBOSITY="--progress-bar"/' ./install_meteor.sh && \
-    echo "Starting meteor ${METEOR_RELEASE} installation...   \n" && \
-    gosu wekan:wekan curl https://install.meteor.com/ | /bin/sh && \
-    mv /root/.meteor /home/wekan/ && \
-    chown wekan --recursive /home/wekan/.meteor && \
-    \
-    # Check if opting for a release candidate instead of major release
-    #if [ "$USE_EDGE" = false ]; then \
-      #gosu wekan:wekan sh /home/wekan/install_meteor.sh; \
-    #  gosu wekan:wekan curl https://install.meteor.com/ | sh; \
-    #else \
-    #  gosu wekan:wekan git clone --recursive --depth 1 -b release/METEOR@${METEOR_EDGE} https://github.com/meteor/meteor.git /home/wekan/.meteor; \
-    #fi; \
-    #\
-    # Get additional packages
-    #mkdir -p /home/wekan/app/packages && \
-    #chown wekan:wekan --recursive /home/wekan && \
-    # REPOS BELOW ARE INCLUDED TO WEKAN REPO
-    #cd /home/wekan/app/packages && \
-    #gosu wekan:wekan git clone --depth 1 -b master https://github.com/wekan/flow-router.git kadira-flow-router && \
-    #gosu wekan:wekan git clone --depth 1 -b master https://github.com/meteor-useraccounts/core.git meteor-useraccounts-core && \
-    #gosu wekan:wekan git clone --depth 1 -b master https://github.com/wekan/meteor-accounts-cas.git && \
-    #gosu wekan:wekan git clone --depth 1 -b master https://github.com/wekan/wekan-ldap.git && \
-    #gosu wekan:wekan git clone --depth 1 -b master https://github.com/wekan/wekan-scrollbar.git && \
-    #gosu wekan:wekan git clone --depth 1 -b master https://github.com/wekan/meteor-accounts-oidc.git && \
-    #gosu wekan:wekan git clone --depth 1 -b master --recurse-submodules https://github.com/wekan/markdown.git && \
-    #gosu wekan:wekan mv meteor-accounts-oidc/packages/switch_accounts-oidc wekan-accounts-oidc && \
-    #gosu wekan:wekan mv meteor-accounts-oidc/packages/switch_oidc wekan-oidc && \
-    #gosu wekan:wekan rm -rf meteor-accounts-oidc && \
-    sed -i 's/api\.versionsFrom/\/\/api.versionsFrom/' /home/wekan/app/packages/meteor-useraccounts-core/package.js && \
-    cd /home/wekan/.meteor && \
-    gosu wekan:wekan /home/wekan/.meteor/meteor -- help; \
-    \
-    # extract the OpenAPI specification
-    #npm install -g api2html@0.3.3 && \
-    #mkdir -p /home/wekan/python && \
-    #chown wekan --recursive /home/wekan/python && \
-    #cd /home/wekan/python && \
-    #gosu wekan:wekan git clone --depth 1 -b master https://github.com/Kronuz/esprima-python && \
-    #cd /home/wekan/python/esprima-python && \
-    #python3 setup.py install --record files.txt && \
-    #cd /home/wekan/app && \
-    #mkdir -p /home/wekan/app/public/api && \
-    #chown wekan --recursive /home/wekan/app && \
-    #gosu wekan:wekan python3 ./openapi/generate_openapi.py --release $(git describe --tags --abbrev=0) > ./public/api/wekan.yml && \
-    #gosu wekan:wekan /opt/nodejs/bin/api2html -c ./public/logo-header.png -o ./public/api/wekan.html ./public/api/wekan.yml; \
-    # Build app
-    cd /home/wekan/app && \
-    mkdir -p /home/wekan/.npm && \
-    chown wekan --recursive /home/wekan/.npm /home/wekan/.config /home/wekan/.meteor && \
-    #gosu wekan:wekan /home/wekan/.meteor/meteor add standard-minifier-js && \
-    gosu wekan:wekan npm install && \
-    gosu wekan:wekan /home/wekan/.meteor/meteor build --directory /home/wekan/app_build && \
-    cp /home/wekan/app/fix-download-unicode/cfs_access-point.txt /home/wekan/app_build/bundle/programs/server/packages/cfs_access-point.js && \
-    #rm /home/wekan/app_build/bundle/programs/server/npm/node_modules/meteor/rajit_bootstrap3-datepicker/lib/bootstrap-datepicker/node_modules/phantomjs-prebuilt/lib/phantom/bin/phantomjs && \
-    chown wekan /home/wekan/app_build/bundle/programs/server/packages/cfs_access-point.js && \
-    #Removed binary version of bcrypt because of security vulnerability that is not fixed yet.
-    #https://github.com/wekan/wekan/commit/4b2010213907c61b0e0482ab55abb06f6a668eac
-    #https://github.com/wekan/wekan/commit/7eeabf14be3c63fae2226e561ef8a0c1390c8d3c
-    #cd /home/wekan/app_build/bundle/programs/server/npm/node_modules/meteor/npm-bcrypt && \
-    #gosu wekan:wekan rm -rf node_modules/bcrypt && \
-    #gosu wekan:wekan npm install bcrypt && \
-    #
-    # Delete phantomjs
-    #cd /home/wekan/app_build/bundle && \
-    #find . -name "*phantomjs*" | xargs rm -rf && \
-    #
-    cd /home/wekan/app_build/bundle/programs/server/ && \
-    gosu wekan:wekan npm install && \
-    #gosu wekan:wekan npm install bcrypt && \
-    # Remove legacy webbroser bundle, so that Wekan works also at Android Firefox, iOS Safari, etc.
-		rm -rf /home/wekan/app_build/bundle/programs/web.browser.legacy && \
-    mv /home/wekan/app_build/bundle /build && \
-    \
-    # Put back the original tar
-    mv $(which tar)~ $(which tar) && \
-    \
-    # Cleanup
-    apt-get remove --purge -y ${BUILD_DEPS} && \
-    apt-get autoremove -y && \
-    npm uninstall -g api2html &&\
-    rm -R /var/lib/apt/lists/* && \
-    rm -R /home/wekan/.meteor && \
-    rm -R /home/wekan/app && \
-    rm -R /home/wekan/app_build
-    #cat /home/wekan/python/esprima-python/files.txt | xargs rm -R && \
-    #rm -R /home/wekan/python
-    #rm /home/wekan/install_meteor.sh
+WORKDIR /bundle
+
+# Install server side NPM depedencies
+RUN cd programs/server/ && \
+    npm install
+
+# Install client side NPM dependencies
+#RUN npm install
 
 ENV PORT=8080
 EXPOSE $PORT
-USER wekan
 
-CMD ["node", "/build/main.js"]
+CMD ["node", "/bundle/main.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN meteor build --directory /build
 # Include the fix for CFS
 RUN cp /usr/src/app/fix-download-unicode/cfs_access-point.txt /build/bundle/programs/server/packages/cfs_access-point.js
 
+# Install server side NPM depedencies
+RUN cd /build/bundle/programs/server/ && \
+    npm install
+
 # Remove the legacy web browser bundle, so that Wekan works in Android Firefox, iOS Safari, etc.
 RUN rm -rf /build/bundle/programs/web.browser.legacy
 
@@ -159,14 +163,9 @@ COPY --from=builder /build/bundle /bundle
 
 WORKDIR /bundle
 
-# Install server side NPM depedencies
-RUN cd programs/server/ && \
-    npm install
-
-# Install client side NPM dependencies
-#RUN npm install
-
 ENV PORT=8080
 EXPOSE $PORT
+
+USER node
 
 CMD ["node", "/bundle/main.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,14 +131,6 @@ services:
     #build:
     #  context: .
     #  dockerfile: Dockerfile
-    #  args:
-    #    - NODE_VERSION=${NODE_VERSION}
-    #    - METEOR_RELEASE=${METEOR_RELEASE}
-    #    - NPM_VERSION=${NPM_VERSION}
-    #    - ARCHITECTURE=${ARCHITECTURE}
-    #    - SRC_PATH=${SRC_PATH}
-    #    - METEOR_EDGE=${METEOR_EDGE}
-    #    - USE_EDGE=${USE_EDGE}
     #-------------------------------------------------------------------------------------
     ports:
       # Docker outsideport:insideport. Do not add anything extra here.


### PR DESCRIPTION
I've re-written the Dockerfile to use the NodeJS base image and multi-stages to simplify the build-run process as well as removing all of the comments and commented-out old code.

I've done some brief benchmarking of the new Dockerfile compared to the old one (based on v4.79).

```
New build time: 6 minutes 55 seconds
Old build time: 8 minutes 32 seconds

New image size: 515MB
Old image size: 644MB.
```

It would be good to reduce the number of environment variables in the Dockerfile too but I didn't want to risk breaking things.

Closes #2762

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3438)
<!-- Reviewable:end -->
