### PR TITLE
add native scroll bar deign in main layout stylesheet

### DIFF
--- a/client/components/main/layouts.styl
+++ b/client/components/main/layouts.styl
@@ -2,6 +2,29 @@
 
 global-reset()
 
+
+    * {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0,0,0,.6) #ddf4ff;
+}
+*::-webkit-scrollbar {
+  width: 12px;
+}
+
+   *::-webkit-scrollbar-track {
+  background: #ddf4ff;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: rgba(0,0,0,.6);
+  border-radius: 20px;
+  border: 3px solid #ddf4ff;
+}   
+
+
+
+
+
 *
   -webkit-box-sizing: unset
   box-sizing: unset


### PR DESCRIPTION
Currently, styling scrollbars for Chrome, Edge, and Safari is available with the vendor prefix pseudo-element 
-webkit-scrollbar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4125)
<!-- Reviewable:end -->
