### PR TITLE
Alphabetic ordered member lists on assigne and member lists

### DIFF
--- a/client/components/cards/cardDetails.js
+++ b/client/components/cards/cardDetails.js
@@ -752,7 +752,7 @@ Template.cardMembersPopup.events({
 
 Template.cardMembersPopup.helpers({
   members() {
-    return Template.instance().members.get();
+    return _.sortBy(Template.instance().members.get(),'fullname');
   },
 });
 
@@ -1614,7 +1614,7 @@ Template.cardAssigneesPopup.helpers({
   },
 
   members() {
-    return Template.instance().members.get();
+    return _.sortBy(Template.instance().members.get(),'fullname');
   },
 
   user() {


### PR DESCRIPTION
fixes https://github.com/wekan/wekan/issues/5070

The lists become sorted by fullname.

I did not found, how to set the members list popup of the board members to another sorting so it may stay sorted by username but i think fullname is more practically in daily business.