### PR TITLE
Feature: Consecutive boardwise card numbering

### DIFF
--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -25,6 +25,9 @@ template(name="cardDetails")
         h2.card-details-title.js-card-title(
           class="{{#if canModifyCard}}js-open-inlined-form is-editable{{/if}}")
             +viewer
+              if currentBoard.allowsCardNumber
+                span.card-number
+                  | ##{getCardNumber}
               = getTitle
             if isWatching
               i.card-details-watch.fa.fa-eye

--- a/client/components/cards/cardDetails.styl
+++ b/client/components/cards/cardDetails.styl
@@ -114,6 +114,12 @@ avatar-radius = 50%
     background: darken(white, 7%)
     border-bottom: 1px solid darken(white, 14%)
 
+    .card-number {
+      color: darken(white, 30%);
+      display: inline-block;
+      margin-right: 5px;
+    }
+
     .close-card-details,
     .maximize-card-details,
     .minimize-card-details,

--- a/client/components/cards/minicard.jade
+++ b/client/components/cards/minicard.jade
@@ -37,6 +37,9 @@ template(name="minicard")
       if getArchived
         span.linked-icon.linked-archived.fa.fa-archive
       +viewer
+        if currentBoard.allowsCardNumber
+          span.card-number
+            | ##{getCardNumber}
         = getTitle
       if $eq 'subtext-with-full-path' currentBoard.presentParentTask
         .parent-subtext

--- a/client/components/cards/minicard.styl
+++ b/client/components/cards/minicard.styl
@@ -114,6 +114,10 @@
       font-size:20px;
       color: #ccc;
   .minicard-title
+    .card-number
+      color: darken(white, 30%);
+      display: inline-block;
+      margin-right: 5px;
     p:last-child
       margin-bottom: 0
     .viewer

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -81,7 +81,9 @@ BlazeComponent.extendComponent({
         Utils.boardView() === 'board-view-cal' ||
         !Utils.boardView()
       )
-        swimlaneId = board.getDefaultSwimline()._id;
+      swimlaneId = board.getDefaultSwimline()._id;
+
+      const nextCardNumber = board.getNextCardNumber();
 
       const _id = Cards.insert({
         title,
@@ -93,6 +95,7 @@ BlazeComponent.extendComponent({
         sort: sortIndex,
         swimlaneId,
         type: cardType,
+        cardNumber: nextCardNumber,
         linkedId,
       });
 
@@ -241,7 +244,7 @@ BlazeComponent.extendComponent({
       Boards.findOne(currentBoardId)
         .customFields()
         .fetch(),
-      function(field) {
+      function (field) {
         if (field.automaticallyOnCard || field.alwaysOnCard)
           arr.push({ _id: field._id, value: null });
       },
@@ -750,17 +753,17 @@ BlazeComponent.extendComponent({
 
   checkIdleTime() {
     return window.requestIdleCallback ||
-    function(handler) {
-      const startTime = Date.now();
-      return setTimeout(function() {
-        handler({
-          didTimeout: false,
-          timeRemaining() {
-            return Math.max(0, 50.0 - (Date.now() - startTime));
-          },
-        });
-      }, 1);
-    };
+      function (handler) {
+        const startTime = Date.now();
+        return setTimeout(function () {
+          handler({
+            didTimeout: false,
+            timeRemaining() {
+              return Math.max(0, 50.0 - (Date.now() - startTime));
+            },
+          });
+        }, 1);
+      };
   }
 
   updateList() {

--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -190,6 +190,13 @@ template(name="boardCardSettingsPopup")
           i.fa.fa-tags
           | {{_ 'labels'}}
     div.check-div
+      a.flex.js-field-has-card-number(class="{{#if allowsCardNumber}}is-checked{{/if}}")
+        .materialCheckBox(class="{{#if allowsCardNumber}}is-checked{{/if}}")
+        span
+          i.fa.fa-hashtag
+          | {{_ 'card'}}
+          | {{_ 'number'}}
+    div.check-div
       a.flex.js-field-has-description-title(class="{{#if allowsDescriptionTitle}}is-checked{{/if}}")
         .materialCheckBox(class="{{#if allowsDescriptionTitle}}is-checked{{/if}}")
         span

--- a/client/components/sidebar/sidebar.js
+++ b/client/components/sidebar/sidebar.js
@@ -776,6 +776,10 @@ BlazeComponent.extendComponent({
     return this.currentBoard.allowsComments;
   },
 
+  allowsCardNumber() {
+    return this.currentBoard.allowsCardNumber;
+  },
+
   allowsDescriptionTitle() {
     return this.currentBoard.allowsDescriptionTitle;
   },
@@ -1017,6 +1021,22 @@ BlazeComponent.extendComponent({
           $('.js-field-has-description-title').toggleClass(
             CKCLS,
             this.currentBoard.allowsDescriptionTitle,
+          );
+        },
+        'click .js-field-has-card-number'(evt) {
+          evt.preventDefault();
+          this.currentBoard.allowsCardNumber = !this.currentBoard
+            .allowsCardNumber;
+          this.currentBoard.setAllowsCardNumber(
+            this.currentBoard.allowsCardNumber,
+          );
+          $(`.js-field-has-card-number ${MCB}`).toggleClass(
+            CKCLS,
+            this.currentBoard.allowsCardNumber,
+          );
+          $('.js-field-has-card-number').toggleClass(
+            CKCLS,
+            this.currentBoard.allowsCardNumber,
           );
         },
         'click .js-field-has-description-text'(evt) {

--- a/models/boards.js
+++ b/models/boards.js
@@ -1066,12 +1066,7 @@ Boards.helpers({
 
   getNextCardNumber() {
     const boardCards = Cards.find({ boardId: this._id }).fetch();
-    if (boardCards.length == 0) {
-      return 1;
-    }
-    const maxCardNumber = Math.max(...boardCards
-      .map(c => c.cardNumber ? c.cardNumber : 0));
-    return maxCardNumber + 1;
+    return boardCards.length + 1;
   },
 
   cardsDueInBetween(start, end) {

--- a/models/boards.js
+++ b/models/boards.js
@@ -375,6 +375,14 @@ Boards.attachSchema(
       defaultValue: true,
     },
 
+    allowsCardNumber: {
+      /**
+       * Does the board allows card numbers?
+       */
+      type: Boolean,
+      defaultValue: false,
+    },
+
     allowsActivities: {
       /**
        * Does the board allows comments?
@@ -1056,6 +1064,16 @@ Boards.helpers({
     return result;
   },
 
+  getNextCardNumber() {
+    const boardCards = Cards.find({ boardId: this._id }).fetch();
+    if (boardCards.length == 0) {
+      return 1;
+    }
+    const maxCardNumber = Math.max(...boardCards
+      .map(c => c.cardNumber ? c.cardNumber : 0));
+    return maxCardNumber + 1;
+  },
+
   cardsDueInBetween(start, end) {
     return Cards.find({
       boardId: this._id,
@@ -1283,6 +1301,10 @@ Boards.mutations({
 
   setAllowsDescriptionTitle(allowsDescriptionTitle) {
     return { $set: { allowsDescriptionTitle } };
+  },
+
+  setAllowsCardNumber(allowsCardNumber) {
+    return { $set: { allowsCardNumber } };
   },
 
   setAllowsDescriptionText(allowsDescriptionText) {

--- a/models/cards.js
+++ b/models/cards.js
@@ -470,6 +470,16 @@ Cards.attachSchema(
       optional: true,
       defaultValue: [],
     },
+    cardNumber: {
+      /**
+       * A boardwise sequentially increasing number that is assigned
+       * to every newly created card
+       */
+      type: Number,
+      decimal: true,
+      optional: true,
+      defaultValue: 0,
+    },
   }),
 );
 
@@ -1645,6 +1655,10 @@ Cards.helpers({
     } else {
       return this.title;
     }
+  },
+
+  getCardNumber() {
+    return this.cardNumber;
   },
 
   getBoardTitle() {
@@ -3207,6 +3221,8 @@ if (Meteor.isServer) {
     Authentication.checkAdminOrCondition(req.userId, addPermission);
     const paramListId = req.params.listId;
     const paramParentId = req.params.parentId;
+
+    const nextCardNumber = board.getNextCardNumber();
     const currentCards = Cards.find(
       {
         listId: paramListId,
@@ -3229,6 +3245,7 @@ if (Meteor.isServer) {
         userId: req.body.authorId,
         swimlaneId: req.body.swimlaneId,
         sort: currentCards.count(),
+        cardNumber: nextCardNumber,
         members,
         assignees,
       });

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1080,16 +1080,22 @@ Migrations.add('add-card-number-allowed', () => {
 
 Migrations.add('assign-boardwise-card-numbers', () => {
   Boards.find().forEach(board => {
-    let nextCardNumber = 1;
+    let nextCardNumber = board.getNextCardNumber();
     Cards.find(
       {
         boardId: board._id,
         cardNumber: {
           $exists: false
         }
+      },
+      {
+        sort: { createdAt: 1 }
       }
     ).forEach(card => {
-      Cards.update(card._id, { $set: { cardNumber } }, noValidate);
+      Cards.update(
+        card._id,
+        { $set: { cardNumber: nextCardNumber } },
+        noValidate);
       nextCardNumber++;
     });
   })

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1061,3 +1061,36 @@ Migrations.add('add-hide-logo-by-default', () => {
     noValidateMulti,
   );
 });
+
+Migrations.add('add-card-number-allowed', () => {
+  Boards.update(
+    {
+      allowsCardNumber: {
+        $exists: false,
+      },
+    },
+    {
+      $set: {
+        allowsCardNumber: false,
+      },
+    },
+    noValidateMulti,
+  );
+});
+
+Migrations.add('assign-boardwise-card-numbers', () => {
+  Boards.find().forEach(board => {
+    let nextCardNumber = 1;
+    Cards.find(
+      {
+        boardId: board._id,
+        cardNumber: {
+          $exists: false
+        }
+      }
+    ).forEach(card => {
+      Cards.update(card._id, { $set: { cardNumber } }, noValidate);
+      nextCardNumber++;
+    });
+  })
+});


### PR DESCRIPTION
Hey @xet7,

first of all thanks for maintaining wekan!
We have been using wekan some time now in our company as a Trello alternative and we came across this [feature-request](https://github.com/wekan/wekan/issues/1473) as we also need to keep track of the cards.

This Pull Request adds this feature to wekan in the following way:

- it assigns a boardwise consecutive `cardNumber` to each card via a migration-script to ensure backward-compatibility
- it further assigns the nextCardNumber whenever a new card is created either through the rest-endpoint or websocket
- Through the card-settings it is possible to enable or disable the appearance of the cardNumber per board. The migration script sets this config to `false` initially
- If enabled the card-number is shown on the mini-card as well as the detail-card.

Please find below screenshots of the feature.

Feel free to reach out anytime.

Thanks again for your effort and time!

Best,
Kai

<img width="305" alt="card-settings" src="https://user-images.githubusercontent.com/45421380/127924126-7420c9ac-a5b4-4319-8b54-4fdc12270267.png">
<img width="595" alt="card-details-cardnumber" src="https://user-images.githubusercontent.com/45421380/127924130-afd08abd-1223-4d11-a0e3-cc8ec3d42db2.png">
<img width="269" alt="minicard-cardnumber" src="https://user-images.githubusercontent.com/45421380/127924132-33d26b57-5ce6-4f1f-9d54-35b3045dea16.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3935)
<!-- Reviewable:end -->
