### PR TITLE
Sorted archives

### DIFF
--- a/client/components/boards/boardArchive.js
+++ b/client/components/boards/boardArchive.js
@@ -11,7 +11,7 @@ BlazeComponent.extendComponent({
     return Boards.find(
       { archived: true },
       {
-        sort: { sort: 1 /* boards default sorting */ },
+        sort: { archivedAt: -1, modifiedAt: -1 },
       },
     );
   },

--- a/client/components/sidebar/sidebarArchives.jade
+++ b/client/components/sidebar/sidebarArchives.jade
@@ -14,6 +14,11 @@ template(name="archivesSidebar")
           if currentUser.isBoardMember
             unless isWorker
               p.quiet
+                if this.archivedAt
+                  | {{_ 'archived-at' }}
+                  | 
+                  | {{ moment this.archivedAt 'LLL' }}
+                  br
                 a.js-restore-card {{_ 'restore'}}
                 if currentUser.isBoardAdmin
                   | -
@@ -37,6 +42,11 @@ template(name="archivesSidebar")
               if currentUser.isBoardMember
                 unless isWorker
                   p.quiet
+                    if this.archivedAt
+                      | {{_ 'archived-at' }}
+                      | 
+                      | {{ moment this.archivedAt 'LLL' }}
+                      br
                     a.js-restore-list {{_ 'restore'}}
                     if currentUser.isBoardAdmin
                       | -
@@ -58,6 +68,11 @@ template(name="archivesSidebar")
               if currentUser.isBoardMember
                 unless isWorker
                   p.quiet
+                    if this.archivedAt
+                      | {{_ 'archived-at' }}
+                      | 
+                      | {{ moment this.archivedAt 'LLL' }}
+                      br
                     a.js-restore-swimlane {{_ 'restore'}}
                     if currentUser.isBoardAdmin
                       | -

--- a/client/components/sidebar/sidebarArchives.js
+++ b/client/components/sidebar/sidebarArchives.js
@@ -34,6 +34,8 @@ BlazeComponent.extendComponent({
     return Cards.find({
       archived: true,
       boardId: Session.get('currentBoard'),
+    }, {
+      sort: { archivedAt: -1, modifiedAt: -1 },
     });
   },
 
@@ -41,6 +43,8 @@ BlazeComponent.extendComponent({
     return Lists.find({
       archived: true,
       boardId: Session.get('currentBoard'),
+    }, {
+      sort: { archivedAt: -1, modifiedAt: -1 },
     });
   },
 
@@ -48,6 +52,8 @@ BlazeComponent.extendComponent({
     return Swimlanes.find({
       archived: true,
       boardId: Session.get('currentBoard'),
+    }, {
+      sort: { archivedAt: -1, modifiedAt: -1 },
     });
   },
 

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -951,5 +951,6 @@
   "excel-font": "Arial",
   "number": "Number",
   "label-colors": "Label Colors",
-  "label-names": "Label Names"
+  "label-names": "Label Names",
+  "archived-at": "archived at"
 }

--- a/models/boards.js
+++ b/models/boards.js
@@ -43,6 +43,13 @@ Boards.attachSchema(
         }
       },
     },
+    archivedAt: {
+      /**
+       * Latest archiving time of the board
+       */
+      type: Date,
+      optional: true,
+    },
     createdAt: {
       /**
        * Creation time of the board
@@ -1042,7 +1049,7 @@ Boards.helpers({
 
 Boards.mutations({
   archive() {
-    return { $set: { archived: true } };
+    return { $set: { archived: true, archivedAt: new Date() } };
   },
 
   restore() {

--- a/models/cards.js
+++ b/models/cards.js
@@ -26,6 +26,13 @@ Cards.attachSchema(
         }
       },
     },
+    archivedAt: {
+      /**
+       * latest archiving date
+       */
+      type: Date,
+      optional: true,
+    },
     parentId: {
       /**
        * ID of the parent card
@@ -1446,6 +1453,7 @@ Cards.mutations({
     return {
       $set: {
         archived: true,
+        archivedAt: new Date(),
       },
     };
   },

--- a/models/lists.js
+++ b/models/lists.js
@@ -32,6 +32,13 @@ Lists.attachSchema(
         }
       },
     },
+    archivedAt: {
+      /**
+       * latest archiving date
+       */
+      type: Date,
+      optional: true,
+    },
     boardId: {
       /**
        * the board associated to this list
@@ -292,7 +299,7 @@ Lists.mutations({
         return card.archive();
       });
     }
-    return { $set: { archived: true } };
+    return { $set: { archived: true, archivedAt: new Date() } };
   },
 
   restore() {
@@ -384,6 +391,7 @@ if (Meteor.isServer) {
   Meteor.startup(() => {
     Lists._collection._ensureIndex({ modifiedAt: -1 });
     Lists._collection._ensureIndex({ boardId: 1 });
+    Lists._collection._ensureIndex({ archivedAt: -1 });
   });
 
   Lists.after.insert((userId, doc) => {

--- a/models/swimlanes.js
+++ b/models/swimlanes.js
@@ -23,6 +23,13 @@ Swimlanes.attachSchema(
         }
       },
     },
+    archivedAt: {
+      /**
+       * latest archiving date of the swimlane
+       */
+      type: Date,
+      optional: true,
+    },
     boardId: {
       /**
        * the ID of the board the swimlane is attached to
@@ -259,7 +266,7 @@ Swimlanes.mutations({
         return list.archive();
       });
     }
-    return { $set: { archived: true } };
+    return { $set: { archived: true, archivedAt: new Date() } };
   },
 
   restore() {


### PR DESCRIPTION
Added sorting to archives. Please review carefully as I don’t read JavaScript, Jade, or Meteor, so I had to rely on try-and-error and pattern reuse.

I particular, I was unable to add the `archivedAt` field to the list of archived boards.  Whatever I tried, I could only display the `title` of the board in the list of archived boards. Another problem is that I could not capitalise the first letter of “archived at”. Of course, one could use “Archived at” in `en.i18n.json` – but this is not as re-usable.

The new field `archivedAt` is necessary because `modifiedAt` of an archived object may change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3518)
<!-- Reviewable:end -->
