### PR TITLE
Fix attachment viewer not being hidden

### DIFF
--- a/client/components/cards/attachments.css
+++ b/client/components/cards/attachments.css
@@ -1,3 +1,6 @@
+.hidden {
+  display: none;
+}
 .attachment-upload {
   text-align: center;
   font-weight: bold;

--- a/client/components/cards/attachments.jade
+++ b/client/components/cards/attachments.jade
@@ -31,9 +31,7 @@ template(name="attachmentDeletePopup")
   button.js-confirm.negate.full(type="submit") {{_ 'delete'}}
 
 template(name="attachmentViewer")
-// Disabled attachment viewer, because it opens with empty content
-// when opening card.
-//#viewer-overlay.hidden
+  #viewer-overlay.hidden
     #viewer-top-bar
       span#attachment-name
       a#viewer-close.fa.fa-times-thin


### PR DESCRIPTION
A fix for attachment viewer not being hidden after removing some dependencies.

It looks like one of those defined a `.hidden` css class which I used for the attachment viewer and I forgot to define it separately. 