### PR TITLE
Fix downloading attachments with unusual filenames [WIP]

### DIFF
--- a/client/components/cards/attachments.js
+++ b/client/components/cards/attachments.js
@@ -292,13 +292,16 @@ Template.cardAttachmentsPopup.events({
       let uploads = [];
       for (const file of files) {
         const fileId = new ObjectID().toString();
-        // If filename is not same as sanitized filename, has XSS, then cancel upload
-        if (file.name !== DOMPurify.sanitize(file.name)) {
-          return false;
+        const fileName = DOMPurify.sanitize(file.name);
+
+        if (fileName !== file.name) {
+          console.warn('Detected possible XSS in file: ', file.name + '. Renamed to: ', fileName + '.');
         }
+
         const config = {
           file: file,
           fileId: fileId,
+          fileName: fileName,
           meta: Utils.getCommonAttachmentMetaFrom(card),
           chunkSize: 'dynamic',
         };


### PR DESCRIPTION
There are quite a few issues that report problems with attachment downloads not working due to various symbols in the filename.
Issues: #3776, #4227,  #4144,  #3774

Here are my findings for the symbols mentioned in above issues:
- \#     preserved
- ?     replaced with a space
- \     replaced with _
- %     preserved
- "     replaced with a space
- \*     replaced with a space
- :     replaced with a space
- <     can't upload (XSS sanitization problem) --> renamed to sanitized version
- \>     replaced with a space
- |     replaced with a space
- \-     preserved
- _     preserved
- (space) preserved
- non-ascii (Тестовый файл.pdf) preserved

So far the only change I made is to rename files that might have XSS and print a warning so that a user (or an admin) can figure out why the filename was changed. 
Previously uploads for such files would fail silently

Issues mentioned above all complained that file downloads would fail with various errors but in my case, running wekan 7.06, they all work fine.
The only change I would make is to fix inconsistent replacements for \.

Do you think anything else should be done here?
