### PR TITLE
Handle '\n' line breaks in PEM-encoded SSL/TLS certificates

### DIFF
--- a/packages/wekan-ldap/server/ldap.js
+++ b/packages/wekan-ldap/server/ldap.js
@@ -100,7 +100,7 @@ export default class LDAP {
 
     if (this.options.ca_cert && this.options.ca_cert !== '') {
       // Split CA cert into array of strings
-      const chainLines = this.constructor.settings_get('LDAP_CA_CERT').split('\n');
+      const chainLines = this.constructor.settings_get('LDAP_CA_CERT').replace(/\\n/g,'\n').split('\n');
       let cert         = [];
       const ca         = [];
       chainLines.forEach((line) => {


### PR DESCRIPTION
For example Podman, handling OCI containers, does not seem to have a way to pass multi-line strings via env files (and Docker seems to have the same issue at least outside of `docker-compose`). Thus this change allows `LDAP_CA_CERT` to handle a string with `\n`, because currently only `0x0A` aka `LF` might work. An example for additionally supported format:

```
LDAP_CA_CERT=-----BEGIN CERTIFICATE-----\n...\n...\n...\n-----END CERTIFICATE-----
```

See also: https://github.com/wekan/wekan/issues/3484

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3485)
<!-- Reviewable:end -->
