### PR TITLE
Global search: Card Details popup opens now in normal view even if maximized card is configured

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -70,7 +70,7 @@ BlazeComponent.extendComponent({
 
 
   cardMaximized() {
-    return Meteor.user().hasCardMaximized();
+    return !Utils.getPopupCardId() && Meteor.user().hasCardMaximized();
   },
 
   canModifyCard() {


### PR DESCRIPTION
Fixes: #4346