### PR TITLE
Move cards to top/bottom ignores the current filter if active

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -658,7 +658,7 @@ Template.cardDetailsActionsPopup.events({
     event.preventDefault();
     const minOrder = _.min(
       this.list()
-        .cards(this.swimlaneId)
+        .cardsUnfiltered(this.swimlaneId)
         .map((c) => c.sort),
     );
     this.move(this.boardId, this.swimlaneId, this.listId, minOrder - 1);
@@ -668,7 +668,7 @@ Template.cardDetailsActionsPopup.events({
     event.preventDefault();
     const maxOrder = _.max(
       this.list()
-        .cards(this.swimlaneId)
+        .cardsUnfiltered(this.swimlaneId)
         .map((c) => c.sort),
     );
     this.move(this.boardId, this.swimlaneId, this.listId, maxOrder + 1);


### PR DESCRIPTION
The problem is, if a filter is set and the card should be moved to e.g. the top though the "hambuger menu" in the card details, the card isn't at the top after removing the filter. Now the card is at top, regardless of a filter or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4192)
<!-- Reviewable:end -->
