### PR TITLE
Fix: Impossible to export board to excel where title exceeding 31 chars

### DIFF
--- a/models/server/ExporterExcel.js
+++ b/models/server/ExporterExcel.js
@@ -167,7 +167,11 @@ class ExporterExcel {
     workbook.lastPrinted = new Date();
     const filename = `${result.title}.xlsx`;
     //init worksheet
-    const worksheet = workbook.addWorksheet(result.title, {
+    let worksheetTitle = result.title;
+    if (worksheetTitle.length > 31) {
+      worksheetTitle = TAPi18n.__('board','',this.userLanguage);
+    }
+    const worksheet = workbook.addWorksheet(worksheetTitle, {
       properties: {
         tabColor: {
           argb: 'FFC0000',
@@ -179,7 +183,7 @@ class ExporterExcel {
       },
     });
     //get worksheet
-    const ws = workbook.getWorksheet(result.title);
+    const ws = workbook.getWorksheet(worksheetTitle);
     ws.properties.defaultRowHeight = 20;
     //init columns
     //Excel font. Western: Arial. zh-CN: 宋体


### PR DESCRIPTION
Fix #3589
- If board title is 31 chars or less, just add it in worksheet title
- If board title is over 31 chars, replace worksheet title by 'board'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4119)
<!-- Reviewable:end -->
