### PR TITLE
Feature: Special handles to notify board or card members in a comment

### DIFF
--- a/client/components/main/editor.js
+++ b/client/components/main/editor.js
@@ -1,3 +1,9 @@
+const specialHandles = [
+  {userId: 'board_members', username: 'board_members'},
+  {userId: 'card_members', username: 'card_members'}
+];
+const specialHandleNames = specialHandles.map(m => m.username);
+
 Template.editor.onRendered(() => {
   const textareaSelector = 'textarea';
   const mentions = [
@@ -7,13 +13,14 @@ Template.editor.onRendered(() => {
       search(term, callback) {
         const currentBoard = Boards.findOne(Session.get('currentBoard'));
         callback(
+          _.union(
           currentBoard
             .activeMembers()
             .map(member => {
               const username = Users.findOne(member.userId).username;
               return username.includes(term) ? username : null;
             })
-            .filter(Boolean),
+            .filter(Boolean), [...specialHandleNames])
         );
       },
       template(value) {
@@ -323,13 +330,13 @@ Blaze.Template.registerHelper(
       return HTML.Raw(
         DOMPurify.sanitize(content, { ALLOW_UNKNOWN_PROTOCOLS: true }),
       );
-    const knowedUsers = currentBoard.members.map(member => {
+    const knowedUsers = _.union(currentBoard.members.map(member => {
       const u = Users.findOne(member.userId);
       if (u) {
         member.username = u.username;
       }
       return member;
-    });
+    }), [...specialHandles]);
     const mentionRegex = /\B@([\w.]*)/gi;
 
     let currentMention;

--- a/models/activities.js
+++ b/models/activities.js
@@ -210,15 +210,30 @@ if (Meteor.isServer) {
             // ignore commenter mention himself?
             continue;
           }
-          const atUser = _.findWhere(knownUsers, { username });
-          if (!atUser) {
-            continue;
+
+          if (activity.boardId && username === 'board_members') {
+            // mentions all board members
+            const knownUids = knownUsers.map(u => u.userId);
+            watchers = _.union(watchers, [...knownUids]);
+            title = 'act-atUserComment';
+          } else if (activity.cardId && username === 'card_members') {
+            // mentions all card members if assigned
+            const card = activity.card();
+            watchers = _.union(watchers, [...card.members]);
+            title = 'act-atUserComment';
+          } else {
+            const atUser = _.findWhere(knownUsers, { username });
+            if (!atUser) {
+              continue;
+            }
+
+            const uid = atUser.userId;
+            params.atUsername = username;
+            params.atEmails = atUser.emails;
+            title = 'act-atUserComment';
+            watchers = _.union(watchers, [uid]);
           }
-          const uid = atUser.userId;
-          params.atUsername = username;
-          params.atEmails = atUser.emails;
-          title = 'act-atUserComment';
-          watchers = _.union(watchers, [uid]);
+
         }
       }
       params.commentId = comment._id;


### PR DESCRIPTION
Hey @xet7, 

this feature adds two convenient handles to either notify 

- all board members (`@board_members`) or 
- all card members (`@card_members`)

if used in a comment.

We found this feature very useful when we used Trello so you don't need to mention everyone explicitly.
The feature uses basically two keywords (`card_members` and `board_members`) which were chosen to avoid username collision in existing wekan instances.

Would be great if you could check the structure of the `specialHandles` array in `editor.js`

```
const specialHandles = [
  {userId: 'board_members', username: 'board_members'},
  {userId: 'card_members', username: 'card_members'}
];
```

I encountered no side-effects so far, but would be really great if you could say if this is a proper way for the fictive `userId`s. if i need to change anything, else please let me know.

Thanks for your time reviewing the changes!

<img width="471" alt="special_handles" src="https://user-images.githubusercontent.com/45421380/128090257-7f640971-7f92-4af8-8bec-5ea0af69f941.png">
