### PR TITLE
Remove hard-coded port 8080 binding in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -346,8 +346,6 @@ RUN \
     #rm -R /home/wekan/python
     #rm /home/wekan/install_meteor.sh
 
-ENV PORT=8080
-EXPOSE $PORT
 USER wekan
 
 #---------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,12 @@ services:
       #  - http://192.168.1.100    <=== using at local LAN
       - ROOT_URL=http://localhost  #   <=== using only at same laptop/desktop where Wekan is installed
       #---------------------------------------------------------------
+      # ==== DEFAULT PORT SETTING ====
+      # By default, Wekan will bind to TCP port 8080. If you need to change this to work with your
+      # reverse proxy settings or other Docker network topology requirements, change this value.
+      #  - Remember to change the above port binding if you change this value!
+      - PORT=8080
+      #---------------------------------------------------------------
       # ==== EMAIL SETTINGS ====
       # Email settings are only at MAIL_URL and MAIL_FROM.
       # Admin Panel has test button, but it's not used for settings.


### PR DESCRIPTION
Removed hardcoding port 8080 in image, allowing more flexibility for complex docker deployments.

Forcing use of port 8080 invalidates various pieces of documentation claiming you can connect to Wekan on other ports like 3001 (see [here](https://github.com/wekan/wekan/wiki/Settings#webserver-config)and [here](https://github.com/wekan/wekan/wiki/Caddy-Webserver-Config#caddy-2)), but it also creates unnecessary rigidity in more complex Docker deployments.

For example in my environment (and the reason for this PR), I don't want to expose containers directly to the underlying host network stack, so I run Caddy as my single host-connected container. I want my Wekan container to connect directly to the Caddy bridge network I've created, but when I set `ports: 8081/tcp` in my wekan `docker-compose.yml`, `docker ps` still reveals that the Wekan container is also bound to the host net on port 8080 in addition to 8081 on the Caddy net.

Setting the environment variable `PORT=8081` in Wekan `docker-compose.yml` doesn't seem to work either. My only guess is because the container image itself was built to bind to port 8080 only.

The best solution I can think of is to simply remove the port declaration and binding in the Dockerfile (f26f86dd3f5eb47152d4cd3e27594780c13a3cbb), letting users set their own port declarations. To this effect I also changed the default `docker-compose.yml` to include a default `PORT=8080` environment variable as well as user guidance on the topic (ca35970f3f1e23d774b1ef15fb1686b58daff282).

This is only my 2nd PR to an oss repo so please let me know if I need to change anything or do anything differently to make everyone's lives easier!