### PR TITLE
[Adding organisations to the board] Layout improvement

### DIFF
--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -91,7 +91,14 @@ template(name="boardOrgGeneral")
   table
     tbody
       tr
-        th {{_ 'displayName'}}
+        th
+          | {{_ 'add-organizations'}}
+          br
+          i.addOrganizationsLabel
+            | {{_ 'to-create-organizations-contact-admin'}}
+          br
+          i.addOrganizationsLabel
+            | {{_ 'add-organizations-label'}}
         th
           if currentUser.isBoardAdmin
             a.member.orgOrTeamMember.add-member.js-manage-board-addOrg(title="{{_ 'add-members'}}")
@@ -106,13 +113,12 @@ template(name="boardTeamGeneral")
     tbody
       tr
         th
-          b
-            | {{_ 'add-teams'}}
+          | {{_ 'add-teams'}}
           br
-          i.addTeamsLabelcss
+          i.addTeamsLabel
             | {{_ 'to-create-teams-contact-admin'}}
           br
-          i.addTeamsLabelcss
+          i.addTeamsLabel
             | {{_ 'add-teams-label'}}
         th
           if currentUser.isBoardAdmin
@@ -488,12 +494,12 @@ template(name="removeBoardOrgPopup")
   form
     input.hide#hideOrgId(type="text" value=org._id)
     label
-      | {{_ 'leave-board'}} ?
+      | {{_ 'remove-organization-from-board'}}
   br
   hr
   div.buttonsContainer
-    input.primary.wide.leaveBoardBtn#leaveBoardBtn(type="submit" value="{{_ 'leave-board'}}")
-    input.primary.wide.cancelLeaveBoardBtn#cancelLeaveBoardBtn(type="submit" value="{{_ 'Cancel'}}")
+    input.primary.wide.leaveBoardBtn#leaveBoardBtn(type="submit" value="{{_ 'confirm-btn'}}")
+    input.primary.wide.cancelLeaveBoardBtn#cancelLeaveBoardBtn(type="submit" value="{{_ 'cancel'}}")
 
 template(name="addBoardTeamPopup")
   select.js-boardTeams#jsBoardTeams

--- a/client/components/sidebar/sidebar.styl
+++ b/client/components/sidebar/sidebar.styl
@@ -225,13 +225,15 @@
   margin-left: 5% !important
   background-color: red !important
 
-.addTeamsLabelcss
-  font-weight: normal;
+.addTeamsLabel, .addOrganizationsLabel
+  font-weight: normal
 
-.js-manage-board-removeTeam
+.js-manage-board-removeTeam:hover, .js-manage-board-removeTeam.is-active,
+.js-manage-board-removeOrg:hover, .js-manage-board-removeOrg.is-active
   box-shadow: 0 0 0 2px #e23210 inset !important
 
-.js-manage-board-addTeam
+.js-manage-board-addTeam:hover, .js-manage-board-addTeam.is-active,
+.js-manage-board-addOrg:hover , .js-manage-board-addOrg.is-active
   box-shadow: 0 0 0 2px #73ea10 inset !important
 
 .addTeamFaPlus

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -1114,5 +1114,9 @@
   "Node_memory_usage_rss": "Node memory usage: resident set size",
   "Node_memory_usage_heap_total": "Node memory usage: total size of the allocated heap",
   "Node_memory_usage_heap_used": "Node memory usage: actual memory used",
-  "Node_memory_usage_external": "Node memory usage: external"
+  "Node_memory_usage_external": "Node memory usage: external",
+  "add-organizations": "Add organizations",
+  "add-organizations-label": "Added organizations are displayed below:",
+  "remove-organization-from-board": "Are you sure you want to remove this organization from the board ?",
+  "to-create-organizations-contact-admin": "To create organizations, please contact administrator."
 }


### PR DESCRIPTION
Form layout "Adding organisations to a board"  improvement, to match layout of [Adding team to the board] form.
(commit f840d26)

Was:
<img width="534" alt="AddRemoveOrgsOrTeamsToBoard-01" src="https://user-images.githubusercontent.com/37017213/141611698-272366f3-62ae-412a-9442-090714eabd7c.png">


Proposed:
<img width="538" alt="AddRemoveOrgsOrTeamsToBoard-02" src="https://user-images.githubusercontent.com/37017213/141611818-d77f2e5e-1444-4364-a7ea-8514bd246dc7.png">

<img width="543" alt="AddRemoveOrgsOrTeamsToBoard-03" src="https://user-images.githubusercontent.com/37017213/141611822-f0faea6c-bcb5-4b49-924c-13d225d61c92.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4143)
<!-- Reviewable:end -->
