### PR TITLE
Fix first user creation for via OIDC

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -1274,7 +1274,6 @@ if (Meteor.isServer) {
     const userCount = Users.find().count();
     if (userCount === 0) {
       user.isAdmin = true;
-      return user;
     }
 
     if (user.services.oidc) {


### PR DESCRIPTION
When setting up a new deploy and registering the first user via OIDC no profile information would be populated. This also prevented updating profile information as the client would error when encountering a null email value. I manually tested this change against the OIDC use case, but, not others. This fix should address #2444

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/3994)
<!-- Reviewable:end -->
