### PR TITLE
add subscription to announcements collection

### DIFF
--- a/client/components/main/header.js
+++ b/client/components/main/header.js
@@ -1,6 +1,7 @@
 Meteor.subscribe('user-admin');
 Meteor.subscribe('boards');
 Meteor.subscribe('setting');
+Meteor.subscribe('announcements');
 Template.header.onCreated(function(){
   const templateInstance = this;
   templateInstance.currentSetting = new ReactiveVar();


### PR DESCRIPTION
Problem: System wide announcements are not shown to regular users (also mentioned in #4355). They are only shown when an admin has opened the admin panel beforehand. In that case `Meteor.subscribe('announcements');` is executed in "client/components/settings/settingBody.js". So the problem seems to be that the announcements collection is not being subscribed otherwise.  