### PR TITLE
Organizations and teams are taken into account when displaying board in « All boards page »

### DIFF
--- a/server/publications/users.js
+++ b/server/publications/users.js
@@ -23,6 +23,8 @@ Meteor.publish('user-admin', function() {
   return Meteor.users.find(this.userId, {
     fields: {
       isAdmin: 1,
+      teams: 1,
+      orgs: 1,
     },
   });
 });
@@ -34,6 +36,8 @@ Meteor.publish('user-authenticationMethod', function(match) {
     {
       fields: {
         authenticationMethod: 1,
+        teams: 1,
+        orgs: 1,
       },
     },
   );


### PR DESCRIPTION

Organizations and teams are taken into account when displaying board in « All boards page », it means that If the current user is one of the board members or if one of the teams or organizations to which he belongs has been configured to have access to this board, then this board will be displayed in « all boards page ».

The point 2 of this comment « https://github.com/wekan/wekan/issues/802#issuecomment-870738124 » is not done yet, i’m working on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3912)
<!-- Reviewable:end -->
