### PR TITLE
4786 fix group routine

### DIFF
--- a/packages/wekan-accounts-lockout/src/knownUser.js
+++ b/packages/wekan-accounts-lockout/src/knownUser.js
@@ -214,11 +214,6 @@ class KnownUser {
   }
 
   static onLogin(loginInfo) {
-    //get the data from oidc login and remove again?
-    if(loginInfo.type ==='oidc'){
-      Meteor.call('groupRoutineOnLogin', loginInfo.user.services.oidc, loginInfo.user._id);
-      return;
-    }
     if (loginInfo.type !== 'password') {
       return;
     }

--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -81,7 +81,6 @@ OAuth.registerService('oidc', 2, null, function (query) {
 
   //temporarily store data from oidc in user.services.oidc.groups to update groups
   serviceData.groups = (userinfo["groups"] && userinfo["wekanGroups"]) ? userinfo["wekanGroups"] : userinfo["groups"];
-
   // groups arriving as array of strings indicate there is no scope set in oidc privider
   // to assign teams and keep admin privileges
   // data needs to be treated  differently.
@@ -105,6 +104,9 @@ OAuth.registerService('oidc', 2, null, function (query) {
       }
     });
   }
+
+  Meteor.call('groupRoutineOnLogin',serviceData, serviceData.id);
+
   return {
     serviceData: serviceData,
     options: { profile: profile }
@@ -285,9 +287,9 @@ Meteor.methods({
     var propagateOidcData = process.env.PROPAGATE_OIDC_DATA || false;
     if (propagateOidcData)
     {
-
       users= Meteor.users;
-      user = users.findOne({'_id':  userId});
+      user = users.findOne({'services.oidc.id':  userId});
+
       if(user)
       {
         //updates/creates Groups and user admin privileges accordingly


### PR DESCRIPTION
Fixes Group Assignment on OIDC Login. 

wekan-accounts-lockout did not start group routine since "onLogin" hook was not called.
Logic moved to wekan-oidc package

Refer to Readme.md in packages/wekan-accounts-oidc/README.md for detailed description on how to use this feature.