### PR TITLE
Fix for CalendarView, Create Card without Refresh

### DIFF
--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -320,7 +320,7 @@ BlazeComponent.extendComponent({
   calendarOptions() {
     return {
       id: 'calendar-view',
-      defaultView: 'agendaDay',
+      defaultView: 'month',
       editable: true,
       selectable: true,
       timezone: 'local',


### PR DESCRIPTION
Fix for https://github.com/wekan/wekan/issues/5086
Changing `defaultView` from `'agendaDay'` to `'month'` fixes the problem that we had to refresh in order to show card when it's created with the calendar view.