### PR TITLE
Allow setting custom kubernetes labels when using the helm chart

### DIFF
--- a/helm/wekan/templates/deployment.yaml
+++ b/helm/wekan/templates/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
     component: wekan
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.deploymentLabels }}
+    {{- toYaml .Values.deploymentLabels | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -22,6 +25,9 @@ spec:
         app: {{ template "wekan.name" . }}
         component: wekan
         release: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "wekan.serviceAccountName" . }}
       containers:

--- a/helm/wekan/values.yaml
+++ b/helm/wekan/values.yaml
@@ -103,6 +103,12 @@ autoscaling:
     ##
     targetCPUUtilizationPercentage: 80
 
+# Optional custom labels for the deployment resource.
+deploymentLabels: {}
+
+# Optional custom labels for the pods created by the deployment.
+podLabels: {}
+
 # ------------------------------------------------------------------------------
 # MongoDB:
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This adds two helm values to the helm chart, for setting custom kubernetes labels on the `Deployment` object, and on the `Pod`s created by the deployment.

We need this when using the backup system velero, to specify which components need to be restored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4031)
<!-- Reviewable:end -->
