### PR TITLE
Show or hide members and assignee(s) on minicard

### DIFF
--- a/client/components/cards/minicard.jade
+++ b/client/components/cards/minicard.jade
@@ -88,15 +88,17 @@ template(name="minicard")
                   +viewer
                     = trueValue
 
-    if getAssignees
-      .minicard-assignees.js-minicard-assignees
-        each getAssignees
-          +userAvatar(userId=this)
+    if showAssignee
+      if getAssignees
+        .minicard-assignees.js-minicard-assignees
+          each getAssignees
+            +userAvatar(userId=this)
 
-    if getMembers
-      .minicard-members.js-minicard-members
-        each getMembers
-          +userAvatar(userId=this)
+    if showMembers
+      if getMembers
+        .minicard-members.js-minicard-members
+          each getMembers
+            +userAvatar(userId=this)
 
     if showCreator
       .minicard-creator

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -49,6 +49,28 @@ BlazeComponent.extendComponent({
     return false;
   },
 
+  showMembers() {
+    if (this.data().board()) {
+      return (
+        this.data().board.allowsMembers === null ||
+        this.data().board().allowsMembers === undefined ||
+        this.data().board().allowsMembers
+      );
+    }
+    return false;
+  },
+
+  showAssignee() {
+    if (this.data().board()) {
+      return (
+        this.data().board.allowsAssignee === null ||
+        this.data().board().allowsAssignee === undefined ||
+        this.data().board().allowsAssignee
+      );
+    }
+    return false;
+  },
+
   /** opens the card label popup only if clicked onto a label
    * <li> this is necessary to have the data context of the minicard.
    *      if .js-card-label is used at click event, then only the data context of the label itself is available at this.currentData()


### PR DESCRIPTION
On minicard "Assignee" and/or "Members" could be displayed or hidden like "Creator".
See #4177

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4179)
<!-- Reviewable:end -->
