### PR TITLE
popover needs to be destroyed anytime the details panel is closed.

### DIFF
--- a/client/components/activities/comments.js
+++ b/client/components/activities/comments.js
@@ -3,6 +3,7 @@ const commentFormIsOpen = new ReactiveVar(false);
 BlazeComponent.extendComponent({
   onDestroyed() {
     commentFormIsOpen.set(false);
+    $(".note-popover").hide();
   },
 
   commentFormIsOpen() {

--- a/client/components/cards/cardDescription.js
+++ b/client/components/cards/cardDescription.js
@@ -3,6 +3,7 @@ const descriptionFormIsOpen = new ReactiveVar(false);
 BlazeComponent.extendComponent({
   onDestroyed() {
     descriptionFormIsOpen.set(false);
+    $(".note-popover").hide();
   },
 
   descriptionFormIsOpen() {


### PR DESCRIPTION
This popover appears in the Description and the comment section.

I am still concerned that this change is required... But I do not understand what is happening as I am not a javascript/web developer
`noClickEscapeOn: ['.js-new-comment','.js-new-comment-form']`
as currently the line is 
`noClickEscapeOn: '.js-new-comment',`

edit: This is the linked issue https://github.com/wekan/wekan/issues/3399

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3712)
<!-- Reviewable:end -->
