### PR TITLE
Make sessinAffinity stickable to clientIP

### DIFF
--- a/openshift/wekan.yml
+++ b/openshift/wekan.yml
@@ -62,7 +62,7 @@ objects:
       targetPort: 8080
     selector:
       name: "${WEKAN_SERVICE_NAME}"
-    sessionAffinity: None
+    sessionAffinity: ClientIP
     type: ClusterIP
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
This would help, but not fix #5120. It's now supports the running of multiple pods for scaling, without the issue that the session will not known on the backend pod.