### PR TITLE
Custom Field StringTemplates didn't save the last input value on touch devices

### DIFF
--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -271,7 +271,7 @@ CardCustomField.register('cardCustomField');
       {
         'submit .js-card-customfield-stringtemplate'(event) {
           event.preventDefault();
-          const items = this.getItems();
+          const items = this.stringtemplateItems.get()
           this.card.setCustomField(this.customFieldId, items);
         },
 


### PR DESCRIPTION
happend when adding a value and clicking the save button without to hit "Enter" before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4188)
<!-- Reviewable:end -->
