### PR TITLE
Small UI improvements

### DIFF
--- a/client/components/cards/minicard.jade
+++ b/client/components/cards/minicard.jade
@@ -49,7 +49,8 @@ template(name="minicard")
         if currentBoard.allowsCardNumber
           span.card-number
             | ##{getCardNumber}
-        = getTitle
+        b
+          = getTitle
       if $eq 'subtext-with-full-path' currentBoard.presentParentTask
         .parent-subtext
           | {{ parentString ' > ' }}

--- a/client/components/lists/list.css
+++ b/client/components/lists/list.css
@@ -16,7 +16,6 @@
   /* overflow: auto; - List width and height resizeable */
 }
 .list:first-child {
-  min-width: 20px;
   margin-left: 5px;
   border-left: none;
 }


### PR DESCRIPTION
## Improvement 1: Bold minicard title
bold minicard title makes it easier to distinguish from other fields that are shown on the card
Before:
![before](https://github.com/wekan/wekan/assets/18378617/9d21c5de-72c4-43d6-944a-539bb8f55c8b)

After:
![after](https://github.com/wekan/wekan/assets/18378617/cce0e40e-7e2f-4681-a0c0-0b19c25f66fa)

## Improvement 2: Fix narrow first list
[A recent commit](https://github.com/wekan/wekan/commit/467835192fbcd9d4016674fa2ee406258cc106e7) made the first list narrower than the rest.

Before:
![before2](https://github.com/wekan/wekan/assets/18378617/69b63d2c-2007-4419-a191-2829e6d0c360)

After:
![after2](https://github.com/wekan/wekan/assets/18378617/7b0039fe-07c6-4db2-87cf-4f6cc0bb318e)

I am not sure why exactly do we need `min-width: 20px`, but if I broke something important feel free to revert that commit.