### PR TITLE
Attachments fixes after migration to meteor files (image preview, global search)

### DIFF
--- a/client/components/cards/attachments.jade
+++ b/client/components/cards/attachments.jade
@@ -20,7 +20,7 @@ template(name="attachmentsGalery")
     each attachments
       .attachment-item
         a.attachment-thumbnail.swipebox(href="{{link}}" title="{{name}}")
-          if isUploaded
+          if link
             if isImage
               img.attachment-thumbnail-img(src="{{link}}")
             else if($eq extension 'mp3')
@@ -38,7 +38,7 @@ template(name="attachmentsGalery")
             else
               span.attachment-thumbnail-ext= extension
           else
-            span.attachment-thumbnail-ext= extension
+            +spinner
         p.attachment-details
           = name
           span.file-size ({{fileSize size}} KB)

--- a/client/components/cards/minicard.jade
+++ b/client/components/cards/minicard.jade
@@ -127,10 +127,10 @@ template(name="minicard")
           span.badge-icon.fa.fa-check(class="{{#if pokerState}}text-green{{/if}}")
           if expiredPoker
             span.badge-text {{ getPokerEstimation }}
-      if attachments.count
+      if attachments.length
         .badge
           span.badge-icon.fa.fa-paperclip
-          span.badge-text= attachments.count
+          span.badge-text= attachments.length
       if checklists.count
         .badge(class="{{#if checklistFinished}}is-finished{{/if}}")
           span.badge-icon.fa.fa-check-square-o

--- a/models/attachments.js
+++ b/models/attachments.js
@@ -85,7 +85,6 @@ if (Meteor.isServer) {
   Meteor.startup(() => {
     Attachments.collection._ensureIndex({ 'meta.cardId': 1 });
     const storagePath = Attachments.storagePath();
-    console.log("Meteor.startup check storagePath: ", storagePath);
     if (!fs.existsSync(storagePath)) {
       console.log("create storagePath because it doesn't exist: " + storagePath);
       fs.mkdirSync(storagePath, { recursive: true });

--- a/models/attachments.js
+++ b/models/attachments.js
@@ -83,7 +83,7 @@ if (Meteor.isServer) {
   });
 
   Meteor.startup(() => {
-    Attachments.collection._ensureIndex({ cardId: 1 });
+    Attachments.collection._ensureIndex({ 'meta.cardId': 1 });
     const storagePath = Attachments.storagePath();
     console.log("Meteor.startup check storagePath: ", storagePath);
     if (!fs.existsSync(storagePath)) {

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1276,3 +1276,7 @@ Migrations.add('migrate-avatars-collectionFS-to-ostrioFiles', () => {
     readStream.pipe(writeStream);
   });
 });
+
+Migrations.add('migrate-attachment-drop-index-cardId', () => {
+  Attachments.collection._dropIndex({'cardId': 1});
+});

--- a/server/publications/cards.js
+++ b/server/publications/cards.js
@@ -774,7 +774,7 @@ function findCards(sessionId, query) {
       Users.find({ _id: { $in: users } }, { fields: Users.safeFields }),
       Checklists.find({ cardId: { $in: cards.map(c => c._id) } }),
       ChecklistItems.find({ cardId: { $in: cards.map(c => c._id) } }),
-      Attachments.find({ cardId: { $in: cards.map(c => c._id) } }),
+      Attachments.find({ 'meta.cardId': { $in: cards.map(c => c._id) } }).cursor,
       CardComments.find({ cardId: { $in: cards.map(c => c._id) } }),
       SessionData.find({ userId, sessionId }),
     ];


### PR DESCRIPTION
Attachments fixes after migration to meteor files (image preview, global search)

- global search was broken
- image preview is back again
- wrong mongo index was created
- attachment count on minicard was missing

should also fix: #4395