### PR TITLE
Set the language on `TAPi18n` when user selects language

### DIFF
--- a/client/components/users/userHeader.js
+++ b/client/components/users/userHeader.js
@@ -213,6 +213,7 @@ Template.changeLanguagePopup.events({
         'profile.language': this.tag,
       },
     });
+    TAPi18n.setLanguage(this.tag);
     event.preventDefault();
   },
 });


### PR DESCRIPTION
When the `TAPi18n` initialization code was removed from an `autorun()`
it no longer is rerun when a user's profile language is changed.

Fixes bug introduced by pull request #3519

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3525)
<!-- Reviewable:end -->
