### PR TITLE
Copy custom fields to new board

### DIFF
--- a/models/boards.js
+++ b/models/boards.js
@@ -518,6 +518,25 @@ Boards.helpers({
       swimlane.type = 'swimlane';
       swimlane.copy(_id);
     });
+
+    // copy custom field definitions
+    const cfMap = {};
+    CustomFields.find({ boardIds: oldId }).forEach(cf => {
+      const id = cf._id;
+      delete cf._id;
+      cf.boardIds = [_id];
+      cfMap[id] = CustomFields.insert(cf);
+    });
+    Cards.find({ boardId: _id }).forEach(card => {
+      Cards.update(card._id, {
+        $set: {
+          customFields: card.customFields.map(cf => {
+            cf._id = cfMap[cf._id];
+            return cf;
+          }),
+        },
+      });
+    });
   },
   /**
    * Is supplied user authorized to view this board?


### PR DESCRIPTION
Custom field definitions are not currently copied when copying a board.

This patch copies the custom field definitions for the new board and updates the cards to use the new definitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3451)
<!-- Reviewable:end -->
