### PR TITLE
Checklistitems are now inserted always at the end of the checklist

### DIFF
--- a/client/components/cards/checklists.js
+++ b/client/components/cards/checklists.js
@@ -111,7 +111,7 @@ BlazeComponent.extendComponent({
         title,
         checklistId: checklist._id,
         cardId: checklist.cardId,
-        sort: checklist.itemCount(),
+        sort: Utils.calculateIndexData(checklist.lastItem()).base,
       });
     }
     // We keep the form opened, empty it.

--- a/models/checklists.js
+++ b/models/checklists.js
@@ -91,6 +91,11 @@ Checklists.helpers({
       { sort: ['sort'] },
     );
   },
+  lastItem() {
+    const allItems = this.items().fetch();
+    const ret = allItems[allItems.length - 1];
+    return ret;
+  },
   finishedCount() {
     return ChecklistItems.find({
       checklistId: this._id,


### PR DESCRIPTION
The number before the checkbox is the internal sorting number, it's not included in the commit

Before:
![wekan_checklistitem_sort_bug](https://user-images.githubusercontent.com/13166201/107383596-6dfea680-6af1-11eb-9991-a7dd7615e61f.gif)

After:
![wekan_checklistitem_sort_bug_fixed](https://user-images.githubusercontent.com/13166201/107383625-748d1e00-6af1-11eb-980a-c275f3398f55.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3551)
<!-- Reviewable:end -->
