### PR TITLE
Permissions for default board

### DIFF
--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -313,17 +313,17 @@ Meteor.methods({
     check(oidcUserId, String);
 
     const defaultBoardParams = (process.env.DEFAULT_BOARD_ID || '').split(':');
-    const defaultBoardId = defaultBoardParams.pop()
+    const defaultBoardId = defaultBoardParams.shift()
     if (!defaultBoardId) return
 
     const board = Boards.findOne(defaultBoardId)
-    const user = Users.findOne({ 'services.oidc.id': oidcUserId })
-    const memberIndex = _.pluck(board.members, 'userId').indexOf(user._id);
-    if(!board || memberIndex > -1) return
+    const userId = Users.findOne({ 'services.oidc.id': oidcUserId })?._id
+    const memberIndex = _.pluck(board?.members, 'userId').indexOf(userId);
+    if(!board || !userId || memberIndex > -1) return
 
-    board.addMember(user._id)
+    board.addMember(userId)
     board.setMemberPermission(
-      user._id,
+      userId,
       defaultBoardParams.contains("isAdmin"),
       defaultBoardParams.contains("isNoComments"),
       defaultBoardParams.contains("isCommentsOnly"),

--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -312,19 +312,23 @@ Meteor.methods({
     check(info, Object);
     check(oidcUserId, String);
 
-    const defaultBoardId = process.env.DEFAULT_BOARD_ID || false;
+    const defaultBoardParams = (process.env.DEFAULT_BOARD_ID || '').split(':');
+    const defaultBoardId = defaultBoardParams.pop()
+    if (!defaultBoardId) return
 
-    if (defaultBoardId)
-    {
-      const board = Boards.findOne(defaultBoardId)
-      const user = Users.findOne({ 'services.oidc.id': oidcUserId })
-      const memberIndex = _.pluck(board.members, 'userId').indexOf(user._id);
+    const board = Boards.findOne(defaultBoardId)
+    const user = Users.findOne({ 'services.oidc.id': oidcUserId })
+    const memberIndex = _.pluck(board.members, 'userId').indexOf(user._id);
+    if(!board || memberIndex > -1) return
 
-      if(board && memberIndex < 0)
-      {
-        board.addMember(user._id)
-      }
-    }
+    board.addMember(user._id)
+    board.setMemberPermission(
+      user._id,
+      defaultBoardParams.contains("isAdmin"),
+      defaultBoardParams.contains("isNoComments"),
+      defaultBoardParams.contains("isCommentsOnly"),
+      defaultBoardParams.contains("isWorker")
+    )
   }
 });
 


### PR DESCRIPTION
This is an addition to [the previous PR](https://github.com/wekan/wekan/pull/5098). It now allows to specify the users permission on the default board. To make new users admin on the default board add it to the ENV:

`DEFAULT_BOARD_ID=someboardId:isAdmin`