### PR TITLE
Issue 2924: Rules not copied during board copy

### DIFF
--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -124,9 +124,13 @@ BlazeComponent.extendComponent({
         },
         'click .js-clone-board'(evt) {
           Meteor.call(
-            'cloneBoard',
+            'copyBoard',
             this.currentData()._id,
-            Session.get('fromBoard'),
+            {
+              sort: Boards.find({ archived: false }).count(),
+              type: 'board',
+              title: Boards.findOne(this.currentData()._id).copyTitle(),
+            },
             (err, res) => {
               if (err) {
                 this.setError(err.error);

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -675,12 +675,19 @@ BlazeComponent.extendComponent({
             element.type = 'swimlane';
             _id = element.copy(this.boardId);
           } else if (this.isBoardTemplateSearch) {
-            board = Boards.findOne(element.linkedId);
-            board.sort = Boards.find({ archived: false }).count();
-            board.type = 'board';
-            board.title = element.title;
-            delete board.slug;
-            _id = board.copy();
+            Meteor.call(
+              'copyBoard',
+              element.linkedId,
+              {
+                sort: Boards.find({ archived: false }).count(),
+                type: 'board',
+                title: element.title,
+              },
+              (err, data) => {
+                _id = data;
+              },
+            );
+            // _id = board.copy();
           }
           Popup.close();
         },

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -687,7 +687,6 @@ BlazeComponent.extendComponent({
                 _id = data;
               },
             );
-            // _id = board.copy();
           }
           Popup.close();
         },

--- a/models/boards.js
+++ b/models/boards.js
@@ -508,6 +508,7 @@ Boards.helpers({
   copy() {
     const oldId = this._id;
     delete this._id;
+    delete this.slug;
     const _id = Boards.insert(this);
 
     // Copy all swimlanes in board

--- a/models/boards.js
+++ b/models/boards.js
@@ -537,6 +537,29 @@ Boards.helpers({
         },
       });
     });
+
+    // copy rules, actions, and triggers
+    const actionsMap = {};
+    Actions.find({ boardId: oldId }).forEach(action => {
+      const id = action._id;
+      delete action._id;
+      action.boardId = _id;
+      actionsMap[id] = Actions.insert(action);
+    });
+    const triggersMap = {};
+    Triggers.find({ boardId: oldId }).forEach(trigger => {
+      const id = trigger._id;
+      delete trigger._id;
+      trigger.boardId = _id;
+      triggersMap[id] = Triggers.insert(trigger);
+    });
+    Rules.find({ boardId: oldId }).forEach(rule => {
+      delete rule._id;
+      rule.boardId = _id;
+      rule.actionId = actionsMap[rule.actionId];
+      rule.triggerId = triggersMap[rule.triggerId];
+      Rules.insert(rule);
+    });
   },
   /**
    * Is supplied user authorized to view this board?

--- a/models/boards.js
+++ b/models/boards.js
@@ -563,6 +563,28 @@ Boards.helpers({
     });
   },
   /**
+   * Return a unique title based on the current title
+   *
+   * @returns {string|null}
+   */
+  copyTitle() {
+    const m = this.title.match(/^(?<title>.*?)\s*(\[(?<num>\d+)]\s*$|\s*$)/);
+    const title = m.groups.title;
+    let num = 0;
+    Boards.find({ title: new RegExp(`^${title}\\s*\\[\\d+]\\s*$`) }).forEach(
+      board => {
+        const m = board.title.match(/^(?<title>.*?)\s*\[(?<num>\d+)]\s*$/);
+        if (m) {
+          const n = parseInt(m.groups.num, 10);
+          num = num < n ? n : num;
+        }
+      },
+    );
+
+    return `${title} [${num + 1}]`;
+  },
+
+  /**
    * Is supplied user authorized to view this board?
    */
   isVisibleBy(user) {

--- a/server/publications/boards.js
+++ b/server/publications/boards.js
@@ -209,3 +209,19 @@ Meteor.publishRelations('board', function(boardId, isArchived) {
 
   return this.ready();
 });
+
+Meteor.methods({
+  copyBoard(boardId, properties) {
+    check(boardId, String);
+    check(properties, Object);
+
+    const board = Boards.findOne(boardId);
+    if (board) {
+      for (const key in properties) {
+        board[key] = properties[key];
+      }
+      return board.copy();
+    }
+    return null;
+  },
+});


### PR DESCRIPTION
Fix for issue #2924
* Added logic to copy rules, triggers and actions to `Boards.copy()`
* Created new Meteor method `copyBoard` server-side
* Changed the duplicate board code to call `copyBoard` instead of `cloneBoard`
* Added new method `Boards.copyTitle()` to create unique names for duplicated boards.

NOTE:
* The line `delete this.slug;` was added to `Boards.copy()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3458)
<!-- Reviewable:end -->
