### PR TITLE
Re-enables custom schemes auto linking

### DIFF
--- a/packages/markdown/src/template-integration.js
+++ b/packages/markdown/src/template-integration.js
@@ -9,7 +9,7 @@ var Markdown = require('markdown-it')({
 
 import markdownItMermaid from "@liradb2000/markdown-it-mermaid";
 
-/*
+
 // Static URL Scheme Listing
 var urlschemes = [
   "aodroplink",
@@ -22,6 +22,10 @@ var urlschemes = [
   "mailspring"
 ];
 
+
+
+
+
 // Better would be a field in the admin backend to set this dynamically
 // instead of putting all known or wanted url schemes here hard into code
 // but i was not able to access those settings
@@ -33,6 +37,42 @@ for(var i=0; i<urlschemes.length;i++){
   Markdown.linkify.add(urlschemes[i]+":",'http:');
 }
 
+
+// build fitting regex
+var regex = RegExp('^(' + urlschemes.join('|') + '):', 'gim');
+
+// Add a hook to enforce URI scheme allow-list
+DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+  // build an anchor to map URLs to
+  var anchor = document.createElement('a');
+
+  // check all href attributes for validity
+  if (node.hasAttribute('href')) {
+    anchor.href = node.getAttribute('href');
+    if (anchor.protocol && !anchor.protocol.match(regex)) {
+      node.removeAttribute('href');
+    }
+  }
+  // check all action attributes for validity
+  if (node.hasAttribute('action')) {
+    anchor.href = node.getAttribute('action');
+    if (anchor.protocol && !anchor.protocol.match(regex)) {
+      node.removeAttribute('action');
+    }
+  }
+  // check all xlink:href attributes for validity
+  if (node.hasAttribute('xlink:href')) {
+    anchor.href = node.getAttribute('xlink:href');
+    if (anchor.protocol && !anchor.protocol.match(regex)) {
+      node.removeAttribute('xlink:href');
+    }
+  }
+});
+
+
+
+
+/*
 // Additional  safeAttrValue function to allow for other specific protocols
 // See https://github.com/leizongmin/js-xss/issues/52#issuecomment-241354114
 function mySafeAttrValue(tag, name, value, cssFilter) {

--- a/releases/delete-phantomjs.sh
+++ b/releases/delete-phantomjs.sh
@@ -1,3 +1,0 @@
-cd ~/repos/wekan/.build
-find . -name "*phantomjs*" | xargs rm -rf
-cd ~/repos/wekan


### PR DESCRIPTION
Seems like i found the correct snippet to reanable the auto linking feature with DOMpurify.

But still i have the problem to not know how to get the list of url schemes from the settings instead of putting them hard into script.

@xet7 @Emile840 may you have an eye on that?
The setting is in wekan for months but nobody wanted to help me out with that problem. i guess its a really simple thingy but im not that much into meteor coding.

adresses https://github.com/wekan/wekan/issues/3218

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4059)
<!-- Reviewable:end -->
