### PR TITLE
Avoid non-terminating containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -348,6 +348,8 @@ RUN \
 
 USER wekan
 
+STOPSIGNAL SIGKILL
+
 #---------------------------------------------------------------------
 # https://github.com/wekan/wekan/issues/3585#issuecomment-1021522132
 # Add more Node heap:


### PR DESCRIPTION
The process 1 in the container does not shut down gracefully after having
received a TERM signal.  Therefore, we send a SIGKILL immediately.  This is a
kludge as long as node/meteor has no proper SIGTERM handler enabled.  See
<https://github.com/wekan/wekan/issues/4668>.