### PR TITLE
Fixed broken migration migrate-attachments-collectionFS-to-ostrioFiles

### DIFF
--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1287,7 +1287,7 @@ Migrations.add('migrate-attachments-collectionFS-to-ostrioFiles', () => {
             listId: fileObj.listId,
             swimlaneId: fileObj.swimlaneId,
             uploadedBeforeMigration: fileObj.uploadedAt,
-            migrationTime: this.now(),
+            migrationTime: new Date(),
             copies: fileObj.copies,
             source: 'import'
           },


### PR DESCRIPTION
- fixes #4925 broken migration `migrate-attachments-collectionFS-to-ostrioFiles`