### PR TITLE
Fix Python-Esprima upstream failing

### DIFF
--- a/releases/rebuild-docs.sh
+++ b/releases/rebuild-docs.sh
@@ -21,6 +21,9 @@ if [ ! -d ~/python/esprima-python ]; then
   cd ~/python
   git clone --depth 1 -b master https://github.com/Kronuz/esprima-python
   cd ~/python/esprima-python
+  # temporary fix until https://github.com/Kronuz/esprima-python/pull/20 gets merged
+  git fetch origin pull/20/head:delete_fix
+  git checkout delete_fix
   # a) Generating docs works on Kubuntu 21.10 with this,
   #    but generating Sandstorm WeKan package does not work
   #    https://github.com/wekan/wekan/issues/4280


### PR DESCRIPTION
Sigh, python-esprima is really not well maintained:
- the maintainer merged https://github.com/Kronuz/esprima-python/pull/19
- this breaks entirely his project
- the submitter of PR 19 submitted a fix one week later
- 10 months later, the fix is still not merged :(

Pull it locally so we get our docs building again.

Fixes: #4731