### PR TITLE
openapi: better handle nested schemas

### DIFF
--- a/openapi/generate_openapi.py
+++ b/openapi/generate_openapi.py
@@ -607,6 +607,9 @@ class SchemaProperty(object):
 
         # deal with subschemas
         if '.' in name:
+            subschema = name.split('.')[0]
+            subschema = subschema.capitalize()
+
             if name.endswith('$'):
                 # reference in reference
                 subschema = ''.join([n.capitalize() for n in self.name.split('.')[:-1]])
@@ -621,9 +624,12 @@ class SchemaProperty(object):
                     print('''  {}:
     type: object'''.format(subschema))
                     return current_schema
+            elif '$' in name:
+                # In the form of 'profile.notifications.$.activity'
+                subschema = name[:name.index('$') - 1]  # 'profile.notifications'
+                subschema = ''.join([s.capitalize() for s in subschema.split('.')])
 
-            subschema = name.split('.')[0]
-            schema_name = self.schema.name + subschema.capitalize()
+            schema_name = self.schema.name + subschema
             name = name.split('.')[-1]
 
             if current_schema != schema_name:
@@ -755,7 +761,7 @@ class Schemas(object):
         # then print the references
         current = None
         required_properties = []
-        properties = [f for f in self.fields if '.' in f.name and not f.name.endswith('$')]
+        properties = [f for f in self.fields if '.' in f.name and not '$' in f.name]
         for prop in properties:
             current = prop.print_openapi(6, current, required_properties)
 
@@ -766,7 +772,7 @@ class Schemas(object):
 
         required_properties = []
         # then print the references in the references
-        for prop in [f for f in self.fields if '.' in f.name and f.name.endswith('$')]:
+        for prop in [f for f in self.fields if '.' in f.name and '$' in f.name]:
             current = prop.print_openapi(6, current, required_properties)
 
         if required_properties:

--- a/public/api/wekan.yml
+++ b/public/api/wekan.yml
@@ -3681,20 +3681,6 @@ definitions:
       - createdAt
       - modifiedAt
       - authenticationMethod
-  UsersEmails:
-    type: object
-    properties:
-      address:
-        description: |
-           The email address
-        type: string
-      verified:
-        description: |
-           Has the email been verified
-        type: boolean
-    required:
-      - address
-      - verified
   UsersProfile:
     type: object
     properties:
@@ -3750,14 +3736,6 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/UsersProfileNotifications"
-      activity:
-        description: |
-           The id of the activity this notification references
-        type: string
-      read:
-        description: |
-           the date on which this notification was read
-        type: string
       showCardsCountAt:
         description: |
            showCardCountAt field of the user
@@ -3813,7 +3791,6 @@ definitions:
            Reference to the board templates swimlane Id
         type: string
     required:
-      - activity
       - templatesBoardId
       - cardTemplatesSwimlaneId
       - listTemplatesSwimlaneId
@@ -3829,3 +3806,30 @@ definitions:
         description: |
            last hit that was returned
         type: number
+  UsersEmails:
+    type: object
+    properties:
+      address:
+        description: |
+           The email address
+        type: string
+      verified:
+        description: |
+           Has the email been verified
+        type: boolean
+    required:
+      - address
+      - verified
+  UsersProfileNotifications:
+    type: object
+    properties:
+      activity:
+        description: |
+           The id of the activity this notification references
+        type: string
+      read:
+        description: |
+           the date on which this notification was read
+        type: string
+    required:
+      - activity


### PR DESCRIPTION
While working on #3757, I realized that the generated openapi was not correct:

There is a 2 levels schemas in profile.notifications.

The code previously assumed we could only have one level, and so was not producing the correct UsersProfileNotifications.

Fix that by being more generic in the way we retrieve the nested subschemas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3762)
<!-- Reviewable:end -->
