### PR TITLE
Only selectively show login elements once settings is loaded

### DIFF
--- a/client/components/main/layouts.css
+++ b/client/components/main/layouts.css
@@ -639,3 +639,7 @@ a:not(.disabled).is-active i.fa {
     transform: rotate(360deg);
   }
 }
+
+.at-pwd-form {
+  display: none;
+}

--- a/client/components/main/layouts.js
+++ b/client/components/main/layouts.js
@@ -45,9 +45,9 @@ Template.userFormsLayout.onCreated(function () {
       return this.stop();
     },
   });
-  Meteor.call('isPasswordLoginDisabled', (_, result) => {
+  Meteor.call('isPasswordLoginEnabled', (_, result) => {
     if (result) {
-      $('.at-pwd-form').hide();
+      $('.at-pwd-form').show();
     }
   });
 

--- a/config/accounts.js
+++ b/config/accounts.js
@@ -4,7 +4,7 @@ const passwordField = AccountsTemplates.removeField('password');
 const emailField = AccountsTemplates.removeField('email');
 let disableRegistration = false;
 let disableForgotPassword = false;
-let passwordLoginDisabled = false;
+let passwordLoginEnabled = false;
 let oidcRedirectionEnabled = false;
 let oauthServerUrl = "home";
 let oauthDashboardUrl = "";
@@ -16,11 +16,9 @@ Meteor.call('isOidcRedirectionEnabled', (_, result) => {
   }
 });
 
-Meteor.call('isPasswordLoginDisabled', (_, result) => {
+Meteor.call('isPasswordLoginEnabled', (_, result) => {
   if (result) {
-    passwordLoginDisabled = true;
-    //console.log('passwordLoginDisabled');
-    //console.log(result);
+    passwordLoginEnabled = true;
   }
 });
 

--- a/models/settings.js
+++ b/models/settings.js
@@ -521,8 +521,8 @@ if (Meteor.isServer) {
       return process.env.DEFAULT_AUTHENTICATION_METHOD;
     },
 
-    isPasswordLoginDisabled() {
-      return process.env.PASSWORD_LOGIN_ENABLED === 'false';
+    isPasswordLoginEnabled() {
+      return !(process.env.PASSWORD_LOGIN_ENABLED === 'false');
     },
     isOidcRedirectionEnabled(){
       return process.env.OIDC_REDIRECTION_ENABLED === 'true' && Object.keys(loadOidcConfig("oidc")).length > 0;


### PR DESCRIPTION
The password login form is always created by meteor so we have to resort to overwriting the default css selector first.

This also reverses the password enabled/disabled flag to be more in-sync with other login methods.

Fixes #5029