### PR TITLE
Fix: clean up /tmp after Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -309,6 +309,7 @@ RUN \
     apt-get remove --purge -y ${BUILD_DEPS} && \
     apt-get autoremove -y && \
     npm uninstall -g api2html &&\
+    rm -R /tmp* && \
     rm -R /var/lib/apt/lists/* && \
     rm -R /home/wekan/.meteor && \
     rm -R /home/wekan/app && \


### PR DESCRIPTION
This drastically reduces docker image size from ~280 MB to ~180 MB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4026)
<!-- Reviewable:end -->
