### PR TITLE
improve multi selection sidebar opening and closing

### DIFF
--- a/client/lib/multiSelection.js
+++ b/client/lib/multiSelection.js
@@ -60,6 +60,8 @@ MultiSelection = {
 
   startRangeCardId: null,
 
+  _sidebarWasOpen: false,
+
   reset() {
     this._selectedCards.set([]);
   },
@@ -84,11 +86,15 @@ MultiSelection = {
 
   activate() {
     if (!this.isActive()) {
+      this._sidebarWasOpen = Sidebar.isOpen();
       EscapeActions.executeUpTo('detailsPane');
       this._isActive.set(true);
       Tracker.flush();
     }
     Sidebar.setView(this.sidebarView);
+    if(Utils.isMiniScreen()) {
+      Sidebar.hide();
+    }
   },
 
   disable() {
@@ -96,6 +102,9 @@ MultiSelection = {
       this._isActive.set(false);
       if (Sidebar && Sidebar.getView() === this.sidebarView) {
         Sidebar.setView();
+        if(!this._sidebarWasOpen) {
+          Sidebar.hide();
+        }
       }
       this.reset();
     }


### PR DESCRIPTION
this patch changes the open/close behavior of the sidebar when
activating and deactiviting the multi selection.

in the past activating the multi selection on a mini screen will hide
the cards and show the multi selection sidebar on the whole screen. a
user would need to hide the sidebar in order to select multiple
cards. this patch changes this behavior. the sidebar will no longer be
opened if the user is on a mini screen while activating the multi
selection.

in the past deactivating the multi selection would show the default
sidebar instead of the multi selection sidebar. after this patch the
default sidebar will only be shown if the sidebar was visible before
activating the multi selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4153)
<!-- Reviewable:end -->
