### PR TITLE
Add /api/boards_count endpoint for statistics

### DIFF
--- a/models/boards.js
+++ b/models/boards.js
@@ -1701,6 +1701,30 @@ if (Meteor.isServer) {
   });
 
   /**
+   * @operation get_boards_count
+   * @summary Get public and private boards count
+   *
+   * @return_type {private: integer, public: integer}
+   */
+  JsonRoutes.add('GET', '/api/boards_count', function(req, res) {
+    try {
+      Authentication.checkUserId(req.userId);
+      JsonRoutes.sendResult(res, {
+        code: 200,
+        data: {
+          private: Boards.find({ permission: 'private' }).count(),
+          public: Boards.find({ permission: 'public' }).count(),
+        },
+      });
+    } catch (error) {
+      JsonRoutes.sendResult(res, {
+        code: 200,
+        data: error,
+      });
+    }
+  });
+
+  /**
    * @operation get_board
    * @summary Get the board with that particular ID
    *

--- a/public/api/wekan.html
+++ b/public/api/wekan.html
@@ -1566,7 +1566,12 @@ var n=this.pipeline.run(e.tokenizer(t)),r=new e.Vector,i=[],o=this._fields.reduc
                     <a href="#get_public_boards" class="toc-h2 toc-link" data-title="get_public_boards">get_public_boards</a>
                     
                   </li>
-                
+
+                  <li>
+                    <a href="#get_boards_count" class="toc-h2 toc-link" data-title="get_boards_count">get_boards_count</a>
+
+                  </li>
+
                   <li>
                     <a href="#new_board" class="toc-h2 toc-link" data-title="new_board">new_board</a>
                     

--- a/public/api/wekan.yml
+++ b/public/api/wekan.yml
@@ -245,6 +245,27 @@ paths:
                 type: string
               defaultSwimlaneId:
                 type: string
+  /api/boards_count:
+    get:
+      operationId: get_boards_count
+      summary: Get boards count
+      tags:
+        - Boards
+      produces:
+        - application/json
+      security:
+          - UserSecurity: []
+      responses:
+        '200':
+          description: |-
+            200 response
+          schema:
+            type: object
+            properties:
+              private:
+                type: integer
+              public:
+                type: integer
   /api/boards/{board}:
     get:
       operationId: get_board


### PR DESCRIPTION
As discussed in #3535, this is a proposition to add an `/api/boards_count`  API endpoint that can return the number of private and public boards on the server, for statistics purpose.

This is my first contribution to Wekan so please let me now if something is missing or wrong and I'll correct :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3556)
<!-- Reviewable:end -->
