### PR TITLE
Fix label width oversize bug

### DIFF
--- a/client/components/cards/labels.styl
+++ b/client/components/cards/labels.styl
@@ -146,6 +146,7 @@
     height: 25px
     margin: 0px 3% 7px 0px
     width: 10.5%
+    max-width: 10.5%
     cursor: pointer
 
 .edit-labels


### PR DESCRIPTION
Happens at Firefox zoom level 90%, probably on Windows...

Fixes: https://github.com/wekan/wekan/pull/4073#issuecomment-971563178

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4157)
<!-- Reviewable:end -->
