### PR TITLE
Added missing activityType: restoredList

### DIFF
--- a/models/lists.js
+++ b/models/lists.js
@@ -465,6 +465,17 @@ if (Meteor.isServer) {
         // list is deleted
         title: doc.title,
       });
+    } else {
+      Activities.insert({
+        userId,
+        type: 'list',
+        activityType: 'restoredList',
+        listId: doc._id,
+        boardId: doc.boardId,
+        // this preserves the name so that the activity can be useful after the
+        // list is deleted
+        title: doc.title,
+      });
     }
   });
 }


### PR DESCRIPTION
Global Webhooks only contained the act-archivedList activity. This pull request adds 
act-restoredList to the webhook activities.