### PR TITLE
fix notification drawer always on top

### DIFF
--- a/client/components/cards/cardDetails.styl
+++ b/client/components/cards/cardDetails.styl
@@ -92,7 +92,7 @@ avatar-radius = 50%
   overflow-x: hidden
   background: darken(white, 3%)
   border-radius: bottom 3px
-  z-index: 20 !important
+  z-index: 20
   animation: flexGrowIn 0.1s
   box-shadow: 0 0 7px 0 darken(white, 30%)
   transition: flex-basis 0.1s
@@ -257,7 +257,7 @@ avatar-radius = 50%
     overflow-x: scroll
     background: darken(white, 3%)
     border-radius: bottom 3px
-    z-index: 1000 !important
+    z-index: 100
     animation: flexGrowIn 0.1s
     box-shadow: 0 0 7px 0 darken(white, 30%)
     transition: flex-basis 0.1s

--- a/client/components/main/header.styl
+++ b/client/components/main/header.styl
@@ -99,7 +99,7 @@
   height: 28px
   font-size: 12px
   display: flex
-  z-index: 21
+  z-index: 1000
   padding: 10px 0px
 
   .allBoards


### PR DESCRIPTION
# Old
Currently the notification drawer can be behind other components, which can be annoying.

![pre_fix_notification-drawer](https://user-images.githubusercontent.com/27204450/150202533-040864b1-f27b-4719-9447-9156d3ba5d62.gif)

# New

The notification drawer is now always on top. As far as I tested, the changes did not break anything on the web version of wekan.

![after_fix_notification-drawer](https://user-images.githubusercontent.com/27204450/150202512-884ae65d-2b07-4cfe-882f-423927ee7c40.gif)

