### PR TITLE
Fix legal notice traduction bug when refreshing sign in page

### DIFF
--- a/client/components/main/layouts.jade
+++ b/client/components/main/layouts.jade
@@ -50,9 +50,11 @@ template(name="userFormsLayout")
           +connectionMethod(authenticationMethod=currentSetting.defaultAuthenticationMethod)
         if isLegalNoticeLinkExist
           div#legalNoticeDiv
-            span {{_ 'acceptance_of_our_legalNotice'}}
-            a.at-link(href="{{currentSetting.legalNotice}}", target="_blank", rel="noopener noreferrer")
+            span#legalNoticeSpan {{_ 'acceptance_of_our_legalNotice'}}
+            a#legalNoticeAtLink.at-link(href="{{currentSetting.legalNotice}}", target="_blank", rel="noopener noreferrer")
               | {{_ 'legalNotice'}}
+          if getLegalNoticeWithWritTraduction
+            div
         div.at-form-lang
           select.select-lang.js-userform-set-language
             each languages

--- a/client/components/main/layouts.js
+++ b/client/components/main/layouts.js
@@ -86,6 +86,18 @@ Template.userFormsLayout.helpers({
       return false;
   },
 
+  getLegalNoticeWithWritTraduction(){
+    let spanLegalNoticeElt = $("#legalNoticeSpan");
+    if(spanLegalNoticeElt != null && spanLegalNoticeElt != undefined){
+      spanLegalNoticeElt.html(TAPi18n.__('acceptance_of_our_legalNotice', {}, T9n.getLanguage() || 'en'));
+    }
+    let atLinkLegalNoticeElt = $("#legalNoticeAtLink");
+    if(atLinkLegalNoticeElt != null && atLinkLegalNoticeElt != undefined){
+      atLinkLegalNoticeElt.html(TAPi18n.__('legalNotice', {}, T9n.getLanguage() || 'en'));
+    }
+    return true;
+  },
+
   isLoading() {
     return Template.instance().isLoading.get();
   },


### PR DESCRIPTION
Fix legal notice traduction bug : 
When refreshing sign in page legal notice line was always in english even if a given language isn't english (see image below)
![image](https://user-images.githubusercontent.com/83423044/144860439-ffba4b5c-fbe6-4525-b203-1c920a295a65.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4217)
<!-- Reviewable:end -->
