### PR TITLE
Fixed placeholder was not visible at list view (mobile view)

### DIFF
--- a/client/components/lists/list.styl
+++ b/client/components/lists/list.styl
@@ -180,7 +180,6 @@
     border-bottom: 1px solid darken(white, 20%)
 
   .list
-    display: contents
     flex-basis: auto
     width: 100%
     border-left: 0px


### PR DESCRIPTION
Before
![wekan_list_drag_drop_placeholder_not_visible](https://user-images.githubusercontent.com/13166201/141775802-38be5f08-371b-4c3c-b690-fc90ed4bbcee.gif)
:

After:
![wekan_list_drag_drop_placeholder_visible](https://user-images.githubusercontent.com/13166201/141775823-7ee65047-3d1d-47d2-8521-d1765732d560.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4148)
<!-- Reviewable:end -->
