### PR TITLE
Fix the bug that displayed a card popup to all swimlanes for public board (when a user is not logged)

### DIFF
--- a/client/components/swimlanes/swimlanes.js
+++ b/client/components/swimlanes/swimlanes.js
@@ -21,7 +21,7 @@ function currentCardIsInThisList(listId, swimlaneId) {
       currentCard.listId === listId &&
       currentCard.swimlaneId === swimlaneId
     );
-  else return currentCard && currentCard.listId === listId;
+  else return currentCard && currentCard.listId === listId && currentCard.swimlaneId === swimlaneId;
 
   // https://github.com/wekan/wekan/issues/1623
   // https://github.com/ChronikEwok/wekan/commit/cad9b20451bb6149bfb527a99b5001873b06c3de


### PR DESCRIPTION
As i mentioned in this comment "https://github.com/wekan/wekan/issues/4572#issuecomment-1198373626",
I fixed the bug that displayed a card popup to all swimlanes for public board (when a user is not logged)