### PR TITLE
Checklist drag handle now at the left side (same place as for the checklist items)

### DIFF
--- a/client/components/cards/checklists.styl
+++ b/client/components/cards/checklists.styl
@@ -44,8 +44,8 @@ textarea.js-add-checklist-item, textarea.js-edit-checklist-item
 
   span.fa.checklist-handle
     padding-right: 20px
-    padding-top: 6px
-    float: right
+    padding-top: 3px
+    float: left
 
 
 .js-confirm-checklist-delete


### PR DESCRIPTION
- most people scroll with their right thumb, so it happens sometimes
  that they move whole checklists by accident.
- this fixes the problem, and also it looks more clean than a drag
  handle in the middle of the screen

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3571)
<!-- Reviewable:end -->
