### PR TITLE
Fix bug in `uniqueTitle`

### DIFF
--- a/models/boards.js
+++ b/models/boards.js
@@ -1287,7 +1287,11 @@ Boards.uniqueTitle = title => {
     },
   );
 
-  return `${base} [${num + 1}]`;
+  if (num > 0) {
+    return `${base} [${num + 1}]`;
+  }
+
+  return title;
 };
 
 Boards.userSearch = (


### PR DESCRIPTION
`uniqueTitle` was returning a numbered title even when not necessary

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3526)
<!-- Reviewable:end -->
