### PR TITLE
Fix bugs with customFields identified in Issue #3574

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,7 +309,7 @@ services:
       #- TRUSTED_URL=https://intra.example.com
       #-----------------------------------------------------------------
       # ==== OUTGOING WEBHOOKS ====
-      # What to send to Outgoing Webhook, or leave out. Example, that includes all that are default: cardId,listId,oldListId,boardId,comment,user,card,commentId .
+      # What to send to Outgoing Webhook, or leave out. If commented out the default values will be: cardId,listId,oldListId,boardId,comment,user,card,commentId,swimlaneId,customerField,customFieldValue
       #- WEBHOOKS_ATTRIBUTES=cardId,listId,oldListId,boardId,comment,user,card,commentId
       #-----------------------------------------------------------------
       # ==== Debug OIDC OAuth2 etc ====

--- a/models/activities.js
+++ b/models/activities.js
@@ -231,9 +231,7 @@ if (Meteor.isServer) {
     if (activity.customFieldId) {
       const customField = activity.customField();
       params.customField = customField.name;
-      params.customFieldValue = Activities.findOne({
-        customFieldId: customField._id,
-      }).value;
+      params.customFieldValue = activity.value;
     }
     // Label activity did not work yet, unable to edit labels when tried this.
     //if (activity.labelId) {

--- a/models/cards.js
+++ b/models/cards.js
@@ -2112,6 +2112,8 @@ function cardCustomFields(userId, doc, fieldNames, modifier) {
             activityType: 'setCustomField',
             boardId: doc.boardId,
             cardId: doc._id,
+            listId: doc.listId,
+            swimlaneId: doc.swimlaneId
           };
           Activities.insert(act);
         }

--- a/server/notifications/outgoing.js
+++ b/server/notifications/outgoing.js
@@ -61,6 +61,8 @@ if (Meteor.isServer) {
     'card',
     'commentId',
     'swimlaneId',
+    'customField',
+    'customFieldValue'
   ];
   const responseFunc = data => {
     const paramCommentId = data.commentId;


### PR DESCRIPTION
Fixed bug with the reference to the customFieldValue in the cards.js

Activity Insert was not being passed the listId, swimlaneId which was required when building the webhook text string.

Added customField and customFieldValue as default values for the webhook msgs. There is no good reason to exclude these (they will only be included when changing a customField anyway). Updated the docker-compose comment to reflect this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3584)
<!-- Reviewable:end -->
