### PR TITLE
Add link card feature to rules

### DIFF
--- a/client/components/rules/actions/boardActions.jade
+++ b/client/components/rules/actions/boardActions.jade
@@ -77,6 +77,29 @@ template(name="boardActions")
     div.trigger-button.js-create-card-action.js-goto-rules
       i.fa.fa-plus
 
+  div.trigger-item
+    div.trigger-content
+      div.trigger-text
+        | {{_'r-link-card'}}
+      div.trigger-text
+        | {{_'r-the-board'}}
+      div.trigger-dropdown
+        select(id="board-id-link")
+          each boards
+            if $eq _id currentBoard._id
+              option(value="{{_id}}" selected) {{_ 'current'}}
+            else
+              option(value="{{_id}}") {{title}}
+      div.trigger-text
+        | {{_'r-in-list'}}
+      div.trigger-dropdown
+        input(id="listName-link",type=text,placeholder="{{_'r-name'}}")
+      div.trigger-text
+        | {{_'r-in-swimlane'}}
+      div.trigger-dropdown
+        input(id="swimlaneName-link",type=text,placeholder="{{_'r-name'}}")
+    div.trigger-button.js-link-card-action.js-goto-rules
+      i.fa.fa-plus
 
 
 

--- a/client/components/rules/actions/boardActions.js
+++ b/client/components/rules/actions/boardActions.js
@@ -178,6 +178,29 @@ BlazeComponent.extendComponent({
             });
           }
         },
+        'click .js-link-card-action'(event) {
+          const ruleName = this.data().ruleName.get();
+          const trigger = this.data().triggerVar.get();
+          const swimlaneName = this.find('#swimlaneName-link').value || '*';
+          const listName = this.find('#listName-link').value || '*';
+          const boardId = Session.get('currentBoard');
+          const destBoardId = this.find('#board-id-link').value;
+          const desc = Utils.getTriggerActionDesc(event, this);
+          const triggerId = Triggers.insert(trigger);
+          const actionId = Actions.insert({
+            actionType: 'linkCard',
+            listName,
+            swimlaneName,
+            boardId: destBoardId,
+            desc,
+          });
+          Rules.insert({
+            title: ruleName,
+            triggerId,
+            actionId,
+            boardId,
+          });
+        },
       },
     ];
   },

--- a/imports/i18n/data/en.i18n.json
+++ b/imports/i18n/data/en.i18n.json
@@ -846,6 +846,7 @@
   "r-df-received-at": "received",
   "r-to-current-datetime": "to current date/time",
   "r-remove-value-from": "Remove value from",
+  "r-link-card": "Link card to",
   "ldap": "LDAP",
   "oauth2": "OAuth2",
   "cas": "CAS",

--- a/server/rulesHelper.js
+++ b/server/rulesHelper.js
@@ -371,8 +371,29 @@ RulesHelper = {
         listId,
         swimlaneId,
         sort: 0,
-        boardId,
+        boardId
       });
+    }
+    if (action.actionType === 'linkCard') {
+      const list = Lists.findOne({ title: action.listName, boardId: action.boardId });
+      const card = Cards.findOne({ _id: activity.cardId });
+      let listId = '';
+      let swimlaneId = '';
+      const swimlane = Swimlanes.findOne({
+        title: action.swimlaneName,
+        boardId: action.boardId,
+      });
+      if (list === undefined) {
+        listId = '';
+      } else {
+        listId = list._id;
+      }
+      if (swimlane === undefined) {
+        swimlaneId = Swimlanes.findOne({ title: 'Default', boardId: action.boardId })._id;
+      } else {
+        swimlaneId = swimlane._id;
+      }
+      card.link(action.boardId, swimlaneId, listId);
     }
   },
 };


### PR DESCRIPTION
I have added a new feature to the board rules: linking of cards to another board

There is a new action that will allow you to create a linked card on baord as part of a rule. You can specify the target board, swimlane and list.

Remarks:
- if given list is empty or not existing, the rule will fail (similar behaviour to createCard rule)
- I could also provide code that would add the link to the first list of the target board


Let me know if I missed out something. This is my first pull request to a public project.