### PR TITLE
fix indentation for image  size and compression

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -287,8 +287,8 @@ services:
       #---------------------------------------------------------------
       # ==== Allow to shrink attached/pasted image ====
       # https://github.com/wekan/wekan/pull/2544
-      #-MAX_IMAGE_PIXEL=1024
-      #-IMAGE_COMPRESS_RATIO=80
+      #- MAX_IMAGE_PIXEL=1024
+      #- IMAGE_COMPRESS_RATIO=80
       #---------------------------------------------------------------
       # ==== NOTIFICATION TRAY AFTER READ DAYS BEFORE REMOVE =====
       # Number of days after a notification is read before we remove it.


### PR DESCRIPTION
Hi,

I just saw this minor indentation problem in the docker-compose.yml

FYI: the README on docker hub seems to be outdated. It still notes that you should not use "latest" tag for docker images:
> Docker: Please only use Docker release tags
> Note: With Docker, please don't use latest tag. Only use release tags. See https://github.com/wekan/wekan/issues/3874

https://hub.docker.com/r/wekanteam/wekan

Cheers :-)