### PR TITLE
Repair LDAP_REJECT_UNAUTHORIZED=false (broken by commit 31f8912, fixes #3493)

### DIFF
--- a/packages/wekan-ldap/server/ldap.js
+++ b/packages/wekan-ldap/server/ldap.js
@@ -19,7 +19,7 @@ export default class LDAP {
       idle_timeout                       : this.constructor.settings_get('LDAP_IDLE_TIMEOUT'),
       encryption                         : this.constructor.settings_get('LDAP_ENCRYPTION'),
       ca_cert                            : this.constructor.settings_get('LDAP_CA_CERT'),
-      reject_unauthorized                : this.constructor.settings_get('LDAP_REJECT_UNAUTHORIZED') || true,
+      reject_unauthorized                : this.constructor.settings_get('LDAP_REJECT_UNAUTHORIZED') !== undefined ? this.constructor.settings_get('LDAP_REJECT_UNAUTHORIZED') : true,
       Authentication                     : this.constructor.settings_get('LDAP_AUTHENTIFICATION'),
       Authentication_UserDN              : this.constructor.settings_get('LDAP_AUTHENTIFICATION_USERDN'),
       Authentication_Password            : this.constructor.settings_get('LDAP_AUTHENTIFICATION_PASSWORD'),


### PR DESCRIPTION
Previous commit 31f89121fecca5a761b05cc3a26d4f237e90b484 happened to fix CVE-2021-3309, but unfortunately breaks `LDAP_REJECT_UNAUTHORIZED=false`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3497)
<!-- Reviewable:end -->
