### PR TITLE
Add Trello attached links to the card description

### DIFF
--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -981,5 +981,6 @@
   "due-date": "Due Date",
   "title-alphabetically": "Title (Alphabetically)",
   "created-at-newest-first": "Created At (Newest First)",
-  "created-at-oldest-first": "Created At (Oldest First)"
+  "created-at-oldest-first": "Created At (Oldest First)",
+  "links-heading": "Links"
 }


### PR DESCRIPTION
This patch adds links attached to Trello cards to the Wekan card's description during import.

Previously, I explored adding the link as an attachment in Wekan.  But there is no file data to store with a link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3669)
<!-- Reviewable:end -->
