### PR TITLE
Fix oidc login when no group data is present

### DIFF
--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -88,7 +88,7 @@ OAuth.registerService('oidc', 2, null, function (query) {
   // data needs to be treated  differently.
   // use case: in oidc provider no scope is set, hence no group attributes.
   //    therefore: keep admin privileges for wekan as before
-  if(typeof serviceData.groups[0] === "string" )
+  if(Array.isArray(serviceData.groups) && serviceData.groups.length && typeof serviceData.groups[0] === "string" )
   {
     user = Meteor.users.findOne({'_id':  serviceData.id});
 


### PR DESCRIPTION
Currently wekan produces an internal server on oidc logins when no group list is present in the response. This fix checks that `serviceData.groups` is actually an array with a non-zero length before accessing the first element.