### PR TITLE
Checklist copy/move dialog was sometimes empty

### DIFF
--- a/client/lib/dialogWithBoardSwimlaneListCard.js
+++ b/client/lib/dialogWithBoardSwimlaneListCard.js
@@ -23,7 +23,7 @@ export class DialogWithBoardSwimlaneListCard extends DialogWithBoardSwimlaneList
   /** returns all available cards of the current list */
   cards() {
     const list = Lists.findOne(this.selectedListId.get());
-    let ret = {}
+    let ret = [];
     if (list) {
       ret = list.cards(this.selectedSwimlaneId.get());
     }


### PR DESCRIPTION
- a Exception was thrown the return value was an object because #each only accepts arrays and cursors

See also:
https://github.com/wekan/wekan/issues/4655#issuecomment-1250106151