### PR TITLE
openapi: actually catch the error when esprima fails at parsing the file

### DIFF
--- a/openapi/generate_openapi.py
+++ b/openapi/generate_openapi.py
@@ -821,6 +821,11 @@ def parse_schemas(schemas_dir):
         for filename in files:
             path = os.path.join(root, filename)
             context = parse_file(path)
+
+            if context is None:
+              # the file doesn't contain a schema (see above)
+              continue
+
             program = context.program
 
             current_schema = None


### PR DESCRIPTION
39f8a138d7ba added a try/except around esprima to catch any hard error from the parsing, but the returned value was not checked.

We now have the file models/exportExcel.js which gives us an unexpected symbol on line 3 (not sure why it is not happy), but that fails the generation of the doc entirely.

Fixes #3884

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3889)
<!-- Reviewable:end -->
