### PR TITLE
Feature: allow word match for rules -> title filter

### DIFF
--- a/server/rulesHelper.js
+++ b/server/rulesHelper.js
@@ -47,8 +47,12 @@ RulesHelper = {
           value = oldSwimlane.title;
         }
       }
+      let matchesList = [value, '*'];
+      if (field === 'cardTitle') {
+        matchesList = value.split(/\W/).concat(matchesList);
+      }
       matchingMap[field] = {
-        $in: [value, '*'],
+        $in: matchesList,
       };
     });
     return matchingMap;


### PR DESCRIPTION
e.g. card title filter 'Foo' will now match both cards named 'Foo', 'Foo bar' and "Foo: bar"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4025)
<!-- Reviewable:end -->
