### PR TITLE
set miniscreen to 250px

### DIFF
--- a/client/components/boards/boardBody.css
+++ b/client/components/boards/boardBody.css
@@ -32,11 +32,10 @@
   animation: fadeIn 0.2s;
   z-index: 16;
 }
-.board-wrapper .board-canvas.is-dragging-active .open-minicard-composer,
 .board-wrapper .board-canvas.is-dragging-active .minicard-wrapper.is-checked {
   display: none;
 }
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 250px) {
   .board-wrapper .board-canvas .swimlane {
     border-bottom: 1px solid #ccc;
     display: flex;

--- a/client/components/lists/list.css
+++ b/client/components/lists/list.css
@@ -6,7 +6,7 @@
   background: #dedede;
   border-left: 1px solid #ccc;
   padding: 0;
-  float: left;  
+  float: left;
   min-width: 270px;
   max-width: 270px;
   /* Reverted incomplete change list width: */
@@ -159,7 +159,7 @@
 #js-wip-limit-edit div {
   float: left;
 }
-@media screen and (max-width: 800px) {
+@media screen and (max-width: 250px) {
   .mini-list {
     flex: 0 0 60px;
     height: auto;

--- a/client/components/swimlanes/swimlanes.css
+++ b/client/components/swimlanes/swimlanes.css
@@ -46,7 +46,6 @@
   background: #dedede;
   display: flex;
   flex-direction: row;
-  overflow: 0;
   max-height: calc(100% - 26px);
 }
 .swimlane.placeholder {

--- a/client/lib/utils.js
+++ b/client/lib/utils.js
@@ -255,7 +255,7 @@ Utils = {
   isMiniScreen() {
     // OLD WINDOW WIDTH DETECTION:
     this.windowResizeDep.depend();
-    return $(window).width() <= 800;
+    return $(window).width() <= 250;
   },
 
   isTouchScreen() {


### PR DESCRIPTION
changed miniscreen width to 250px, on Android Firefox works like a charm, still many templates to fix, like header - where "All boards" shortcut must hide it's text (css are working with max-width = 800px).
From boardBody.css removed the line where the Plus sign is deleted from all lists on card dragging, it was shrinking lists to 0 making them unable to receive the moved card (the glitch when the card cannot be dropped on another swimlane), either this or we should add a minimum height to the list.
