### PR TITLE
Changed default behaviour for BIGEVENTS that no activity matches it.

### DIFF
--- a/models/activities.js
+++ b/models/activities.js
@@ -254,17 +254,19 @@ if (Meteor.isServer) {
       if (value) params[key] = value;
     });
     if (board) {
-      const BIGEVENTS = process.env.BIGEVENTS_PATTERN || 'due'; // if environment BIGEVENTS_PATTERN is set or default, any activityType matching it is important
-      try {
-        const atype = activity.activityType;
-        if (new RegExp(BIGEVENTS).exec(atype)) {
-          watchers = _.union(
-            watchers,
-            board.activeMembers().map(member => member.userId),
-          ); // notify all active members for important events system defined or default to all activity related to due date
+      const BIGEVENTS = process.env.BIGEVENTS_PATTERN; // if environment BIGEVENTS_PATTERN is set, any activityType matching it is important
+      if (BIGEVENTS) {
+        try {
+          const atype = activity.activityType;
+          if (new RegExp(BIGEVENTS).exec(atype)) {
+            watchers = _.union(
+              watchers,
+              board.activeMembers().map(member => member.userId),
+            ); // notify all active members for important events
+          }
+        } catch (e) {
+          // passed env var BIGEVENTS_PATTERN is not a valid regex
         }
-      } catch (e) {
-        // passed env var BIGEVENTS_PATTERN is not a valid regex
       }
 
       const watchingUsers = _.pluck(


### PR DESCRIPTION
Previously, all changes to due dates notified all board members.  Now, you have
to set the environment variable BIGEVENTS_PATTERN explicitly to "due" to
restore this behaviour.  By default, no activity is considered a "big event".
Fixes <https://github.com/wekan/wekan/issues/3133>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3561)
<!-- Reviewable:end -->
