### PR TITLE
change url scheme recognition for allowing abasurl to link

### DIFF
--- a/packages/markdown/src/template-integration.js
+++ b/packages/markdown/src/template-integration.js
@@ -37,7 +37,7 @@ function mySafeAttrValue(tag, name, value, cssFilter) {
   // then use your custom function
   if (tag === 'a' && name === 'href') {
     // only filter the value if starts with an registered url scheme
-    urlscheme = value.split(/:\/\//);
+    urlscheme = value.split(/:/);
     //console.log("validating "+urlscheme[0]);
     if(urlschemes.includes(urlscheme[0])) return value;
     else {


### PR DESCRIPTION
autolinking is not working for abasurl as it contains not url conform characters so you would still have to link it manually but it is not sanitized anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3641)
<!-- Reviewable:end -->
