### PR TITLE
Improved attachment gallery and attachment viewer

### DIFF
--- a/client/components/cards/attachments.css
+++ b/client/components/cards/attachments.css
@@ -7,69 +7,76 @@
   text-align: center;
   font-weight: bold;
 }
-.attachments-gallery {
+.attachment-gallery {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
 }
-.attachments-gallery .attachment-item {
-  width: 31.33%;
-  margin: 10px 1% 0;
-  text-align: center;
-  border-radius: 3px;
-  overflow: auto;
-  background: #ededed;
-  min-height: 120px;
+.attachment-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-top: 16px;
 }
-.attachments-gallery .attachment-item:hover {
+.attachment-item:hover {
   background: #e0e0e0;
 }
-.attachments-gallery .attachment-item.add-attachment {
-  display: flex;
-  align-items: center;
-}
-.attachments-gallery .attachment-item.add-attachment a {
+.attachment-thumbnail-container {
   display: block;
-  margin: auto;
+  width: 150px;
+  min-width: 150px;
+  max-height: 150px;
+  padding-right: 16px;
+
 }
-.attachments-gallery .attachment-item .attachment-thumbnail {
-  height: 80px;
+.attachment-thumbnail {
+  max-width: 150px;
+  max-height: 150px;
+  min-height: 2em;
+  cursor: pointer;
+}
+.attachment-thumbnail-text {
+  min-height: 2em;
   display: flex;
   align-items: center;
   justify-content: center;
-  position: relative;
+  font-size: 2em;
+  cursor: pointer;
+  border: 1px solid #ccc;
+  border-radius: 5px;
 }
-.attachments-gallery .attachment-item .attachment-thumbnail .attachment-thumbnail-img {
-  max-height: 100%;
-  max-width: 100%;
-}
-.attachments-gallery .attachment-item .attachment-thumbnail .attachment-thumbnail-ext {
-  text-transform: uppercase;
-  font-size: 1.6em;
-}
-.attachments-gallery .attachment-item .attachment-details {
-  font-size: 0.75em;
-  margin: 3px;
-}
-.attachments-gallery .attachment-item .attachment-details .attachment-details-actions a {
+.attachment-details-container {
   display: block;
+  flex-grow: 1;
 }
-.attachments-gallery .attachment-item .attachment-details .attachment-details-actions a.attachment-details-menu {
-  padding-top: 10px;
+.attachment-details {
+  display: flex;
+  justify-content: space-between;
+  margin-right: 25px; /* Make sure the icons are not to far to the right */
 }
-.attachment-image-preview {
-  max-width: 100px;
-  display: block;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+.attachment-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
-.preview-clipboard-image {
-  width: 280px;
-  max-width: 100%;
-  height: 200px;
-  display: block;
-  border: 1px solid #000;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+.add-attachment {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed #555;
+  border-radius: 5px;
+  padding: 10px;
+  cursor: pointer;
+  margin-top: 16px;
 }
-#viewer-overlay{
+.icon {
+  font-size: 1.5em;
+  cursor: pointer;
+  margin-left: 10px;
+}
+.icon:hover {
+  color: #666;
+}
+#viewer-overlay {
   width: 100%;
   height: 100vh;
   position: fixed;
@@ -92,40 +99,43 @@
   position: absolute;
   padding: 20 20;
 }
-#viewer-container{
+#viewer-container {
   text-align: center;
 }
 #pdf-viewer {
-  margin-top: 4vh;
-  width: 100%;
+  width: 40vw;
   height: 100vh;
 }
-.pdf-preview-error{
+.pdf-preview-error {
   margin-top: 20vh;
   display: block;
   font-size: 2em;
   color: white;
 }
-@media screen and (max-width: 800px) {
-  .attachments-gallery .attachment-item {
-    width: 48%;
-  }
-  .attachments-gallery .attachment-item .attachment-thumbnail {
-    height: 130px;
-  }
-  .attachments-gallery .attachment-item .attachment-details {
-    font-size: 1.1em;
+
+@media screen and (max-width: 1600px) {
+  #pdf-viewer {
+    width: 60vw;
   }
 }
-@media screen and (max-width: 360px) {
+
+@media screen and (max-width: 800px) {
   #pdf-viewer {
-    margin-top: 5vh;
-    width: 100%;
+    width: 100vh;
   }
-  .attachments-gallery .attachment-item {
-    width: 100%;
+  .attachment-thumbnail-container {
+    width: 100px;
+    min-width: 100px;
   }
-  .attachments-gallery .attachment-item .attachment-thumbnail {
-    height: 200px;
+  .attachment-thumbnail {
+    max-width: 100px;
+  }
+  .attachment-details {
+    flex-direction: column;
+    margin-right: 0px;
+  }
+  .attachment-actions {
+    flex-direction: row;
+    margin-top: 10px;
   }
 }

--- a/client/components/cards/attachments.css
+++ b/client/components/cards/attachments.css
@@ -1,8 +1,3 @@
-.slide {
-  /* swipebox slide background gradient of black to blue, so that back SVG images are visible */
-  background: rgb(2,0,36);
-  background: linear-gradient(90deg, rgba(2,0,36,1) 0%, rgba(9,9,121,1) 14%, rgba(0,212,255,1) 100%);
-}
 .attachment-upload {
   text-align: center;
   font-weight: bold;
@@ -83,26 +78,53 @@
   top: 48px;  /* height of the navbar */
   left: 0;
   z-index: 9999 !important;
-  background: rgba(13,13,13,0.9);
+  background: rgba(13,13,13,0.95);
 }
 #viewer-container {
-  position: relative;
-  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   height: 100%;
+}
+#viewer-top-bar {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  padding: 16px;
+}
+#attachment-name {
+  color: white;
+  font-size: 1.5em;
+  max-width: calc(100% - 50px); /* Make sure the name does not overlap the close button */
 }
 #viewer-close {
   color:white;
   cursor: pointer;
   font-size: 4em;
   top: 0;
-  right: 16px;
+  right: 8px;
   position: absolute;
-  padding: 20 20;
 }
-#viewer-container {
-  text-align: center;
+.attachment-arrow {
+  font-size: 4em;
+  color:white;
+  cursor: pointer;
+  align-self: center;
+  margin: 0 20px;
+}
+#image-viewer {
+  background:
+    repeating-conic-gradient(#808080 0% 25%, transparent 0% 50%)
+      50% / 20px 20px; /* Checkerboard background for transparent images */
+  max-width: 100%;
 }
 #pdf-viewer {
+  width: 40vw;
+  height: 100vh;
+}
+#txt-viewer{
+  background-color: white;
   width: 40vw;
   height: 100vh;
 }
@@ -120,8 +142,32 @@
 }
 
 @media screen and (max-width: 800px) {
+  #viewer-container {
+    display: block;
+  }
+  .attachment-arrow{
+    position: absolute;
+    bottom: 2.2em;
+    font-size: 1.6em;
+    padding: 16px;
+  }
+  #prev-attachment{
+    left: 0;
+  }
+  #next-attachment{
+    right: 0;
+  }
   #pdf-viewer {
-    width: 100vh;
+    width: 100%;
+    height: calc(100vh - 155px);  /* Full height - height of top and bottom bars */
+  }
+  #txt-viewer {
+    width: 100%;
+    height: calc(100vh - 155px);  /* Full height - height of top and bottom bars */
+  }
+  #audio-viewer {
+    margin-top: 20%;
+    width: 100%;
   }
   .attachment-thumbnail-container {
     width: 100px;

--- a/client/components/cards/attachments.jade
+++ b/client/components/cards/attachments.jade
@@ -32,10 +32,20 @@ template(name="attachmentDeletePopup")
 
 template(name="attachmentViewer")
   #viewer-overlay.hidden
-    #viewer-container
-      object#pdf-viewer(type="application/pdf")
-        span.pdf-preview-error {{_ 'preview-pdf-not-supported' }}
+    #viewer-top-bar
+      span#attachment-name
       a#viewer-close.fa.fa-times-thin
+
+    #viewer-container
+      i.fa.fa-chevron-left.attachment-arrow#prev-attachment
+      #viewer-content
+        img#image-viewer.hidden
+        video#video-viewer.hidden(controls="true")
+        audio#audio-viewer.hidden(controls="true")
+        object#pdf-viewer.hidden(type="application/pdf")
+          span.pdf-preview-error {{_ 'preview-pdf-not-supported' }}
+        object#txt-viewer.hidden(type="text/plain")
+      i.fa.fa-chevron-right.attachment-arrow#next-attachment
 
 template(name="attachmentGallery")
 
@@ -47,7 +57,7 @@ template(name="attachmentGallery")
     each attachments
 
       .attachment-item
-        .attachment-thumbnail-container(href="{{link}}" class="{{#if isImage}}swipebox{{/if}} {{#if $eq extension 'pdf'}}pdf{{/if}}")
+        .attachment-thumbnail-container.open-preview(data-attachment-id="{{_id}}" data-card-id="{{ meta.cardId }}")
           if link
             if(isImage)
               img.attachment-thumbnail(src="{{link}}" title="{{sanitize name}}")

--- a/client/components/cards/attachments.jade
+++ b/client/components/cards/attachments.jade
@@ -30,54 +30,63 @@ template(name="attachmentDeletePopup")
   p {{_ "attachment-delete-pop"}}
   button.js-confirm.negate.full(type="submit") {{_ 'delete'}}
 
-template(name="attachmentsGallery")
+template(name="attachmentViewer")
   #viewer-overlay.hidden
     #viewer-container
       object#pdf-viewer(type="application/pdf")
         span.pdf-preview-error {{_ 'preview-pdf-not-supported' }}
       a#viewer-close.fa.fa-times-thin
 
-  .attachments-gallery
-    if currentUser.isBoardMember
-      unless currentUser.isCommentOnly
-        unless currentUser.isWorker
-          //li.attachment-item.add-attachment
-          a.js-add-attachment(title="{{_ 'add-attachment' }}")
-            i.fa.fa-plus
-    each attachments
-      .attachment-item
+template(name="attachmentGallery")
 
-        span.attachment-thumbnail(href="{{link}}" title="{{sanitize name}}" class="{{#if isImage}}swipebox{{/if}} {{#if $eq extension 'pdf'}}pdf{{/if}}")
+  .attachment-gallery
+
+    a.attachment-item.add-attachment.js-add-attachment
+      i.fa.fa-plus.icon
+
+    each attachments
+
+      .attachment-item
+        .attachment-thumbnail-container(href="{{link}}" class="{{#if isImage}}swipebox{{/if}} {{#if $eq extension 'pdf'}}pdf{{/if}}")
           if link
-            if($eq extension 'svg')
-              img.attachment-thumbnail-img(src="{{link}}" title="{{sanitize name}}" type="image/svg+xml")
-            else if isImage
-              img.attachment-thumbnail-img(src="{{link}}" title="{{sanitize name}}")
+            if(isImage)
+              img.attachment-thumbnail(src="{{link}}" title="{{sanitize name}}")
+            else if($eq extension 'svg')
+              img.attachment-thumbnail(src="{{link}}" title="{{sanitize name}}" type="image/svg+xml")
             else if($eq extension 'mp3')
-              video(width="100%" height="100%" title="{{sanitize name}}" controls="true")
+              video.attachment-thumbnail(title="{{sanitize name}}")
                 source(src="{{link}}" type="audio/mpeg")
             else if($eq extension 'ogg')
-              video(width="100%" height="100%" title="{{sanitize name}}" controls="true")
+              video.attachment-thumbnail(title="{{sanitize name}}")
                 source(src="{{link}}" type="video/ogg")
             else if($eq extension 'webm')
-              video(width="100%" height="100%" title="{{sanitize name}}" controls="true")
+              video.attachment-thumbnail(title="{{sanitize name}}")
                 source(src="{{link}}" type="video/webm")
             else if($eq extension 'mp4')
-              video(width="100%" height="100%" title="{{sanitize name}}" controls="true")
+              video.attachment-thumbnail(title="{{sanitize name}}")
                 source(src="{{link}}" type="video/mp4")
             else
-              span.attachment-thumbnail-ext= extension
-        p.attachment-details
-          = name
-          span.file-size ({{fileSize size}})
-          span.attachment-details-actions
-            a.js-download(href="{{link}}?download=true", download="{{name}}")
-              i.fa.fa-download
-              | {{_ 'download'}}
-            if currentUser.isBoardMember
-              unless currentUser.isCommentOnly
-                unless currentUser.isWorker
-                  a.fa.fa-navicon.attachment-details-menu.js-open-attachment-menu(title="{{_ 'attachmentActionsPopup-title'}}")
+              span.attachment-thumbnail-text= extension
+
+        .attachment-details-container
+          .attachment-details
+            div
+              b
+                = name
+              span.file-size ({{fileSize size}})
+            .attachment-actions
+              a.js-download(href="{{link}}?download=true", download="{{name}}")
+                i.fa.fa-download.icon(title="{{_ 'download'}}")
+              if currentUser.isBoardAdmin
+                a.js-rename
+                  i.fa.fa-pencil-square-o.icon(title="{{_ 'rename'}}")
+                a.js-confirm-delete
+                  i.fa.fa-trash.icon(title="{{_ 'delete'}}")
+              if currentUser.isBoardMember
+                unless currentUser.isCommentOnly
+                  unless currentUser.isWorker
+                    a.fa.fa-navicon.icon.js-open-attachment-menu(title="{{_ 'attachmentActionsPopup-title'}}")
+
 
 template(name="attachmentActionsPopup")
   ul.pop-over-list
@@ -98,12 +107,6 @@ template(name="attachmentActionsPopup")
               | {{_ 'remove-background-image'}}
             else
               | {{_ 'add-background-image'}}
-        a.js-rename
-          i.fa.fa-pencil-square-o
-          | {{_ 'rename'}}
-        a.js-confirm-delete
-          i.fa.fa-close
-          | {{_ 'delete'}}
         p.attachment-storage
           | {{versions.original.storage}}
 

--- a/client/components/cards/attachments.js
+++ b/client/components/cards/attachments.js
@@ -4,17 +4,11 @@ import DOMPurify from 'dompurify';
 const filesize = require('filesize');
 const prettyMilliseconds = require('pretty-ms');
 
-Template.attachmentsGallery.events({
+Template.attachmentGallery.events({
   'click .pdf'(event) {
     let link = $(event.currentTarget).attr("href");
     $("#pdf-viewer").attr("data", link);
     $("#viewer-overlay").removeClass("hidden");
-  },
-  'click #viewer-container'(event) {
-    $("#viewer-overlay").addClass("hidden");
-  },
-  'click #viewer-close'(event) {
-    $("#viewer-overlay").addClass("hidden");
   },
   'click .js-add-attachment': Popup.open('cardAttachments'),
   // If we let this event bubble, FlowRouter will handle it and empty the page
@@ -23,9 +17,23 @@ Template.attachmentsGallery.events({
     event.stopPropagation();
   },
   'click .js-open-attachment-menu': Popup.open('attachmentActions'),
+  'click .js-rename': Popup.open('attachmentRename'),
+  'click .js-confirm-delete': Popup.afterConfirm('attachmentDelete', function() {
+    Attachments.remove(this._id);
+    Popup.back(2);
+  }),
 });
 
-Template.attachmentsGallery.helpers({
+Template.attachmentViewer.events({
+  'click #viewer-container'(event) {
+    $("#viewer-overlay").addClass("hidden");
+  },
+  'click #viewer-close'(event) {
+    $("#viewer-overlay").addClass("hidden");
+  },
+});
+
+Template.attachmentGallery.helpers({
   isBoardAdmin() {
     return Meteor.user().isBoardAdmin();
   },
@@ -194,11 +202,6 @@ BlazeComponent.extendComponent({
   events() {
     return [
       {
-        'click .js-rename': Popup.open('attachmentRename'),
-        'click .js-confirm-delete': Popup.afterConfirm('attachmentDelete', function() {
-          Attachments.remove(this._id);
-          Popup.back(2);
-        }),
         'click .js-add-cover'() {
           Cards.findOne(this.data().meta.cardId).setCover(this.data()._id);
           Popup.back();

--- a/client/components/cards/cardDetails.jade
+++ b/client/components/cards/cardDetails.jade
@@ -562,7 +562,8 @@ template(name="cardDetails")
             br
           | {{_ 'invalid-file'}}
           .card-checklist-attachmentGallery.card-attachmentGallery
-            +attachmentsGallery
+            +attachmentViewer
+            +attachmentGallery
       hr
 
     .card-details-right


### PR DESCRIPTION
This PR adds a nicer attachment gallery with bigger previews and easier access (less clicks) to most common actions (download, rename, delete)

![image](https://github.com/wekan/wekan/assets/18378617/b7d97df6-77ff-40fc-bab8-de5b39b2d4c7)

and an improved attachment viewer with support for:
- images/gifs (transparent images and SVGs are displayed with a checkerboard background)
- videos
- text files
- pdfs
- audio files
![image](https://github.com/wekan/wekan/assets/18378617/7116d729-234b-43f4-810e-57e54083c219)
![image](https://github.com/wekan/wekan/assets/18378617/2522f429-e023-4603-9b4b-70e6a0c1cc1a)
![image](https://github.com/wekan/wekan/assets/18378617/c57cdee4-3836-4b2f-a3f2-d737a2eb6bb7)
![image](https://github.com/wekan/wekan/assets/18378617/aa0e31ee-35fd-4031-8519-0f9a6ab1cc71)
![image](https://github.com/wekan/wekan/assets/18378617/6101efd8-d1b1-46af-ab89-84582cddb3d5)
![image](https://github.com/wekan/wekan/assets/18378617/92cf8d13-519a-4e7c-863c-50b8a4263a99)

The viewer also works on mobile:
![image](https://github.com/wekan/wekan/assets/18378617/99a1c9be-c9ff-4a8e-90e0-f527f7bd8a23)

This viewer no longer uses swipebox so we can remove it (I haven't done that yet)

This PR closes #3888 and #4524