### PR TITLE
Feature/propagate OIDC data

### DIFF
--- a/packages/wekan-oidc/loginHandler.js
+++ b/packages/wekan-oidc/loginHandler.js
@@ -1,0 +1,88 @@
+module.exports = {
+  addGroups: function (user, groups){
+  teamArray=[]
+  teams = user.teams
+  if (!teams)
+  {
+    for (group of groups){
+      team = Team.findOne({"teamDisplayName": group});
+      if (team)
+    {
+      team_hash = {'teamId': team._id, 'teamDisplayName': group}
+      teamArray.push(team_hash);
+    }
+  }
+    teams = {'teams': teamArray}
+    users.update({ _id: user._id }, { $set:  teams});
+    return;
+  }
+  else{
+
+    for (group of groups){
+      team = Team.findOne({"teamDisplayName": group})
+      team_contained= false;
+      if (team)
+      {
+        team_hash = {'teamId': team._id, 'teamDisplayName': group}
+        for (const [count,teams_hash] of Object.entries(teams))
+        {
+          if (teams_hash["teamId"] === team._id)
+          {
+          team_contained=true;
+          break;
+        }
+      }
+      if (team_contained)
+      {
+        continue;
+      }
+      else
+      {
+        console.log("TEAM to be added:", team);
+        teams.push({'teamId': Team.findOne({'teamDisplayName': group})._id, 'teamDisplayName': group});
+      }
+    }
+  }
+  console.log("XXXXXXXXXXX Team Array: ", teams);
+  teams = {'teams': teams}
+  users.update({ _id: user._id }, { $set:  teams});
+  }
+},
+changeUsername: function(user, name)
+{
+  username = {'username': name};
+  if (user.username != username) users.update({ _id: user._id }, { $set:  username});
+},
+changeFullname: function(user, name)
+{
+  username = {'profile.fullname': name};
+  if (user.username != username) users.update({ _id: user._id }, { $set:  username});
+},
+addEmail: function(user, email)
+{
+  user_email = user.emails || [];
+  var contained = false;
+  position = 0;
+  for (const [count, mail_hash] of Object.entries(user_email))
+  {
+    if (mail_hash['address'] === email)
+    {
+      contained = true;
+      position = count;
+      break;
+    }
+  }
+  if(contained && position != 0)
+  {
+    user_email.splice(position,1);
+    contained = false;
+  }
+  if(!contained)
+  {
+    user_email.unshift({'address': email, 'verified': true});
+    user_email = {'emails': user_email};
+    console.log(user_email);
+    users.update({ _id: user._id }, { $set:  user_email});
+  }
+}
+}

--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -18,6 +18,7 @@ if (process.env.OAUTH2_CA_CERT !== undefined) {
 OAuth.registerService('oidc', 2, null, function (query) {
 
   var debug = process.env.DEBUG || false;
+  console.log(process.env);
   var propagateOidcData = process.env.PROPAGATE_OIDC_DATA || false;
 
   var token = getToken(query);
@@ -79,12 +80,12 @@ OAuth.registerService('oidc', 2, null, function (query) {
   profile.email = userinfo[process.env.OAUTH2_EMAIL_MAP]; // || userinfo["email"];
   if (propagateOidcData)
   {
+    users= Meteor.users;
+    user = users.findOne({'services.oidc.id':  serviceData.id});
     if(user)
     {
       serviceData.groups = profile.groups
       profile.groups = userinfo["groups"];
-      users= Meteor.users;
-      user = users.findOne({'services.oidc.id':  serviceData.id});
       if(userinfo["groups"]) addGroups(user, userinfo["groups"]);
       if(profile.email) addEmail(user, profile.email)
       if(profile.name) changeFullname(user, profile.name)

--- a/packages/wekan-oidc/package.js
+++ b/packages/wekan-oidc/package.js
@@ -10,6 +10,7 @@ Package.onUse(function(api) {
   api.use('oauth@1.1.0', ['client', 'server']);
   api.use('http@1.1.0', ['server']);
   api.use('underscore@1.0.0', 'client');
+  api.use('ecmascript@0.9.0');
   api.use('templating@1.1.0', 'client');
   api.use('random@1.0.0', 'client');
   api.use('service-configuration@1.0.0', ['client', 'server']);


### PR DESCRIPTION
If some OIDC provider (e.g.authentik) is used, user data changed in oidc provider is propagated to wekan and mongodb updated accordingly.

E.g. in authentik it is possible to assign users to "groups". On next login these groups (as far as they exist in wekan) will be added as teams relation to the user object.
____________________________________________
Changes include:

**Email** changes via oidc have not been reflected before. --> Now supported
**Fullname** changes via oidc have not been reflected. --> Now supported
**(first) Email** changes via oidc have not been reflected. --> Now supported
**Group assignment** in oidc assigns to **Teams** in wekan on next login. Key is Team Name. Be careful not to use the same Team Name (mongo: teamDisplayName) twice.


You have to set:
export $PROPAGATE_OIDC_DATA=true

packages edited:
wekan-oidc/*
