### PR TITLE
Fix getLabels exception in template helper

### DIFF
--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -363,6 +363,9 @@ BlazeComponent.extendComponent({
             const currentBoard = Boards.findOne(Session.get('currentBoard'));
             callback(
               $.map(currentBoard.labels, label => {
+                if (label.name == undefined) {
+                  label.name = "";
+                }
                 if (
                   label.name.indexOf(term) > -1 ||
                   label.color.indexOf(term) > -1

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -277,9 +277,12 @@ BlazeComponent.extendComponent({
 
   getLabels() {
     const currentBoardId = Session.get('currentBoard');
-    return Boards.findOne(currentBoardId).labels.filter(label => {
-      return this.labels.get().indexOf(label._id) > -1;
-    });
+    if (Boards.findOne(currentBoardId).labels) {
+      return Boards.findOne(currentBoardId).labels.filter(label => {
+        return this.labels.get().indexOf(label._id) > -1;
+      });
+    }
+    return false;
   },
 
   pressKey(evt) {


### PR DESCRIPTION
Fix getLabels exception in template helper when board has no labels
Fix getLabels error when boards.labels.name doesn't exists

(refers to https://github.com/wekan/wekan/pull/342 and https://github.com/wekan/wekan/commit/5d77ad4f6ba70038486d734e97844c547e664e88)