### PR TITLE
Fix: Show missing user mentions popover when posting comments in maximized card layout

### DIFF
--- a/client/components/main/layouts.styl
+++ b/client/components/main/layouts.styl
@@ -317,6 +317,9 @@ kbd
 .grabbing
   cursor: grabbing
 
+.textcomplete-dropdown
+  z-index: 2000 !important;
+
 // Implement a thiner close icon as suggested in
 // https://github.com/FortAwesome/Font-Awesome/issues/1540#issuecomment-68689950
 .fa.fa-times-thin:before


### PR DESCRIPTION
Hey,

this PR fixes issue [#3866](https://github.com/wekan/wekan/issues/3866) which states that the user mentioning does not work when used in maximized card layout.

this is due to the z-index of `.card-details-maximized` in `cardDetails.styl` that is set to `1000` which overrules the default z-index of `.textcomplete-dropdown` that is set to `100`.

This PR sets the z-index to `2000` to have the autocomplete component always on top.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3939)
<!-- Reviewable:end -->
