### PR TITLE
Cards, CustomFields sorted alphabetically, fixes #3517

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -724,9 +724,7 @@ Cards.helpers({
         definition,
       };
     });
-    if (ret.definition !== undefined) {
-      ret.sort((a, b) => a.definition.name.localeCompare(b.definition.name));
-    }
+    ret.sort((a, b) => a.definition.name !== undefined && b.definition.name !== undefined && a.definition.name.localeCompare(b.definition.name));
     return ret;
   },
 


### PR DESCRIPTION
- last fix didn't work and disabled alphabetic sorting
- also works with linked cards

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3521)
<!-- Reviewable:end -->
