### PR TITLE
Fix: Incorrect card numbers for sub tasks

### DIFF
--- a/client/components/cards/subtasks.js
+++ b/client/components/cards/subtasks.js
@@ -37,6 +37,8 @@ BlazeComponent.extendComponent({
         ? targetBoard.getDefaultSwimline()._id
         : targetSwimlane._id;
 
+    const nextCardNumber = targetBoard.getNextCardNumber();
+
     if (title) {
       const _id = Cards.insert({
         title,
@@ -49,6 +51,7 @@ BlazeComponent.extendComponent({
         sort: sortIndex,
         swimlaneId,
         type: 'cardType-card',
+        cardNumber: nextCardNumber
       });
 
       // In case the filter is active we need to add the newly inserted card in


### PR DESCRIPTION
@xet7 This fixes issue https://github.com/wekan/wekan/issues/3970 

which addresses incorrect card numbers for subtasks.
since subtasks can be stored basically in any board (in the same board or in another board) the subtask will always be assigned the next card number of the target board.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3977)
<!-- Reviewable:end -->
