### PR TITLE
Fixed trim whitespace at multiline editor fields

### DIFF
--- a/client/lib/inlinedform.js
+++ b/client/lib/inlinedform.js
@@ -49,7 +49,8 @@ InlinedForm = BlazeComponent.extendComponent({
 
   getValue() {
     const input = this.find('textarea,input[type=text]');
-    return this.isOpen.get() && input && input.value.replaceAll(/\s +$/gm, '');
+    // \s without \n + unicode (https://developer.mozilla.org/de/docs/Web/JavaScript/Guide/Regular_Expressions#special-white-space)
+    return this.isOpen.get() && input && input.value.replaceAll(/[ \f\r\t\v]+$/gm, '');
   },
 
   events() {


### PR DESCRIPTION
- before whitespaces were only trimmed if 2 or more whitespaces were at
  the end of the line
- now every whitespace is trimmed at the end of each line

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4146)
<!-- Reviewable:end -->
