### PR TITLE
Card Details, add missing hr line (before Activity title)

### DIFF
--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -547,6 +547,7 @@ template(name="cardDetails")
     .card-details-right
 
       unless currentUser.isNoComments
+        hr
         .activity-title
           h3.card-details-item-title
             i.fa.fa-history


### PR DESCRIPTION
Add missing hr line

<img width="845" alt="card details" src="https://user-images.githubusercontent.com/37017213/140427183-ba3c4985-4fbf-4905-9e5c-4cdf4991b050.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4117)
<!-- Reviewable:end -->
