### PR TITLE
Card labels on minicard withouth text are now at the same line again

### DIFF
--- a/client/components/cards/minicard.jade
+++ b/client/components/cards/minicard.jade
@@ -9,7 +9,7 @@ template(name="minicard")
     if cover
       .minicard-cover(style="background-image: url('{{cover.url}}');")
     if labels
-      .minicard-labels
+      .minicard-labels(class="{{#if hiddenMinicardLabelText}}minicard-labels-no-text{{/if}}")
         each labels
           unless hiddenMinicardLabelText
             span.js-card-label.card-label(class="card-label-{{color}}" title=name)

--- a/client/components/cards/minicard.styl
+++ b/client/components/cards/minicard.styl
@@ -88,6 +88,10 @@
       margin-right: 3px
       margin-bottom: 3px
 
+  .minicard-labels-no-text
+    display: flex
+    flex-wrap: wrap
+
   .minicard-custom-fields
     display:block;
   .minicard-custom-field


### PR DESCRIPTION
Fixes: https://github.com/wekan/wekan/pull/4073#pullrequestreview-793677680

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4109)
<!-- Reviewable:end -->
