### PR TITLE
attachment copy changes now the boardId, listId and swimlaneId in the collection data

### DIFF
--- a/models/lib/fileStoreStrategy.js
+++ b/models/lib/fileStoreStrategy.js
@@ -696,6 +696,7 @@ export const moveToStorage = function(fileObj, storageDestination, fileStoreStra
 };
 
 export const copyFile = function(fileObj, newCardId, fileStoreStrategyFactory) {
+  const newCard = Cards.findOne(newCardId);
   Object.keys(fileObj.versions).forEach(versionName => {
     const strategyRead = fileStoreStrategyFactory.getFileStrategy(fileObj, versionName);
     const readStream = strategyRead.getReadStream();
@@ -721,10 +722,10 @@ export const copyFile = function(fileObj, newCardId, fileStoreStrategyFactory) {
           fileName: fileObj.name,
           type: fileObj.type,
           meta: {
-            boardId: fileObj.meta.boardId,
+            boardId: newCard.boardId,
             cardId: newCardId,
-            listId: fileObj.meta.listId,
-            swimlaneId: fileObj.meta.swimlaneId,
+            listId: newCard.listId,
+            swimlaneId: newCard.swimlaneId,
             source: 'copy',
             copyFrom: fileObj._id,
             copyStorage: strategyRead.getStorageName(),

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1420,3 +1420,18 @@ Migrations.add('migrate-attachment-migration-fix-source-import', () => {
     noValidateMulti
   );
 });
+
+Migrations.add('attachment-cardCopy-fix-boardId-etc', () => {
+  Attachments.find( {"meta.source": "copy"} ).forEach(_attachment => {
+    const cardId = _attachment.meta.cardId;
+    const card = Cards.findOne(cardId);
+    console.log("update attachment id: ", _attachment._id);
+    Attachments.update(_attachment._id, {
+      $set: {
+        "meta.boardId": card.boardId,
+        "meta.listId": card.listId,
+        "meta.swimlaneId": card.swimlaneId,
+      }
+    });
+  });
+});


### PR DESCRIPTION
- fixing admin attachment view, copied card attachments were wrong if copied to another board / list / swimlane