### PR TITLE
Add custom field "stringtemplate"

### DIFF
--- a/client/components/cards/cardCustomFields.jade
+++ b/client/components/cards/cardCustomFields.jade
@@ -119,3 +119,23 @@ template(name="cardCustomField-dropdown")
         if value
             +viewer
                 = selectedItem
+
+template(name="cardCustomField-stringtemplate")
+    if canModifyCard
+        +inlinedForm(classNames="js-card-customfield-stringtemplate")
+            +editor(autofocus=true)
+                = data.value
+            .edit-controls.clearfix
+                button.primary(type="submit") {{_ 'save'}}
+                a.fa.fa-times-thin.js-close-inlined-form
+        else
+            a.js-open-inlined-form
+                if value
+                    +viewer
+                        = formattedValue
+                else
+                    | {{_ 'edit'}}
+    else
+        if value
+            +viewer
+                = formattedValue

--- a/client/components/cards/cardCustomFields.jade
+++ b/client/components/cards/cardCustomFields.jade
@@ -125,7 +125,7 @@ template(name="cardCustomField-stringtemplate")
         +inlinedForm(classNames="js-card-customfield-stringtemplate")
             each item in stringtemplateItems.get
                 input.js-card-customfield-stringtemplate-item(type="text" value=item placeholder="")
-            input.js-card-customfield-stringtemplate-item.last(type="text" value="" placeholder="{{_ 'custom-field-dropdown-options-placeholder'}}")
+            input.js-card-customfield-stringtemplate-item.last(type="text" value="" placeholder="{{_ 'custom-field-stringtemplate-item-placeholder'}}")
             .edit-controls.clearfix
                 button.primary(type="submit") {{_ 'save'}}
                 a.fa.fa-times-thin.js-close-inlined-form

--- a/client/components/cards/cardCustomFields.jade
+++ b/client/components/cards/cardCustomFields.jade
@@ -123,8 +123,9 @@ template(name="cardCustomField-dropdown")
 template(name="cardCustomField-stringtemplate")
     if canModifyCard
         +inlinedForm(classNames="js-card-customfield-stringtemplate")
-            +editor(autofocus=true)
-                = data.value
+            each item in stringtemplateItems.get
+                input.js-card-customfield-stringtemplate-item(type="text" value=item placeholder="")
+            input.js-card-customfield-stringtemplate-item.last(type="text" value="" placeholder="{{_ 'custom-field-dropdown-options-placeholder'}}")
             .edit-controls.clearfix
                 button.primary(type="submit") {{_ 'save'}}
                 a.fa.fa-times-thin.js-close-inlined-form

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -272,7 +272,9 @@ CardCustomField.register('cardCustomField');
           if (event.keyCode === 13) {
             event.preventDefault();
 
-            if (event.target.value.trim()) {
+            if (event.metaKey || event.ctrlKey) {
+              this.find('button[type=submit]').click();
+            } else if (event.target.value.trim()) {
               const inputLast = this.find('input.last');
 
               let items = this.getItems();

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -234,3 +234,33 @@ CardCustomField.register('cardCustomField');
     ];
   }
 }.register('cardCustomField-dropdown'));
+
+// cardCustomField-stringtemplate
+(class extends CardCustomField {
+  onCreated() {
+    super.onCreated();
+
+    this.stringtemplateFormat = this.data().definition.settings.stringtemplateFormat;
+  }
+
+  formattedValue() {
+    lines = this.data().value.replace(/\r\n|\n\r|\n|\r/g, '\n').split('\n');
+    lines = lines.map(line =>
+      this.stringtemplateFormat.replace(/%\{value\}/gi, line)
+    );
+
+    return lines.join(' ');
+  }
+
+  events() {
+    return [
+      {
+        'submit .js-card-customfield-stringtemplate'(event) {
+          event.preventDefault();
+          const value = this.currentComponent().getValue();
+          this.card.setCustomField(this.customFieldId, value);
+        },
+      },
+    ];
+  }
+}.register('cardCustomField-stringtemplate'));

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -276,12 +276,23 @@ CardCustomField.register('cardCustomField');
           if (event.keyCode === 13) {
             event.preventDefault();
 
-            if (event.target.value.trim()) {
-              if(event.target === this.find('input.last')) {
+            if (!!event.target.value.trim()) {
+              const inputLast = this.find('input.last');
+
+              if(event.target === inputLast) {
+                console.log("keydown[enter] - last");
                 const items = this.getItems();
                 this.stringtemplateItems.set(items);
-                this.find('input.last').value = '';
+                inputLast.value = '';
+              } else if(event.target.nextSibling === inputLast) {
+                console.log("keydown[enter] - last-1");
+                const items = this.getItems();
+                this.stringtemplateItems.set(items);
+                inputLast.focus();
               } else {
+                console.log("keydown[enter]");
+                event.target.blur();
+
                 const idx = Array.from(this.findAll('input'))
                   .indexOf(event.target);
                 let items = this.getItems();

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -247,7 +247,7 @@ CardCustomField.register('cardCustomField');
     return this.data().value
       .replace(/\r\n|\n\r|\n|\r/g, '\n')
       .split('\n')
-      .filter(value => value.trim() != '')
+      .filter(value => value.trim() !== '')
       .map(value => this.stringtemplateFormat.replace(/%\{value\}/gi, value))
       .join(' ');
   }

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -244,12 +244,12 @@ CardCustomField.register('cardCustomField');
   }
 
   formattedValue() {
-    lines = this.data().value.replace(/\r\n|\n\r|\n|\r/g, '\n').split('\n');
-    lines = lines.map(line =>
-      this.stringtemplateFormat.replace(/%\{value\}/gi, line)
-    );
-
-    return lines.join(' ');
+    return this.data().value
+      .replace(/\r\n|\n\r|\n|\r/g, '\n')
+      .split('\n')
+      .filter(value => value.trim() != '')
+      .map(value => this.stringtemplateFormat.replace(/%\{value\}/gi, value))
+      .join(' ');
   }
 
   events() {

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -241,6 +241,7 @@ CardCustomField.register('cardCustomField');
     super.onCreated();
 
     this.stringtemplateFormat = this.data().definition.settings.stringtemplateFormat;
+    this.stringtemplateSeparator = this.data().definition.settings.stringtemplateSeparator;
   }
 
   formattedValue() {
@@ -249,7 +250,7 @@ CardCustomField.register('cardCustomField');
       .split('\n')
       .filter(value => value.trim() !== '')
       .map(value => this.stringtemplateFormat.replace(/%\{value\}/gi, value))
-      .join(' ');
+      .join(this.stringtemplateSeparator ?? '');
   }
 
   events() {

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -287,7 +287,12 @@ CardCustomField.register('cardCustomField');
                 let items = this.getItems();
                 items.splice(idx + 1, 0, '');
                 this.stringtemplateItems.set(items);
-                //event.target.nextSibling.focus();
+
+                Tracker.afterFlush(() => {
+                  const element = this.findAll('input')[idx + 1];
+                  element.focus();
+                  element.value = '';
+                });
               }
             }
           }

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -243,15 +243,11 @@ CardCustomField.register('cardCustomField');
     this.stringtemplateFormat = this.data().definition.settings.stringtemplateFormat;
     this.stringtemplateSeparator = this.data().definition.settings.stringtemplateSeparator;
 
-    this.stringtemplateItems = new ReactiveVar(
-      this.data().value ?? [],
-    );
+    this.stringtemplateItems = new ReactiveVar(this.data().value ?? []);
   }
 
   formattedValue() {
-    return this.stringtemplateItems.get()
-      // .replace(/\r\n|\n\r|\n|\r/g, '\n')
-      // .split('\n')
+    return (this.data().value ?? [])
       .filter(value => !!value.trim())
       .map(value => this.stringtemplateFormat.replace(/%\{value\}/gi, value))
       .join(this.stringtemplateSeparator ?? '');
@@ -276,28 +272,21 @@ CardCustomField.register('cardCustomField');
           if (event.keyCode === 13) {
             event.preventDefault();
 
-            if (!!event.target.value.trim()) {
+            if (event.target.value.trim()) {
               const inputLast = this.find('input.last');
 
-              if(event.target === inputLast) {
-                console.log("keydown[enter] - last");
-                const items = this.getItems();
-                this.stringtemplateItems.set(items);
+              let items = this.getItems();
+
+              if (event.target === inputLast) {
                 inputLast.value = '';
-              } else if(event.target.nextSibling === inputLast) {
-                console.log("keydown[enter] - last-1");
-                const items = this.getItems();
-                this.stringtemplateItems.set(items);
+              } else if (event.target.nextSibling === inputLast) {
                 inputLast.focus();
               } else {
-                console.log("keydown[enter]");
                 event.target.blur();
 
                 const idx = Array.from(this.findAll('input'))
                   .indexOf(event.target);
-                let items = this.getItems();
                 items.splice(idx + 1, 0, '');
-                this.stringtemplateItems.set(items);
 
                 Tracker.afterFlush(() => {
                   const element = this.findAll('input')[idx + 1];
@@ -305,11 +294,13 @@ CardCustomField.register('cardCustomField');
                   element.value = '';
                 });
               }
+
+              this.stringtemplateItems.set(items);
             }
           }
         },
 
-        'focusout .js-card-customfield-stringtemplate-item'(event) {
+        'blur .js-card-customfield-stringtemplate-item'(event) {
           if (!event.target.value.trim() || event.target === this.find('input.last')) {
             const items = this.getItems();
             this.stringtemplateItems.set(items);
@@ -319,7 +310,7 @@ CardCustomField.register('cardCustomField');
 
         'click .js-close-inlined-form'(event) {
           this.stringtemplateItems.set(this.data().value ?? []);
-        }
+        },
       },
     ];
   }

--- a/client/components/cards/minicard.jade
+++ b/client/components/cards/minicard.jade
@@ -82,6 +82,9 @@ template(name="minicard")
                     +minicardCustomFieldDate
                 else if $eq definition.type "checkbox"
                   .materialCheckBox(class="{{#if value }}is-checked{{/if}}")
+                else if $eq definition.type "stringtemplate"
+                  +viewer
+                    = formattedStringtemplateCustomFieldValue(definition)
                 else
                   +viewer
                     = trueValue

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -32,7 +32,7 @@ BlazeComponent.extendComponent({
     return customFieldTrueValue
       .replace(/\r\n|\n\r|\n|\r/g, '\n')
       .split('\n')
-      .filter(value => value.trim() != '')
+      .filter(value => value.trim() !== '')
       .map(value => definition.settings.stringtemplateFormat.replace(/%\{value\}/gi, value))
       .join(' ');
   },

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -30,8 +30,6 @@ BlazeComponent.extendComponent({
       customField && customField.trueValue ? customField.trueValue : [];
 
     return customFieldTrueValue
-      // .replace(/\r\n|\n\r|\n|\r/g, '\n')
-      // .split('\n')
       .filter(value => !!value.trim())
       .map(value => definition.settings.stringtemplateFormat.replace(/%\{value\}/gi, value))
       .join(definition.settings.stringtemplateSeparator ?? '');

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -27,7 +27,7 @@ BlazeComponent.extendComponent({
       .find(f => f._id === definition._id);
 
     const customFieldTrueValue =
-      customField && customField.trueValue ? customField.trueValue : '';
+      customField && customField.trueValue ? customField.trueValue : [];
 
     return customFieldTrueValue
       // .replace(/\r\n|\n\r|\n|\r/g, '\n')

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -26,16 +26,15 @@ BlazeComponent.extendComponent({
       .customFieldsWD()
       .find(f => f._id === definition._id);
 
-    if(customField && customField.trueValue) {
-      lines = customField.trueValue.replace(/\r\n|\n\r|\n|\r/g, '\n').split('\n');
-      lines = lines.map(line =>
-        definition.settings.stringtemplateFormat.replace(/%\{value\}/gi, line)
-      );
+    const customFieldTrueValue =
+      customField && customField.trueValue ? customField.trueValue : '';
 
-      return lines.join(' ');
-    } else {
-      return '';
-    }
+    return customFieldTrueValue
+      .replace(/\r\n|\n\r|\n|\r/g, '\n')
+      .split('\n')
+      .filter(value => value.trim() != '')
+      .map(value => definition.settings.stringtemplateFormat.replace(/%\{value\}/gi, value))
+      .join(' ');
   },
 
   events() {

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -34,7 +34,7 @@ BlazeComponent.extendComponent({
       .split('\n')
       .filter(value => value.trim() !== '')
       .map(value => definition.settings.stringtemplateFormat.replace(/%\{value\}/gi, value))
-      .join(' ');
+      .join(definition.settings.stringtemplateSeparator ?? '');
   },
 
   events() {

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -30,9 +30,9 @@ BlazeComponent.extendComponent({
       customField && customField.trueValue ? customField.trueValue : '';
 
     return customFieldTrueValue
-      .replace(/\r\n|\n\r|\n|\r/g, '\n')
-      .split('\n')
-      .filter(value => value.trim() !== '')
+      // .replace(/\r\n|\n\r|\n|\r/g, '\n')
+      // .split('\n')
+      .filter(value => !!value.trim())
       .map(value => definition.settings.stringtemplateFormat.replace(/%\{value\}/gi, value))
       .join(definition.settings.stringtemplateSeparator ?? '');
   },

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -21,6 +21,23 @@ BlazeComponent.extendComponent({
     }).format(customFieldTrueValue);
   },
 
+  formattedStringtemplateCustomFieldValue(definition) {
+    const customField = this.data()
+      .customFieldsWD()
+      .find(f => f._id === definition._id);
+
+    if(customField && customField.trueValue) {
+      lines = customField.trueValue.replace(/\r\n|\n\r|\n|\r/g, '\n').split('\n');
+      lines = lines.map(line =>
+        definition.settings.stringtemplateFormat.replace(/%\{value\}/gi, line)
+      );
+
+      return lines.join(' ');
+    } else {
+      return '';
+    }
+  },
+
   events() {
     return [
       {

--- a/client/components/sidebar/sidebarCustomFields.jade
+++ b/client/components/sidebar/sidebarCustomFields.jade
@@ -51,7 +51,7 @@ template(name="createCustomFieldPopup")
                 input.js-dropdown-item(type="text" value=name placeholder="")
             input.js-dropdown-item.last(type="text" value="" placeholder="{{_ 'custom-field-dropdown-options-placeholder'}}")
 
-        div.js-field-settings.js-field-settings-paramlink(class="{{#if isTypeNotSelected 'stringtemplate'}}hide{{/if}}")
+        div.js-field-settings.js-field-settings-stringtemplate(class="{{#if isTypeNotSelected 'stringtemplate'}}hide{{/if}}")
             label
                 | {{_ 'custom-field-stringtemplate-format'}}
             input.js-field-stringtemplate(type="text" value=getStringtemplateFormat)

--- a/client/components/sidebar/sidebarCustomFields.jade
+++ b/client/components/sidebar/sidebarCustomFields.jade
@@ -50,6 +50,12 @@ template(name="createCustomFieldPopup")
             each dropdownItems.get
                 input.js-dropdown-item(type="text" value=name placeholder="")
             input.js-dropdown-item.last(type="text" value="" placeholder="{{_ 'custom-field-dropdown-options-placeholder'}}")
+
+        div.js-field-settings.js-field-settings-paramlink(class="{{#if isTypeNotSelected 'stringtemplate'}}hide{{/if}}")
+            label
+                | {{_ 'custom-field-stringtemplate-format'}}
+            input.js-field-stringtemplate(type="text" value=getStringtemplateFormat)
+
         a.flex.js-field-show-on-card(class="{{#if showOnCard}}is-checked{{/if}}")
             .materialCheckBox(class="{{#if showOnCard}}is-checked{{/if}}")
 

--- a/client/components/sidebar/sidebarCustomFields.jade
+++ b/client/components/sidebar/sidebarCustomFields.jade
@@ -54,7 +54,10 @@ template(name="createCustomFieldPopup")
         div.js-field-settings.js-field-settings-stringtemplate(class="{{#if isTypeNotSelected 'stringtemplate'}}hide{{/if}}")
             label
                 | {{_ 'custom-field-stringtemplate-format'}}
-            input.js-field-stringtemplate(type="text" value=getStringtemplateFormat)
+            input.js-field-stringtemplate-format(type="text" value=getStringtemplateFormat)
+            label
+                | {{_ 'custom-field-stringtemplate-separator'}}
+            input.js-field-stringtemplate-separator(type="text" value=getStringtemplateSeparator)
 
         a.flex.js-field-show-on-card(class="{{#if showOnCard}}is-checked{{/if}}")
             .materialCheckBox(class="{{#if showOnCard}}is-checked{{/if}}")

--- a/client/components/sidebar/sidebarCustomFields.js
+++ b/client/components/sidebar/sidebarCustomFields.js
@@ -16,7 +16,15 @@ BlazeComponent.extendComponent({
 }).register('customFieldsSidebar');
 
 const CreateCustomFieldPopup = BlazeComponent.extendComponent({
-  _types: ['text', 'number', 'date', 'dropdown', 'currency', 'checkbox', 'stringtemplate'],
+  _types: [
+    'text',
+    'number',
+    'date',
+    'dropdown',
+    'currency',
+    'checkbox',
+    'stringtemplate',
+  ],
 
   _currencyList: [
     {
@@ -81,7 +89,7 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
     this.stringtemplateFormat = new ReactiveVar(
       this.data().settings && this.data().settings.stringtemplateFormat
         ? this.data().settings.stringtemplateFormat
-        : "",
+        : '',
     );
   },
 

--- a/client/components/sidebar/sidebarCustomFields.js
+++ b/client/components/sidebar/sidebarCustomFields.js
@@ -91,6 +91,12 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
         ? this.data().settings.stringtemplateFormat
         : '',
     );
+
+    this.stringtemplateSeparator = new ReactiveVar(
+      this.data().settings && this.data().settings.stringtemplateSeparator
+        ? this.data().settings.stringtemplateSeparator
+        : '',
+    );
   },
 
   types() {
@@ -139,6 +145,10 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
     return this.stringtemplateFormat.get();
   },
 
+  getStringtemplateSeparator() {
+    return this.stringtemplateSeparator.get();
+  },
+
   getSettings() {
     const settings = {};
     switch (this.type.get()) {
@@ -157,6 +167,9 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
       case 'stringtemplate': {
         const stringtemplateFormat = this.stringtemplateFormat.get();
         settings.stringtemplateFormat = stringtemplateFormat;
+
+        const stringtemplateSeparator = this.stringtemplateSeparator.get();
+        settings.stringtemplateSeparator = stringtemplateSeparator;
         break;
       }
     }
@@ -181,9 +194,13 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
             evt.target.value = '';
           }
         },
-        'input .js-field-stringtemplate'(evt) {
+        'input .js-field-stringtemplate-format'(evt) {
           const value = evt.target.value;
           this.stringtemplateFormat.set(value);
+        },
+        'input .js-field-stringtemplate-separator'(evt) {
+          const value = evt.target.value;
+          this.stringtemplateSeparator.set(value);
         },
         'click .js-field-show-on-card'(evt) {
           let $target = $(evt.target);

--- a/client/components/sidebar/sidebarCustomFields.js
+++ b/client/components/sidebar/sidebarCustomFields.js
@@ -16,7 +16,7 @@ BlazeComponent.extendComponent({
 }).register('customFieldsSidebar');
 
 const CreateCustomFieldPopup = BlazeComponent.extendComponent({
-  _types: ['text', 'number', 'date', 'dropdown', 'currency', 'checkbox'],
+  _types: ['text', 'number', 'date', 'dropdown', 'currency', 'checkbox', 'stringtemplate'],
 
   _currencyList: [
     {
@@ -77,6 +77,12 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
         ? this.data().settings.dropdownItems
         : [],
     );
+
+    this.stringtemplateFormat = new ReactiveVar(
+      this.data().settings && this.data().settings.stringtemplateFormat
+        ? this.data().settings.stringtemplateFormat
+        : "",
+    );
   },
 
   types() {
@@ -121,6 +127,10 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
     return items;
   },
 
+  getStringtemplateFormat() {
+    return this.stringtemplateFormat.get();
+  },
+
   getSettings() {
     const settings = {};
     switch (this.type.get()) {
@@ -134,6 +144,11 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
           item => !!item.name.trim(),
         );
         settings.dropdownItems = dropdownItems;
+        break;
+      }
+      case 'stringtemplate': {
+        const stringtemplateFormat = this.stringtemplateFormat.get();
+        settings.stringtemplateFormat = stringtemplateFormat;
         break;
       }
     }
@@ -157,6 +172,10 @@ const CreateCustomFieldPopup = BlazeComponent.extendComponent({
             this.dropdownItems.set(items);
             evt.target.value = '';
           }
+        },
+        'input .js-field-stringtemplate'(evt) {
+          const value = evt.target.value;
+          this.stringtemplateFormat.set(value);
         },
         'click .js-field-show-on-card'(evt) {
           let $target = $(evt.target);

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -990,5 +990,5 @@
   "move-swimlane": "Move Swimlane",
   "moveSwimlanePopup-title": "Move Swimlane",
   "custom-field-stringtemplate": "String Template",
-  "custom-field-stringtemplate-format": "Format"
+  "custom-field-stringtemplate-format": "Format (use %{value} as placeholder)"
 }

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -991,5 +991,5 @@
   "moveSwimlanePopup-title": "Move Swimlane",
   "custom-field-stringtemplate": "String Template",
   "custom-field-stringtemplate-format": "Format (use %{value} as placeholder)",
-  "custom-field-stringtemplate-separator": "Separator (use &amp;#32; or &amp;nbsp; for a space)"
+  "custom-field-stringtemplate-separator": "Separator (use &#32; or &nbsp; for a space)"
 }

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -990,5 +990,6 @@
   "move-swimlane": "Move Swimlane",
   "moveSwimlanePopup-title": "Move Swimlane",
   "custom-field-stringtemplate": "String Template",
-  "custom-field-stringtemplate-format": "Format (use %{value} as placeholder)"
+  "custom-field-stringtemplate-format": "Format (use %{value} as placeholder)",
+  "custom-field-stringtemplate-separator": "Separator (use &amp;#32; or &amp;nbsp; for a space)"
 }

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -991,5 +991,6 @@
   "moveSwimlanePopup-title": "Move Swimlane",
   "custom-field-stringtemplate": "String Template",
   "custom-field-stringtemplate-format": "Format (use %{value} as placeholder)",
-  "custom-field-stringtemplate-separator": "Separator (use &#32; or &nbsp; for a space)"
+  "custom-field-stringtemplate-separator": "Separator (use &#32; or &nbsp; for a space)",
+  "custom-field-stringtemplate-item-placeholder": "Press enter to add more items"
 }

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -988,5 +988,7 @@
   "hide-system-messages-of-all-users": "Hide system messages of all users",
   "now-system-messages-of-all-users-are-hidden": "Now system messages of all users are hidden",
   "move-swimlane": "Move Swimlane",
-  "moveSwimlanePopup-title": "Move Swimlane"
+  "moveSwimlanePopup-title": "Move Swimlane",
+  "custom-field-stringtemplate": "String Template",
+  "custom-field-stringtemplate-format": "Format"
 }

--- a/models/cards.js
+++ b/models/cards.js
@@ -155,10 +155,14 @@ Cards.attachSchema(
           /**
            * value attached to the custom field
            */
-          type: Match.OneOf(String, Number, Boolean, Date),
+          type: Match.OneOf(String, Number, Boolean, Date, [String]),
           optional: true,
           defaultValue: '',
         },
+        'value.$': {
+          type: String,
+          optional: true,
+        }
       }),
     },
     dateLastActivity: {

--- a/models/cards.js
+++ b/models/cards.js
@@ -162,7 +162,7 @@ Cards.attachSchema(
         'value.$': {
           type: String,
           optional: true,
-        }
+        },
       }),
     },
     dateLastActivity: {

--- a/models/customFields.js
+++ b/models/customFields.js
@@ -29,6 +29,7 @@ CustomFields.attachSchema(
         'dropdown',
         'checkbox',
         'currency',
+        'stringtemplate',
       ],
     },
     settings: {
@@ -63,6 +64,10 @@ CustomFields.attachSchema(
           type: String,
         },
       }),
+    },
+    'settings.stringtemplateFormat': {
+      type: String,
+      optional: true,
     },
     showOnCard: {
       /**

--- a/models/customFields.js
+++ b/models/customFields.js
@@ -69,6 +69,10 @@ CustomFields.attachSchema(
       type: String,
       optional: true,
     },
+    'settings.stringtemplateSeparator': {
+      type: String,
+      optional: true,
+    },
     showOnCard: {
       /**
        * should we show on the cards this custom field


### PR DESCRIPTION
This PR implements a new custom field of type "stringtemplate".

It allows the user to add a string template containing a placeholder "%{value}" which will then be replaced by the card's field value.

I want to use this in combination with abas ERP, where you can directly open windows from the browser by using the custom URL scheme abasurl. For showing the data of the part with the part number 123456 the url would be `abasurl:<(Part)>123456<(View)>?DDE=001`. As the command is rather complex, it is quite tedious to write this link and I cannot imagine, that my users are able to write such a link by hand. So I will change the current custom field of type text to a new custom field of type stringtemplate, where the format is `[%{value}](abasurl:<(Part)>%{value}<(View)>?DDE=001)`, so that the link is auto generated.

The raw value is split by line separators and each non-empty line is formatted separately.

The following GIF shows an example, how you could use this field, to add a custom field for a phone number which is linked with the tel scheme.
![stringtemplate](https://user-images.githubusercontent.com/11574078/114024764-b8dc3680-9874-11eb-986b-ca6ff9ba76d6.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3701)
<!-- Reviewable:end -->
