### PR TITLE
[Admin panel] Added a parameter to display or not the visibility of a board in private mode only

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -157,6 +157,7 @@
     "Integrations": true,
     "HTTP": true,
     "AccountSettings": true,
+    "TableVisibilityModeSettings": true,
     "Announcements": true,
     "Swimlanes": true,
     "ChecklistItems": true,

--- a/client/components/boards/boardHeader.jade
+++ b/client/components/boards/boardHeader.jade
@@ -147,14 +147,15 @@ template(name="boardVisibilityList")
           if visibilityCheck
             i.fa.fa-check
           span.sub-name {{_ 'private-desc'}}
-    li
-      with "public"
-        a.js-select-visibility
-          i.fa.fa-globe.colorful
-          | {{_ 'public'}}
-          if visibilityCheck
-            i.fa.fa-check
-          span.sub-name {{_ 'public-desc'}}
+    if notAllowPrivateVisibilityOnly
+      li
+        with "public"
+          a.js-select-visibility
+            i.fa.fa-globe.colorful
+            | {{_ 'public'}}
+            if visibilityCheck
+              i.fa.fa-check
+            span.sub-name {{_ 'public-desc'}}
 
 template(name="boardChangeVisibilityPopup")
   +boardVisibilityList

--- a/client/components/boards/boardHeader.js
+++ b/client/components/boards/boardHeader.js
@@ -194,6 +194,11 @@ const CreateBoard = BlazeComponent.extendComponent({
     this.visibilityMenuIsOpen = new ReactiveVar(false);
     this.visibility = new ReactiveVar('private');
     this.boardId = new ReactiveVar('');
+    Meteor.subscribe('tableVisibilityModeSettings');
+  },
+
+  notAllowPrivateVisibilityOnly(){
+    return !TableVisibilityModeSettings.findOne('tableVisibilityMode-allowPrivateOnly').booleanValue;
   },
 
   visibilityCheck() {
@@ -310,6 +315,9 @@ const CreateBoard = BlazeComponent.extendComponent({
 }.register('headerBarCreateBoardPopup'));
 
 BlazeComponent.extendComponent({
+  notAllowPrivateVisibilityOnly(){
+    return !TableVisibilityModeSettings.findOne('tableVisibilityMode-allowPrivateOnly').booleanValue;
+  },
   visibilityCheck() {
     const currentBoard = Boards.findOne(Session.get('currentBoard'));
     return this.currentData() === currentBoard.permission;

--- a/client/components/settings/settingBody.jade
+++ b/client/components/settings/settingBody.jade
@@ -23,6 +23,10 @@ template(name="setting")
                 i.fa.fa-users
                 | {{_ 'accounts'}}
             li
+              a.js-setting-menu(data-id="tableVisibilityMode-setting")
+                i.fa.fa-eye
+                | {{_ 'tableVisibilityMode'}}
+            li
               a.js-setting-menu(data-id="announcement-setting")
                 i.fa.fa-bullhorn
                 | {{_ 'admin-announcement'}}
@@ -44,6 +48,8 @@ template(name="setting")
               +email
           else if accountSetting.get
             +accountSettings
+          else if tableVisibilityModeSetting.get
+            +tableVisibilityModeSettings
           else if announcementSetting.get
             +announcementSettings
           else if layoutSetting.get
@@ -96,7 +102,7 @@ template(name='email')
     //  li.smtp-form
     //    .title {{_ 'smtp-username'}}
     //    .form-group
-    //      input.wekan-form-control#mail-server-username(type="text", placeholder="{{_ 'username'}}" value="{{currentSetting.mailServer.username}}")
+    //      input.wekan-form-control#mail-server-u"accounts-allowUserNameChange": "Allow Username Change",sername(type="text", placeholder="{{_ 'username'}}" value="{{currentSetting.mailServer.username}}")
     //  li.smtp-form
     //    .title {{_ 'smtp-password'}}
     //    .form-group
@@ -119,6 +125,17 @@ template(name='email')
 
     li
       button.js-send-smtp-test-email.primary {{_ 'send-smtp-test'}}
+
+template(name='tableVisibilityModeSettings')
+  ul#tableVisibilityMode-setting.setting-detail
+    li.tableVisibilityMode-form
+      .title {{_ 'tableVisibilityMode-allowPrivateOnly'}}
+      .form-group.flex
+        input.wekan-form-control#accounts-allowPrivateOnly(type="radio" name="allowPrivateOnly" value="true" checked="{{#if allowPrivateOnly}}checked{{/if}}")
+        span {{_ 'yes'}}
+        input.wekan-form-control#accounts-allowPrivateOnly(type="radio" name="allowPrivateOnly" value="false" checked="{{#unless allowPrivateOnly}}checked{{/unless}}")
+        span {{_ 'no'}}
+      button.js-tableVisibilityMode-save.primary {{_ 'save'}}
 
 template(name='accountSettings')
   ul#account-setting.setting-detail

--- a/client/components/settings/settingBody.js
+++ b/client/components/settings/settingBody.js
@@ -7,6 +7,7 @@ BlazeComponent.extendComponent({
     this.generalSetting = new ReactiveVar(true);
     this.emailSetting = new ReactiveVar(false);
     this.accountSetting = new ReactiveVar(false);
+    this.tableVisibilityModeSetting = new ReactiveVar(false);
     this.announcementSetting = new ReactiveVar(false);
     this.layoutSetting = new ReactiveVar(false);
     this.webhookSetting = new ReactiveVar(false);
@@ -14,6 +15,7 @@ BlazeComponent.extendComponent({
     Meteor.subscribe('setting');
     Meteor.subscribe('mailServer');
     Meteor.subscribe('accountSettings');
+    Meteor.subscribe('tableVisibilityModeSettings');
     Meteor.subscribe('announcements');
     Meteor.subscribe('globalwebhooks');
   },
@@ -88,6 +90,7 @@ BlazeComponent.extendComponent({
       this.announcementSetting.set('announcement-setting' === targetID);
       this.layoutSetting.set('layout-setting' === targetID);
       this.webhookSetting.set('webhook-setting' === targetID);
+      this.tableVisibilityModeSetting.set('tableVisibilityMode-setting' === targetID);
     }
   },
 
@@ -316,6 +319,46 @@ BlazeComponent.extendComponent({
     ];
   },
 }).register('accountSettings');
+
+BlazeComponent.extendComponent({
+  saveTableVisibilityChange() {
+    const allowPrivateOnly =
+      $('input[name=allowPrivateOnly]:checked').val() === 'true';
+    TableVisibilityModeSettings.update('tableVisibilityMode-allowPrivateOnly', {
+      $set: { booleanValue: allowPrivateOnly },
+    });
+  },
+  allowPrivateOnly() {
+    return TableVisibilityModeSettings.findOne('tableVisibilityMode-allowPrivateOnly').booleanValue;
+  },
+  allHideSystemMessages() {
+    Meteor.call('setAllUsersHideSystemMessages', (err, ret) => {
+      if (!err && ret) {
+        if (ret === true) {
+          const message = `${TAPi18n.__(
+            'now-system-messages-of-all-users-are-hidden',
+          )}`;
+          alert(message);
+        }
+      } else {
+        const reason = err.reason || '';
+        const message = `${TAPi18n.__(err.error)}\n${reason}`;
+        alert(message);
+      }
+    });
+  },
+
+  events() {
+    return [
+      {
+        'click button.js-tableVisibilityMode-save': this.saveTableVisibilityChange,
+      },
+      {
+        'click button.js-all-hide-system-messages': this.allHideSystemMessages,
+      },
+    ];
+  },
+}).register('tableVisibilityModeSettings');
 
 BlazeComponent.extendComponent({
   onCreated() {

--- a/i18n/ar-EG.i18n.json
+++ b/i18n/ar-EG.i18n.json
@@ -657,6 +657,8 @@
     "accounts": "Accounts",
     "accounts-allowEmailChange": "Allow Email Change",
     "accounts-allowUserNameChange": "Allow Username Change",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "createdAt": "Created at",
     "modifiedAt": "Modified at",
     "verified": "Verified",

--- a/i18n/ar.i18n.json
+++ b/i18n/ar.i18n.json
@@ -657,6 +657,8 @@
     "accounts": "الحسابات",
     "accounts-allowEmailChange": "السماح بتغيير البريد الإلكتروني",
     "accounts-allowUserNameChange": "Allow Username Change",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "createdAt": "Created at",
     "modifiedAt": "Modified at",
     "verified": "Verified",

--- a/i18n/bg.i18n.json
+++ b/i18n/bg.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/br.i18n.json
+++ b/i18n/br.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/ca.i18n.json
+++ b/i18n/ca.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignat",

--- a/i18n/cs.i18n.json
+++ b/i18n/cs.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Jste si jisti, že chcete smazat tento tým? Tuto akci nelze vrátit zpět.",
     "delete-org-confirm-popup": "Jste si jisti, že chcete smazat tuto organizaci? Tuto akci nelze vrátit zpět.",
     "accounts-allowUserDelete": "Dovolit uživatelům smazat vlastní účet",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Skrýt text popisku minikarty",
     "show-desktop-drag-handles": "Zobrazit okraje pro přesun plochy",
     "assignee": "Řešitel",

--- a/i18n/da.i18n.json
+++ b/i18n/da.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Tillad brugere at slette deres egen konto",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Skjul etiketteteksten for minikort",
     "show-desktop-drag-handles": "Vis trække-håndtag for skrivebord",
     "assignee": "Tildelt til",

--- a/i18n/de-CH.i18n.json
+++ b/i18n/de-CH.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Sind Sie sicher, dass Sie dieses Team löschen möchten? Es gibt kein Zurück!",
     "delete-org-confirm-popup": "Sind Sie sicher, dass Sie diese Organisation löschen möchten? Es gibt kein Zurück!",
     "accounts-allowUserDelete": "Erlaube Benutzern ihren eigenen Account zu löschen",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Labeltext auf Minikarte ausblenden",
     "show-desktop-drag-handles": "Desktop-Ziehpunkte anzeigen",
     "assignee": "Zugewiesen",

--- a/i18n/de.i18n.json
+++ b/i18n/de.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Sind Sie sicher, daß Sie dieses Team löschen wollen? Es gibt keine Möglichkeit, das rückgängig zu machen.",
     "delete-org-confirm-popup": "Sind Sie sicher, daß Sie diese Organisation löschen wollen? Es gibt keine Möglichkeit, das rückgängig zu machen.",
     "accounts-allowUserDelete": "Erlaube Benutzern ihren eigenen Account zu löschen",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Labeltext auf Minikarte ausblenden",
     "show-desktop-drag-handles": "Desktop-Ziehpunkte anzeigen",
     "assignee": "Zugewiesen",

--- a/i18n/el.i18n.json
+++ b/i18n/el.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/en-GB.i18n.json
+++ b/i18n/en-GB.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/en-IT.i18n.json
+++ b/i18n/en-IT.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -657,6 +657,8 @@
   "accounts": "Accounts",
   "accounts-allowEmailChange": "Allow Email Change",
   "accounts-allowUserNameChange": "Allow Username Change",
+  "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
   "createdAt": "Created at",
   "modifiedAt": "Modified at",
   "verified": "Verified",

--- a/i18n/eo.i18n.json
+++ b/i18n/eo.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/es-AR.i18n.json
+++ b/i18n/es-AR.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/es-CL.i18n.json
+++ b/i18n/es-CL.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Permitir a los usuarios eliminar su cuenta",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Ocultar el texto de la etiqueta de la minitarjeta",
     "show-desktop-drag-handles": "Mostrar los controles de arrastre del escritorio",
     "assignee": "Asignado",

--- a/i18n/es-LA.i18n.json
+++ b/i18n/es-LA.i18n.json
@@ -657,6 +657,8 @@
     "accounts": "Accounts",
     "accounts-allowEmailChange": "Allow Email Change",
     "accounts-allowUserNameChange": "Allow Username Change",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "createdAt": "Created at",
     "modifiedAt": "Modified at",
     "verified": "Verified",

--- a/i18n/es-MX.i18n.json
+++ b/i18n/es-MX.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/es-PE.i18n.json
+++ b/i18n/es-PE.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Permitir a los usuarios eliminar su cuenta",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Ocultar el texto de la etiqueta de la minitarjeta",
     "show-desktop-drag-handles": "Mostrar los controles de arrastre del escritorio",
     "assignee": "Asignado",

--- a/i18n/es-PY.i18n.json
+++ b/i18n/es-PY.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/es.i18n.json
+++ b/i18n/es.i18n.json
@@ -657,6 +657,8 @@
     "accounts": "Cuentas",
     "accounts-allowEmailChange": "Permitir cambiar el correo electrónico",
     "accounts-allowUserNameChange": "Permitir cambiar el nombre de usuario",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "createdAt": "Fecha de alta",
     "modifiedAt": "Modified at",
     "verified": "Verificado",

--- a/i18n/eu.i18n.json
+++ b/i18n/eu.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/fa-IR.i18n.json
+++ b/i18n/fa-IR.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/fa.i18n.json
+++ b/i18n/fa.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "به کاربران اجازه دهید خودشان اکانتشان را حذف کنند",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "مخفی کردن اسم لیبل مینی کارت",
     "show-desktop-drag-handles": "نمایش دستگیره‌های درگ‌کردن دسکتاپ",
     "assignee": "محول شده",

--- a/i18n/fi.i18n.json
+++ b/i18n/fi.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Haluatko varmasti poistaa tämän tiimin? Tätä ei voi peruuttaa.",
     "delete-org-confirm-popup": "Haluatko varmasti poistaa tämän organisaation? Tätä ei voi peruuttaa.",
     "accounts-allowUserDelete": "Salli käyttäjien poistaa tilinsä itse",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Piilota minikortin nimilappu teksti",
     "show-desktop-drag-handles": "Näytä työpöydän vedon kahvat",
     "assignee": "Käsittelijä",

--- a/i18n/fr-CH.i18n.json
+++ b/i18n/fr-CH.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/fr.i18n.json
+++ b/i18n/fr.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Autoriser les utilisateurs à supprimer leur compte",
     "hide-minicard-label-text": "Cacher l'étiquette de la minicarte",
     "show-desktop-drag-handles": "Voir les poignées de déplacement du bureau",
+    "tableVisibilityMode-allowPrivateOnly": "[Mode de visibilité d'un tableau] Autoriser le mode privé uniquement",
+    "tableVisibilityMode" : "Mode de visibilité d'un tableau",
     "assignee": "Personne assignée",
     "cardAssigneesPopup-title": "Personne assignée",
     "addmore-detail": "Ajouter une description plus détaillée",

--- a/i18n/gl.i18n.json
+++ b/i18n/gl.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/he.i18n.json
+++ b/i18n/he.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "למחוק את הצוות הזה? אי אפשר לשחזר.",
     "delete-org-confirm-popup": "למחוק את הארגון הזה? אי אפשר לשחזר.",
     "accounts-allowUserDelete": "לאפשר למשתמשים למחוק את החשבונות של עצמם",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "הסתרת טקסט התווית של מיני כרטיס",
     "show-desktop-drag-handles": "הצגת ידיות גרירה של שולחן העבודה",
     "assignee": "גורם אחראי",

--- a/i18n/hi.i18n.json
+++ b/i18n/hi.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/hr.i18n.json
+++ b/i18n/hr.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/hu.i18n.json
+++ b/i18n/hu.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Rejtse el a Címke szövegét a mini Kártyákon",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Felelős",

--- a/i18n/hy.i18n.json
+++ b/i18n/hy.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",
     "addmore-detail": "Add a more detailed description",

--- a/i18n/id.i18n.json
+++ b/i18n/id.i18n.json
@@ -859,6 +859,8 @@
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Sembunyikan teks label kartu mini",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "show-desktop-drag-handles": "Tampilkan gagang seret desktop",
     "assignee": "Penerima tugas",
     "cardAssigneesPopup-title": "Penerima tugas",

--- a/i18n/ig.i18n.json
+++ b/i18n/ig.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",
     "addmore-detail": "Add a more detailed description",

--- a/i18n/it.i18n.json
+++ b/i18n/it.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Permetti agli utenti di cancellare il loro profilo",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Nascondi etichetta minicard",
     "show-desktop-drag-handles": "Mostra maniglie di trascinamento del desktop",
     "assignee": "Assegnatario",

--- a/i18n/ja.i18n.json
+++ b/i18n/ja.i18n.json
@@ -859,6 +859,8 @@
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "ユーザー自身のアカウント削除を許可",
     "hide-minicard-label-text": "ミニカードのラベル名を隠す",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "show-desktop-drag-handles": "デスクトップへのドラッグハンドルを表示",
     "assignee": "担当者",
     "cardAssigneesPopup-title": "担当者",

--- a/i18n/ka.i18n.json
+++ b/i18n/ka.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/km.i18n.json
+++ b/i18n/km.i18n.json
@@ -656,6 +656,8 @@
     "no": "No",
     "accounts": "Accounts",
     "accounts-allowEmailChange": "Allow Email Change",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "accounts-allowUserNameChange": "Allow Username Change",
     "createdAt": "Created at",
     "modifiedAt": "Modified at",

--- a/i18n/ko.i18n.json
+++ b/i18n/ko.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/lt.i18n.json
+++ b/i18n/lt.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/lv.i18n.json
+++ b/i18n/lv.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Ļaut lietotājiem dzēst savus kontus",
     "hide-minicard-label-text": "Slēpt birku tekstu mini kartiņā",
     "show-desktop-drag-handles": "Rādīt darba virsmas vilkšanas simbolus",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Īpašnieks",
     "cardAssigneesPopup-title": "Īpašnieks",
     "addmore-detail": "Pievienot detalizētāku aprakstu",

--- a/i18n/mk.i18n.json
+++ b/i18n/mk.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",
     "addmore-detail": "Add a more detailed description",

--- a/i18n/mn.i18n.json
+++ b/i18n/mn.i18n.json
@@ -657,6 +657,8 @@
     "accounts": "Accounts",
     "accounts-allowEmailChange": "Allow Email Change",
     "accounts-allowUserNameChange": "Allow Username Change",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "createdAt": "Created at",
     "modifiedAt": "Modified at",
     "verified": "Verified",

--- a/i18n/nb.i18n.json
+++ b/i18n/nb.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Er du sikker på at du vil slette Teamet? Du kan ikke angre.",
     "delete-org-confirm-popup": "Er du sikker på at du vil slette denne Organisasjonen? Du kan ikke angre.",
     "accounts-allowUserDelete": "Tillat brukere å slette egen konto",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Skjul tekst på etikett",
     "show-desktop-drag-handles": "Vis ikon for flytting av kort",
     "assignee": "Tildelt",

--- a/i18n/nl.i18n.json
+++ b/i18n/nl.i18n.json
@@ -657,6 +657,8 @@
     "accounts": "Accounts",
     "accounts-allowEmailChange": "Sta E-mailadres wijzigingen toe",
     "accounts-allowUserNameChange": "Sta Gebruikersnaam wijzigingen toe",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "createdAt": "Aangemaakt op",
     "modifiedAt": "Gewijzigd op",
     "verified": "Geverifieerd",

--- a/i18n/oc.i18n.json
+++ b/i18n/oc.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/pa.i18n.json
+++ b/i18n/pa.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",

--- a/i18n/pl.i18n.json
+++ b/i18n/pl.i18n.json
@@ -861,6 +861,8 @@
     "hide-minicard-label-text": "Ukryj opisy etykiet minikart",
     "show-desktop-drag-handles": "Pokaż przeciągnięcia na pulpit",
     "assignee": "Przypisani",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "cardAssigneesPopup-title": "Przypisani",
     "addmore-detail": "Dodaj bardziej szczegółowy opis",
     "show-on-card": "Pokaż na karcie",

--- a/i18n/pt-BR.i18n.json
+++ b/i18n/pt-BR.i18n.json
@@ -863,6 +863,8 @@
     "assignee": "Administrador",
     "cardAssigneesPopup-title": "Administrador",
     "addmore-detail": "Adicionar descrição detalhada",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "show-on-card": "Mostrar no Cartão",
     "new": "Novo",
     "editOrgPopup-title": "Editar Organização",

--- a/i18n/pt.i18n.json
+++ b/i18n/pt.i18n.json
@@ -657,6 +657,8 @@
     "accounts": "Contas",
     "accounts-allowEmailChange": "Permitir Alteração do E-mail",
     "accounts-allowUserNameChange": "Permitir Alteração de Nome de Utilizador",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "createdAt": "Criado em",
     "modifiedAt": "Modificado em",
     "verified": "Verificado",

--- a/i18n/ro.i18n.json
+++ b/i18n/ro.i18n.json
@@ -859,6 +859,8 @@
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Hide minicard label text",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",

--- a/i18n/ru.i18n.json
+++ b/i18n/ru.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Вы уверены, что хотите удалить эту команду? Эту операцию нельзя отменить.",
     "delete-org-confirm-popup": "Вы уверены, что хотите удалить эту организацию? Эту операцию нельзя отменить.",
     "accounts-allowUserDelete": "Разрешить пользователям удалять собственные аккаунты",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Скрыть текст меток на карточках",
     "show-desktop-drag-handles": "Показать ярлыки для перетаскивания",
     "assignee": "Исполнитель",

--- a/i18n/sk.i18n.json
+++ b/i18n/sk.i18n.json
@@ -859,6 +859,8 @@
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Hide minicard label text",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "show-desktop-drag-handles": "Show desktop drag handles",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",

--- a/i18n/sl.i18n.json
+++ b/i18n/sl.i18n.json
@@ -859,6 +859,8 @@
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Dovoli uporabnikom, da sami izbrišejo svoj račun",
     "hide-minicard-label-text": "Skrij besedilo oznak na karticah",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "show-desktop-drag-handles": "Pokaži ročke za povleko na namizju",
     "assignee": "Dodeljen član",
     "cardAssigneesPopup-title": "Dodeljen član",

--- a/i18n/sr.i18n.json
+++ b/i18n/sr.i18n.json
@@ -859,6 +859,8 @@
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Dozvoli korisnicima da sami brišu svoj nalog",
     "hide-minicard-label-text": "Sakrij tekst nalepnice minikartice",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "show-desktop-drag-handles": "Prikaži kvake za povlačenje sa radne površine",
     "assignee": "Zastupnik",
     "cardAssigneesPopup-title": "Zastupnik",

--- a/i18n/sv.i18n.json
+++ b/i18n/sv.i18n.json
@@ -858,6 +858,8 @@
     "delete-team-confirm-popup": "Are you sure you want to delete this team? There is no undo.",
     "delete-org-confirm-popup": "Are you sure you want to delete this organization? There is no undo.",
     "accounts-allowUserDelete": "Tillåt användare att själv ta bort sina konton",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "hide-minicard-label-text": "Dölj etikett för minikort",
     "show-desktop-drag-handles": "Visa greppytor i desktop",
     "assignee": "Tilldelad till",

--- a/i18n/sw.i18n.json
+++ b/i18n/sw.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",
     "addmore-detail": "Add a more detailed description",

--- a/i18n/ta.i18n.json
+++ b/i18n/ta.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",
     "addmore-detail": "Add a more detailed description",

--- a/i18n/th.i18n.json
+++ b/i18n/th.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Allow users to self delete their account",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",
     "addmore-detail": "Add a more detailed description",

--- a/i18n/tr.i18n.json
+++ b/i18n/tr.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Kullanıcılara hesaplarını silmek için izin ver.",
     "hide-minicard-label-text": "Mini kart etiklerini gizle",
     "show-desktop-drag-handles": "Masaüstü sürükleme tutamaçlarını göster",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Atanan",
     "cardAssigneesPopup-title": "Atanan",
     "addmore-detail": "Daha ayrıntılı bir açıklama ekle",

--- a/i18n/uk.i18n.json
+++ b/i18n/uk.i18n.json
@@ -860,6 +860,8 @@
     "accounts-allowUserDelete": "Дозволити користувачам видаляти їх власні облікові записи",
     "hide-minicard-label-text": "Hide minicard label text",
     "show-desktop-drag-handles": "Show desktop drag handles",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "assignee": "Assignee",
     "cardAssigneesPopup-title": "Assignee",
     "addmore-detail": "Add a more detailed description",

--- a/i18n/vi.i18n.json
+++ b/i18n/vi.i18n.json
@@ -862,6 +862,8 @@
     "show-desktop-drag-handles": "Hiển thị nút kéo thả trên Desktop",
     "assignee": "Người được giao",
     "cardAssigneesPopup-title": "Người được giao",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "addmore-detail": "Thêm mô tả chi tiết hơn",
     "show-on-card": "Hiển thị trên thẻ",
     "new": "Mới",

--- a/i18n/zh-CN.i18n.json
+++ b/i18n/zh-CN.i18n.json
@@ -863,6 +863,8 @@
     "assignee": "被指派人",
     "cardAssigneesPopup-title": "被指派人",
     "addmore-detail": "添加更详细的说明",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "show-on-card": "显示卡片",
     "new": "新",
     "editOrgPopup-title": "编辑组织",

--- a/i18n/zh-HK.i18n.json
+++ b/i18n/zh-HK.i18n.json
@@ -865,6 +865,8 @@
     "addmore-detail": "Add a more detailed description",
     "show-on-card": "Show on Card",
     "new": "New",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "editOrgPopup-title": "Edit Organization",
     "newOrgPopup-title": "New Organization",
     "editTeamPopup-title": "Edit Team",

--- a/i18n/zh-TW.i18n.json
+++ b/i18n/zh-TW.i18n.json
@@ -869,6 +869,8 @@
     "newOrgPopup-title": "新建組織",
     "editTeamPopup-title": "編輯團隊",
     "newTeamPopup-title": "新建團隊",
+    "tableVisibilityMode-allowPrivateOnly": "[Board visibility Mode] Allow private mode only",
+    "tableVisibilityMode" : "Board visibility mode",
     "editUserPopup-title": "編輯使用者",
     "newUserPopup-title": "新增使用者",
     "notifications": "通知",

--- a/models/tableVisibilityModeSettings.js
+++ b/models/tableVisibilityModeSettings.js
@@ -1,0 +1,73 @@
+TableVisibilityModeSettings = new Mongo.Collection('tableVisibilityModeSettings');
+
+TableVisibilityModeSettings.attachSchema(
+  new SimpleSchema({
+    _id: {
+      type: String,
+    },
+    booleanValue: {
+      type: Boolean,
+      optional: true,
+    },
+    sort: {
+      type: Number,
+      decimal: true,
+    },
+    createdAt: {
+      type: Date,
+      optional: true,
+      // eslint-disable-next-line consistent-return
+      autoValue() {
+        if (this.isInsert) {
+          return new Date();
+        } else if (this.isUpsert) {
+          return { $setOnInsert: new Date() };
+        } else {
+          this.unset();
+        }
+      },
+    },
+    modifiedAt: {
+      type: Date,
+      denyUpdate: false,
+      // eslint-disable-next-line consistent-return
+      autoValue() {
+        if (this.isInsert || this.isUpsert || this.isUpdate) {
+          return new Date();
+        } else {
+          this.unset();
+        }
+      },
+    },
+  }),
+);
+
+TableVisibilityModeSettings.allow({
+  update(userId) {
+    const user = Users.findOne(userId);
+    return user && user.isAdmin;
+  },
+});
+
+if (Meteor.isServer) {
+  Meteor.startup(() => {
+    TableVisibilityModeSettings._collection._ensureIndex({ modifiedAt: -1 });
+    TableVisibilityModeSettings.upsert(
+      { _id: 'tableVisibilityMode-allowPrivateOnly' },
+      {
+        $setOnInsert: {
+          booleanValue: false,
+          sort: 0,
+        },
+      },
+    );
+  });
+}
+
+TableVisibilityModeSettings.helpers({
+  allowPrivateOnly() {
+    return TableVisibilityModeSettings.findOne('tableVisibilityMode-allowPrivateOnly').booleanValue;
+  },
+});
+
+export default TableVisibilityModeSettings;

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1,4 +1,5 @@
 import AccountSettings from '../models/accountSettings';
+import TableVisibilityModeSettings from '../models/tableVisibilityModeSettings';
 import Actions from '../models/actions';
 import Activities from '../models/activities';
 import Announcements from '../models/announcements';
@@ -645,6 +646,7 @@ Migrations.add('mutate-boardIds-in-customfields', () => {
 
 const modifiedAtTables = [
   AccountSettings,
+  TableVisibilityModeSettings,
   Actions,
   Activities,
   Announcements,
@@ -699,6 +701,7 @@ Migrations.add('add-missing-created-and-modified', () => {
 Migrations.add('fix-incorrect-dates', () => {
   const tables = [
     AccountSettings,
+    TableVisibilityModeSettings,
     Actions,
     Activities,
     Announcements,

--- a/server/publications/tableVisibilityModeSettings.js
+++ b/server/publications/tableVisibilityModeSettings.js
@@ -1,0 +1,3 @@
+Meteor.publish('tableVisibilityModeSettings', function() {
+  return TableVisibilityModeSettings.find();
+});


### PR DESCRIPTION
I added a setting in admin panel page, so that an admin user can activate or not a possibility of creating board in private mode only (see gif image below)

![parameter for board private visibilility](https://user-images.githubusercontent.com/83423044/131143604-80b81a1b-28da-493c-afde-adab29e225d2.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3976)
<!-- Reviewable:end -->
