### PR TITLE
Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ that by providing one-click installation on various platforms.
 We also welcome sponsors for features and bugfixes.
 By working directly with WeKan ® you get the benefit of active maintenance and new features added by growing WeKan ® developer community.
 
+You can [self-host Wekan in one-click](https://app.trydome.io/signup?package=wekan) on Dome:
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=wekan)
+
+
 ## Screenshot
 
 [More screenshots at Features page](https://github.com/wekan/wekan/wiki/Features)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ that by providing one-click installation on various platforms.
 We also welcome sponsors for features and bugfixes.
 By working directly with WeKan ® you get the benefit of active maintenance and new features added by growing WeKan ® developer community.
 
-You can [self-host Wekan in one-click](https://app.trydome.io/signup?package=wekan) on Dome:
+You can self-host Wekan in one-click on [Dome](https://app.trydome.io/signup?package=wekan):
 
 [![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=wekan)
 


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.  We saw that you have detailed instructions in the wiki but didn't see a way to contribute to it so we made a PR on the readme

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:
https://e8ca23d7f2c96b20792d3c8de7e20fcc26924990.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.