### PR TITLE
RegExp possible at "Custom Field String Templates"

### DIFF
--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -2,6 +2,7 @@ import moment from 'moment/min/moment-with-locales';
 import { TAPi18n } from '/imports/i18n';
 import { DatePicker } from '/client/lib/datepicker';
 import Cards from '/models/cards';
+import { CustomFieldStringTemplate } from '/client/lib/customFields'
 
 Template.cardCustomFieldsPopup.helpers({
   hasCustomField() {
@@ -245,38 +246,17 @@ CardCustomField.register('cardCustomField');
 }.register('cardCustomField-dropdown'));
 
 // cardCustomField-stringtemplate
-(class extends CardCustomField {
+class CardCustomFieldStringTemplate extends CardCustomField {
   onCreated() {
     super.onCreated();
 
-    this.stringtemplateFormat = this.data().definition.settings.stringtemplateFormat;
-    this.stringtemplateSeparator = this.data().definition.settings.stringtemplateSeparator;
+    this.customField = new CustomFieldStringTemplate(this.data().definition);
 
     this.stringtemplateItems = new ReactiveVar(this.data().value ?? []);
   }
 
   formattedValue() {
-    const ret = (this.data().value ?? [])
-      .filter(value => !!value.trim())
-      .map(value => {
-        let _ret = this.stringtemplateFormat.replace(/[%$]\{.+?\}/g, function(_match) {
-          let __ret;
-          if (_match.match(/%\{value\}/i)) {
-            __ret = value;
-          } else {
-            _match = _match.replace(/^\$/, "");
-            try {
-              const _json = JSON.parse(_match);
-              __ret =  value.replace(new RegExp(_json.regex, _json.flags), _json.replace);
-            } catch (err) {
-              console.error(err);
-            }
-          }
-          return __ret;
-        });
-        return _ret;
-      })
-      .join(this.stringtemplateSeparator ?? '');
+    const ret = this.customField.getFormattedValue(this.data().value);
     return ret;
   }
 
@@ -348,4 +328,5 @@ CardCustomField.register('cardCustomField');
       },
     ];
   }
-}.register('cardCustomField-stringtemplate'));
+}
+CardCustomFieldStringTemplate.register('cardCustomField-stringtemplate');

--- a/client/components/cards/cardCustomFields.js
+++ b/client/components/cards/cardCustomFields.js
@@ -256,10 +256,28 @@ CardCustomField.register('cardCustomField');
   }
 
   formattedValue() {
-    return (this.data().value ?? [])
+    const ret = (this.data().value ?? [])
       .filter(value => !!value.trim())
-      .map(value => this.stringtemplateFormat.replace(/%\{value\}/gi, value))
+      .map(value => {
+        let _ret = this.stringtemplateFormat.replace(/[%$]\{.+?\}/g, function(_match) {
+          let __ret;
+          if (_match.match(/%\{value\}/i)) {
+            __ret = value;
+          } else {
+            _match = _match.replace(/^\$/, "");
+            try {
+              const _json = JSON.parse(_match);
+              __ret =  value.replace(new RegExp(_json.regex, _json.flags), _json.replace);
+            } catch (err) {
+              console.error(err);
+            }
+          }
+          return __ret;
+        });
+        return _ret;
+      })
       .join(this.stringtemplateSeparator ?? '');
+    return ret;
   }
 
   getItems() {

--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -1,4 +1,5 @@
 import { TAPi18n } from '/imports/i18n';
+import { CustomFieldStringTemplate } from '/client/lib/customFields'
 
 // Template.cards.events({
 //   'click .member': Popup.open('cardMember')
@@ -31,12 +32,8 @@ BlazeComponent.extendComponent({
     const customFieldTrueValue =
       customField && customField.trueValue ? customField.trueValue : [];
 
-    return customFieldTrueValue
-      .filter(value => !!value.trim())
-      .map(value =>
-        definition.settings.stringtemplateFormat.replace(/%\{value\}/gi, value),
-      )
-      .join(definition.settings.stringtemplateSeparator ?? '');
+    const ret = new CustomFieldStringTemplate(definition).getFormattedValue(customFieldTrueValue);
+    return ret;
   },
 
   showCreator() {

--- a/client/lib/customFields.js
+++ b/client/lib/customFields.js
@@ -1,0 +1,38 @@
+class CustomField {
+  constructor(definition) {
+    this.definition = definition;
+  }
+}
+
+export class CustomFieldStringTemplate extends CustomField {
+  constructor(definition) {
+    super(definition);
+    this.format = definition.settings.stringtemplateFormat;
+    this.separator = definition.settings.stringtemplateSeparator;
+  }
+
+  getFormattedValue(rawValue) {
+    const ret = (rawValue ?? [])
+      .filter(value => !!value.trim())
+      .map(value => {
+        let _ret = this.format.replace(/[%$]\{.+?\}/g, function(_match) {
+          let __ret;
+          if (_match.match(/%\{value\}/i)) {
+            __ret = value;
+          } else {
+            _match = _match.replace(/^\$/, "");
+            try {
+              const _json = JSON.parse(_match);
+              __ret =  value.replace(new RegExp(_json.regex, _json.flags), _json.replace);
+            } catch (err) {
+              console.error(err);
+            }
+          }
+          return __ret;
+        });
+        return _ret;
+      })
+      .join(this.separator ?? '');
+    return ret;
+  }
+}

--- a/client/lib/customFields.js
+++ b/client/lib/customFields.js
@@ -15,7 +15,7 @@ export class CustomFieldStringTemplate extends CustomField {
     const ret = (rawValue ?? [])
       .filter(value => !!value.trim())
       .map(value => {
-        let _ret = this.format.replace(/[%$]\{.+?\}/g, function(_match) {
+        let _ret = this.format.replace(/[%$]\{.+?[^0-9]\}/g, function(_match) {
           let __ret;
           if (_match.match(/%\{value\}/i)) {
             __ret = value;


### PR DESCRIPTION
Idea from PR:
https://github.com/wekan/wekan/issues/3701#issuecomment-815864735

---

the regexp syntax is e.g.:

${regex:".(.*).", replace:"$1", flags:"i"}

removes the first and last character and uses case-insensitive search.

See also:
https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/RegExp