### PR TITLE
Attachment migration, try to ignore error on Cloudron on removing old index cardId

### DIFF
--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1278,5 +1278,8 @@ Migrations.add('migrate-avatars-collectionFS-to-ostrioFiles', () => {
 });
 
 Migrations.add('migrate-attachment-drop-index-cardId', () => {
-  Attachments.collection._dropIndex({'cardId': 1});
+  try {
+    Attachments.collection._dropIndex({'cardId': 1});
+  } catch (error) {
+  }
 });


### PR DESCRIPTION
- should fix: https://github.com/wekan/wekan/issues/4407#issuecomment-1065782781