### PR TITLE
fix for migration "attachment-cardCopy-fix-boardId-etc"

### DIFF
--- a/server/migrations.js
+++ b/server/migrations.js
@@ -1425,13 +1425,15 @@ Migrations.add('attachment-cardCopy-fix-boardId-etc', () => {
   Attachments.find( {"meta.source": "copy"} ).forEach(_attachment => {
     const cardId = _attachment.meta.cardId;
     const card = Cards.findOne(cardId);
-    console.log("update attachment id: ", _attachment._id);
-    Attachments.update(_attachment._id, {
-      $set: {
-        "meta.boardId": card.boardId,
-        "meta.listId": card.listId,
-        "meta.swimlaneId": card.swimlaneId,
-      }
-    });
+    if (card.boardId && card.listId && card.swimlaneId) {
+      console.log("update attachment id: ", _attachment._id);
+      Attachments.update(_attachment._id, {
+        $set: {
+          "meta.boardId": card.boardId,
+          "meta.listId": card.listId,
+          "meta.swimlaneId": card.swimlaneId,
+        }
+      });
+    }
   });
 });


### PR DESCRIPTION
- every card must have a boardId, listId and swimlaneId, if not, the database data is corrupt, but the migration should also not break wekan from startup
- fixes #4998