### PR TITLE
Fixed Bug: copy to clipboard uses pathname

### DIFF
--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -12,7 +12,6 @@ template(name="cardDetails")
             a.fa.fa-link.card-copy-button.js-copy-link(
               class="fa-link"
               title="{{_ 'copy-card-link-to-clipboard'}}"
-              value="{{ originRelativeUrl }}"
             )
         if isMiniScreen
           a.fa.fa-times-thin.close-card-details-mobile-web.js-close-card-details

--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -291,6 +291,8 @@ BlazeComponent.extendComponent({
         },
         'click .js-copy-link'() {
           StringToCopyElement = document.getElementById('cardURL_copy');
+          StringToCopyElement.value =
+            window.location.origin + window.location.pathname;
           StringToCopyElement.select();
           if (document.execCommand('copy')) {
             StringToCopyElement.blur();


### PR DESCRIPTION
This will use the current URL to copy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3661)
<!-- Reviewable:end -->
