### PR TITLE
Fix: Consecutive Card numbering when a card is moved to another board or copied

### DIFF
--- a/models/boards.js
+++ b/models/boards.js
@@ -1065,8 +1065,23 @@ Boards.helpers({
   },
 
   getNextCardNumber() {
-    const boardCards = Cards.find({ boardId: this._id }).fetch();
-    return boardCards.length + 1;
+    const boardCards = Cards.find(
+      {
+        boardId: this._id
+      },
+      {
+        sort: { cardNumber: -1 },
+        limit: 1
+      }
+    ).fetch();
+
+    // If no card is assigned to the board, return 1
+    if (!boardCards || boardCards.length === 0) {
+      return 1;
+    }
+
+    const maxCardNr = !!boardCards[0].cardNumber ? boardCards[0].cardNumber : 0;
+    return maxCardNr + 1;
   },
 
   cardsDueInBetween(start, end) {

--- a/models/cards.js
+++ b/models/cards.js
@@ -577,6 +577,7 @@ Cards.helpers({
 
     delete this._id;
     this.boardId = boardId;
+    this.cardNumber = Boards.findOne(boardId).getNextCardNumber();
     this.swimlaneId = swimlaneId;
     this.listId = listId;
     const _id = Cards.insert(this);
@@ -1989,8 +1990,12 @@ Cards.mutations({
         '_id',
       );
 
+      // assign the new card number from the target board
+      const newCardNumber = newBoard.getNextCardNumber();
+
       Object.assign(mutatedFields, {
         labelIds: newCardLabelIds,
+        cardNumber: newCardNumber
       });
 
       mutatedFields.customFields = this.mapCustomFieldsToBoard(newBoard._id);


### PR DESCRIPTION
Hey @xet7 and @mfilser ,

because of @mfilser very good remarks on my previous [PR](https://github.com/wekan/wekan/pull/3935) regarding the consecutive boardwise card numbering i submit another PR that includes the following fixes:

- If a card is moved to **another** board it, the card will receive the next card number from the target board. 
- If a card is copied to the same or another board, it will always receive the next card number from the target board

This PR also includes enhancements for `Boards.getNextCardNumber()`. It basically works now the following way:
1. return `1`, If no card is assigned to the board, 
2. return `1`, If the board has cards where **none** of the cards have the attribute `cardNumber` (this should never happen due to the migration-script `assign-boardwise-card-numbers` that is running prior to launch)
3. return `highestCardNumber + 1`, if the board has cards with the attribute `cardNumber`

If there is anything else i should need to take care of please do not hesitate to add further comments to this PR.

As mentioned in the other PR, i think the cardNumbers should continuously increase but can contain caps within a board. this happens if for instance a card that does not have the highest cardNumber in a board is moved to another board.

Thank you both for taking the time

Best
Kai

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3936)
<!-- Reviewable:end -->
