### PR TITLE
Sort Organizations, Teams and People

### DIFF
--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -89,7 +89,7 @@ BlazeComponent.extendComponent({
   },
   teamsDatas() {
     if(Meteor.user().teams)
-      return Meteor.user().teams;
+      return Meteor.user().teams.sort((a, b) => a.teamDisplayName.localeCompare(b.teamDisplayName));
     else
       return [];
   },
@@ -101,7 +101,7 @@ BlazeComponent.extendComponent({
   },
   orgsDatas() {
     if(Meteor.user().orgs)
-      return Meteor.user().orgs;
+      return Meteor.user().orgs.sort((a, b) => a.orgDisplayName.localeCompare(b.orgDisplayName));
     else
       return [];
   },

--- a/client/components/settings/peopleBody.js
+++ b/client/components/settings/peopleBody.js
@@ -254,10 +254,10 @@ Template.editUserPopup.helpers({
     return Template.instance().authenticationMethods.get();
   },
   orgsDatas() {
-    return Org.find({}, {sort: { createdAt: -1 }});
+    return Org.find({}, {sort: { orgDisplayName: 1 }});
   },
   teamsDatas() {
-    return Team.find({}, {sort: { createdAt: -1 }});
+    return Team.find({}, {sort: { teamDisplayName: 1 }});
   },
   isSelected(match) {
     const userId = Template.instance().data.userId;
@@ -327,10 +327,10 @@ Template.newUserPopup.helpers({
     return Template.instance().authenticationMethods.get();
   },
   orgsDatas() {
-    return Org.find({}, {sort: { createdAt: -1 }});
+    return Org.find({}, {sort: { orgDisplayName: 1 }});
   },
   teamsDatas() {
-    return Team.find({}, {sort: { createdAt: -1 }});
+    return Team.find({}, {sort: { teamDisplayName: 1 }});
   },
   isSelected(match) {
     const userId = Template.instance().data.userId;
@@ -420,7 +420,7 @@ BlazeComponent.extendComponent({
 BlazeComponent.extendComponent({
   onCreated() {},
   teamsDatas() {
-    return Team.find({}, {sort: { createdAt: -1 }});
+    return Team.find({}, {sort: { teamDisplayName: 1 }});
   },
   events() {
     return [

--- a/client/components/settings/peopleBody.js
+++ b/client/components/settings/peopleBody.js
@@ -144,6 +144,7 @@ BlazeComponent.extendComponent({
   },
   orgList() {
     const orgs = Org.find(this.findOrgsOptions.get(), {
+      sort: { orgDisplayName: 1 },
       fields: { _id: true },
     });
     this.numberOrgs.set(orgs.count(false));
@@ -151,6 +152,7 @@ BlazeComponent.extendComponent({
   },
   teamList() {
     const teams = Team.find(this.findTeamsOptions.get(), {
+      sort: { teamDisplayName: 1 },
       fields: { _id: true },
     });
     this.numberTeams.set(teams.count(false));
@@ -158,6 +160,7 @@ BlazeComponent.extendComponent({
   },
   peopleList() {
     const users = Users.find(this.findUsersOptions.get(), {
+      sort: { username: 1 },
       fields: { _id: true },
     });
     this.numberPeople.set(users.count(false));

--- a/client/components/sidebar/sidebar.js
+++ b/client/components/sidebar/sidebar.js
@@ -1325,8 +1325,7 @@ BlazeComponent.extendComponent({
 
 Template.addBoardOrgPopup.helpers({
   orgsDatas() {
-    // return Org.find({}, {sort: { createdAt: -1 }});
-    let orgs = Org.find({}, {sort: { createdAt: -1 }});
+    let orgs = Org.find({}, {sort: { orgDisplayName: 1 }});
     return orgs;
   },
 });
@@ -1499,7 +1498,7 @@ BlazeComponent.extendComponent({
 
 Template.addBoardTeamPopup.helpers({
   teamsDatas() {
-    let teams = Team.find({}, {sort: { createdAt: -1 }});
+    let teams = Team.find({}, {sort: { teamDisplayName: 1 }});
     return teams;
   },
 });

--- a/models/org.js
+++ b/models/org.js
@@ -217,7 +217,7 @@ if (Meteor.isServer) {
   // Index for Organization name.
   Meteor.startup(() => {
     // Org._collection._ensureIndex({ name: -1 });
-    Org._collection._ensureIndex({ orgDisplayName: -1 });
+    Org._collection._ensureIndex({ orgDisplayName: 1 });
   });
 }
 

--- a/models/team.js
+++ b/models/team.js
@@ -214,7 +214,7 @@ if (Meteor.isServer) {
 if (Meteor.isServer) {
   // Index for Team name.
   Meteor.startup(() => {
-    Team._collection._ensureIndex({ teamDisplayName: -1 });
+    Team._collection._ensureIndex({ teamDisplayName: 1 });
   });
 }
 

--- a/models/users.js
+++ b/models/users.js
@@ -521,7 +521,7 @@ Users.helpers({
   },
   orgsUserBelongs() {
     if (this.orgs) {
-      return this.orgs.map(function(org){return org.orgDisplayName}).join(',');
+      return this.orgs.map(function(org){return org.orgDisplayName}).sort().join(',');
     }
     return '';
   },
@@ -533,7 +533,7 @@ Users.helpers({
   },
   teamsUserBelongs() {
     if (this.teams) {
-      return this.teams.map(function(team){ return team.teamDisplayName}).join(',');
+      return this.teams.map(function(team){ return team.teamDisplayName}).sort().join(',');
     }
     return '';
   },


### PR DESCRIPTION
See  #4231
At Admin Panel: 
- sort Organizations by orgDisplayName
- sort Teams by teamDisplayName
- sort People (users) by username

All boards view:
- sort Organizations by orgDisplayName
- sort Teams by teamDisplayName

Board view:
- At addBoardOrgPopup: sort Organizations by orgDisplayName
- At addBoardTeamPopup sort Teams by teamDisplayName

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wekan/wekan/4232)
<!-- Reviewable:end -->
