### PR TITLE
Mobile View, list header is now always at top and only lists/cards view have a scroll area

### DIFF
--- a/client/components/lists/list.styl
+++ b/client/components/lists/list.styl
@@ -180,7 +180,8 @@
     border-bottom: 1px solid darken(white, 20%)
 
   .list
-    display: block
+    display: contents
+    flex-basis: auto
     width: 100%
     border-left: 0px
     &:first-child


### PR DESCRIPTION
It's now the same behaviour as at desktop view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3563)
<!-- Reviewable:end -->
