### PR TITLE
Added members list and board card count per list on My Boards

### DIFF
--- a/client/components/boards/boardsList.jade
+++ b/client/components/boards/boardsList.jade
@@ -94,6 +94,17 @@ template(name="boardList")
                   span.board-list-item-name(title="{{_ 'board-drag-drop-reorder-or-click-open'}}")
                     +viewer
                       = title
+                  unless isMiniScreen
+                    if allowsBoardMemberList
+                      .minicard-members
+                        each member in boardMembers _id
+                          a.name
+                            +userAvatar(userId=member noRemove=true)
+                    if allowsCardCounterList
+                        .minicard-lists.flex.flex-wrap
+                          each list in boardLists _id
+                            .item
+                              | {{ list }}
                   i.fa.js-star-board(
                     class="fa-star{{#if isStarred}} is-star-active{{else}}-o{{/if}}"
                     title="{{_ 'star-board-title'}}")

--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -194,6 +194,26 @@ BlazeComponent.extendComponent({
       sort: { sort: 1 /* boards default sorting */ },
     });
   },
+  boardLists(boardId) {
+    let boardLists = [];
+    const lists = Lists.find({'boardId' : boardId})
+    lists.forEach(list => {
+      let cardCount = Cards.find({'boardId':boardId, 'listId':list._id}).count()
+      boardLists.push(`${list.title}: ${cardCount}`);
+    });
+    return boardLists
+  },
+
+  boardMembers(boardId) {
+    let boardMembers = [];
+    const lists = Boards.findOne({'_id' : boardId})
+    let members = lists.members
+    members.forEach(member => {
+      boardMembers.push(member.userId);
+    });
+    return boardMembers
+  },
+
   isStarred() {
     const user = Meteor.user();
     return user && user.hasStarred(this.currentData()._id);

--- a/client/components/boards/boardsList.styl
+++ b/client/components/boards/boardsList.styl
@@ -251,3 +251,26 @@ $spaceBetweenTiles = 16px
 
 .js-board
   display: block;
+
+.minicard-members
+  padding: 6px 0 6px 8px
+  width: 100%
+  margin-bottom: 2px
+  margin-left: -4px
+  display: inline-block
+
+.minicard-lists
+  margin: 0 auto
+  max-width: 95%
+  height: 100%
+
+.flex
+  display: flex
+
+.flex-wrap
+  flex-wrap: wrap
+
+  .item
+    margin: 2px;
+    padding-right: 6px
+    text-align: center

--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -138,6 +138,22 @@ template(name="boardChangeColorPopup")
           if isSelected
             i.fa.fa-check
 
+template(name="boardInfoOnMyBoardsPopup")
+  form.board-info-on-my-boards
+    h3 {{_ 'board-info-on-my-boards'}}
+    div.check-div
+      a.flex.js-field-has-cardcounterlist(class="{{#if allowsCardCounterList}}is-checked{{/if}}")
+        .materialCheckBox(class="{{#if allowsCardCounterList}}is-checked{{/if}}")
+        span
+          i.fa.fa-sign-out
+          | {{_ 'Show card counter per list'}}
+    div.check-div
+      a.flex.js-field-has-boardmemberlist(class="{{#if allowsBoardMember}}is-checked{{/if}}")
+        .materialCheckBox(class="{{#if allowsBoardMember}}is-checked{{/if}}")
+        span
+          i.fa.fa-hourglass-start
+          | {{_ 'Show Board member avatars'}}
+
 template(name="boardCardSettingsPopup")
   form.board-card-settings
     h3 {{_ 'show-on-card'}}
@@ -387,6 +403,11 @@ template(name="boardMenuPopup")
         a.js-change-board-color
           i.fa.fa-paint-brush
           | {{_ 'board-change-color'}}
+    if currentUser.isBoardAdmin
+      li
+        a.js-board-info-on-my-boards(title="{{_ 'board-info-on-my-boards'}}")
+          i.fa.fa-paint-brush
+          | {{_ 'board-info-on-my-boards'}}
   hr
   ul.pop-over-list
     if withApi

--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -146,13 +146,13 @@ template(name="boardInfoOnMyBoardsPopup")
         .materialCheckBox(class="{{#if allowsCardCounterList}}is-checked{{/if}}")
         span
           i.fa.fa-sign-out
-          | {{_ 'Show card counter per list'}}
+          | {{_ 'show-card-counter-per-list'}}
     div.check-div
       a.flex.js-field-has-boardmemberlist(class="{{#if allowsBoardMember}}is-checked{{/if}}")
         .materialCheckBox(class="{{#if allowsBoardMember}}is-checked{{/if}}")
         span
           i.fa.fa-hourglass-start
-          | {{_ 'Show Board member avatars'}}
+          | {{_ 'show-board_members-avatar'}}
 
 template(name="boardCardSettingsPopup")
   form.board-card-settings

--- a/client/components/sidebar/sidebar.js
+++ b/client/components/sidebar/sidebar.js
@@ -199,6 +199,7 @@ Template.boardMenuPopup.events({
     Popup.back();
   },
   'click .js-change-board-color': Popup.open('boardChangeColor'),
+  'click .js-board-info-on-my-boards': Popup.open('boardInfoOnMyBoards'),
   'click .js-change-language': Popup.open('changeLanguage'),
   'click .js-archive-board ': Popup.afterConfirm('archiveBoard', function() {
     const currentBoard = Boards.findOne(Session.get('currentBoard'));
@@ -647,6 +648,60 @@ BlazeComponent.extendComponent({
     ];
   },
 }).register('boardChangeColorPopup');
+
+BlazeComponent.extendComponent({
+  onCreated() {
+    this.currentBoard = Boards.findOne(Session.get('currentBoard'));
+  },
+
+  allowsCardCounterList() {
+    return this.currentBoard.allowsCardCounterList;
+  },
+
+  allowsBoardMemberList() {
+    return this.currentBoard.allowsBoardMemberList;
+  },
+
+  events() {
+    return [
+      {
+        'click .js-field-has-cardcounterlist'(evt) {
+          evt.preventDefault();
+          this.currentBoard.allowsCardCounterList = !this.currentBoard
+            .allowsCardCounterList;
+            this.currentBoard.setAllowsCardCounterList(
+              this.currentBoard.allowsCardCounterList,
+          );
+          $(`.js-field-has-cardcounterlist ${MCB}`).toggleClass(
+            CKCLS,
+            this.currentBoard.allowsCardCounterList,
+          );
+          $('.js-field-has-cardcounterlist').toggleClass(
+            CKCLS,
+            this.currentBoard.allowsCardCounterList,
+          );
+        },
+
+        'click .js-field-has-boardmemberlist'(evt) {
+          evt.preventDefault();
+          this.currentBoard.allowsBoardMemberList = !this.currentBoard
+            .allowsBoardMemberList;
+            this.currentBoard.setAllowsBoardMemberList(
+              this.currentBoard.allowsBoardMemberList,
+          );
+          $(`.js-field-has-boardmemberlist ${MCB}`).toggleClass(
+            CKCLS,
+            this.currentBoard.allowsBoardMemberList,
+          );
+          $('.js-field-has-boardmemberlist').toggleClass(
+            CKCLS,
+            this.currentBoard.allowsBoardMemberList,
+          );
+        },
+      },
+    ];
+  },
+}).register('boardInfoOnMyBoardsPopup');
 
 BlazeComponent.extendComponent({
   onCreated() {

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -135,6 +135,7 @@
   "avatar-too-big": "The avatar is too large (520KB max)",
   "back": "Back",
   "board-change-color": "Change color",
+  "board-info-on-my-boards" : "Board info on My Boards",
   "board-nb-stars": "%s stars",
   "board-not-found": "Board not found",
   "board-private-info": "This board will be <strong>private</strong>.",

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -136,6 +136,8 @@
   "back": "Back",
   "board-change-color": "Change color",
   "board-info-on-my-boards" : "Board info on My Boards",
+  "show-card-counter-per-list": "Show card counter per list",
+  "show-board_members-avatar": "Show Board members avatars",
   "board-nb-stars": "%s stars",
   "board-not-found": "Board not found",
   "board-private-info": "This board will be <strong>private</strong>.",

--- a/models/boards.js
+++ b/models/boards.js
@@ -292,6 +292,20 @@ Boards.attachSchema(
         }
       },
     },
+    allowsCardCounterList: {
+      /**
+       * Show card counter per list
+       */
+      type: Boolean,
+      defaultValue: false,
+    },
+    allowsBoardMemberList: {
+      /**
+       * Show board member list
+       */
+      type: Boolean,
+      defaultValue: false,
+    },
     description: {
       /**
        * The description of the board
@@ -1432,6 +1446,14 @@ Boards.mutations({
 
   setAllowsReceivedDate(allowsReceivedDate) {
     return { $set: { allowsReceivedDate } };
+  },
+
+  setAllowsCardCounterList(allowsCardCounterList) {
+    return { $set: { allowsCardCounterList } };
+  },
+
+  setAllowsBoardMemberList(allowsBoardMemberList) {
+    return { $set: { allowsBoardMemberList } };
   },
 
   setAllowsStartDate(allowsStartDate) {

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -73,6 +73,39 @@ Migrations.add('board-background-color', () => {
   );
 });
 
+Migrations.add('add-cardcounterlist-allowed', () => {
+  Boards.update(
+    {
+      allowsCardCounterList: {
+        $exists: false,
+      },
+    },
+    {
+      $set: {
+        allowsCardCounterList: true,
+      },
+    },
+    noValidateMulti,
+  );
+});
+
+Migrations.add('add-boardmemberlist-allowed', () => {
+  Boards.update(
+    {
+      allowsBoardMemberList: {
+        $exists: false,
+      },
+    },
+    {
+      $set: {
+        allowsBoardMemberList: true,
+      },
+    },
+    noValidateMulti,
+  );
+});
+
+
 Migrations.add('lowercase-board-permission', () => {
   ['Public', 'Private'].forEach(permission => {
     Boards.update(


### PR DESCRIPTION
Hi @xet7 

This PR implements on My Boards:
- Card count per list
- Members list

For each board it's possible enable/disable show these info on My Boards
On sidebar:
-> "Board Settings" -> "Board info on My Boards" 

I did not find a way to change popup header:
![Screenshot 2022-04-15 at 12-47-00 Board 5 -](https://user-images.githubusercontent.com/24301085/163596834-e929da30-5733-4018-a054-5745eb8bb338.png)

Do you know how to fix it?
Thanks!

