### PR TITLE
App reconnect is now possible if the connection was interrupted

### DIFF
--- a/client/components/main/header.jade
+++ b/client/components/main/header.jade
@@ -93,3 +93,6 @@ template(name="offlineWarning")
     p
       i.fa.fa-warning
       | {{_ 'app-is-offline'}}
+
+      a.app-try-reconnect
+        {{_ 'app-try-reconnect'}}

--- a/client/components/main/header.js
+++ b/client/components/main/header.js
@@ -41,3 +41,10 @@ Template.header.events({
     Session.set('currentCard', null);
   },
 });
+
+Template.offlineWarning.events({
+  'click a.app-try-reconnect'(event) {
+    event.preventDefault();
+    Meteor.reconnect();
+  },
+});

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -106,6 +106,7 @@
   "and-n-other-card_plural": "And __count__ other cards",
   "apply": "Apply",
   "app-is-offline": "Loading, please wait. Refreshing the page will cause data loss. If loading does not work, please check that server has not stopped.",
+  "app-try-reconnect": "Try reconnect.",
   "archive": "Move to Archive",
   "archive-all": "Move All to Archive",
   "archive-board": "Move Board to Archive",


### PR DESCRIPTION
Especially on mobile devices after "display on" it takes sometimes a long time to reconnect or in the worst case the app doesn't reconnect, so the user has the chance to manually try to reconnect the wekan app so unsaved edits are tranfered to the server without data lost.

See this screenshot:
![grafik](https://user-images.githubusercontent.com/13166201/141772292-c05d4308-6986-479a-a06e-20454c06a971.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4147)
<!-- Reviewable:end -->
