### PR TITLE
Move card to other boards API

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -3499,6 +3499,9 @@ JsonRoutes.add('GET', '/api/boards/:boardId/cards_count', function(
       const paramBoardId = req.params.boardId;
       const paramCardId = req.params.cardId;
       const paramListId = req.params.listId;
+      const newBoardId = req.body.newBoardId;
+      const newSwimlaneId = req.body.newSwimlaneId;
+      const newListId = req.body.newListId;
       Authentication.checkBoardAccess(req.userId, paramBoardId);
 
       if (req.body.title) {
@@ -3825,6 +3828,34 @@ JsonRoutes.add('GET', '/api/boards/:boardId/cards_count', function(
             fieldName: 'listId',
           },
           paramListId,
+        );
+      }
+      if (newBoardId && newSwimlaneId && newListId) {
+        // Move the card to the new board, swimlane, and list
+        Cards.direct.update(
+          {
+            _id: paramCardId,
+            listId: paramListId,
+            boardId: paramBoardId,
+            archived: false,
+          },
+          {
+            $set: {
+              boardId: newBoardId,
+              swimlaneId: newSwimlaneId,
+              listId: newListId,
+            },
+          },
+        );
+
+        const card = ReactiveCache.getCard(paramCardId);
+        cardMove(
+          req.userId,
+          card,
+          ['boardId', 'swimlaneId', 'listId'],
+          newListId,
+          newSwimlaneId,
+          newBoardId,
         );
       }
       JsonRoutes.sendResult(res, {


### PR DESCRIPTION
### Summary

Ability to change the card's board and swimlane and list.

### Details

- **Card Field Updates**: The API endpoint now supports changing the board of a card. When provided, the `newBoardId` and `newSwimlaneId` and `newListId` parameters can be used to move a card to a new board.

