### PR TITLE
Fix: export html popup

### DIFF
--- a/client/lib/exportHTML.js
+++ b/client/lib/exportHTML.js
@@ -155,6 +155,50 @@ window.ExportHtml = Popup => {
     );
   };
 
+  const getWebFonts = () => {
+    fontUrls = [];
+
+    for (let sheet of document.styleSheets) {
+      // Get the base URL of the stylesheet
+      let baseUrl = sheet.href ? new URL(sheet.href).origin : window.location.origin;
+
+      try {
+        for (let rule of sheet.cssRules) {
+          if (rule.type === CSSRule.FONT_FACE_RULE) {
+            let src = rule.style.getPropertyValue('src');
+            let urlMatch = src.match(/url\(["']?(.+?)["']?\)/);
+            if (urlMatch) {
+              let fontUrl = urlMatch[1];
+
+              // Resolve the URL relative to the stylesheet's base URL
+              let resolvedUrl = new URL(fontUrl, baseUrl);
+              fontUrls.push(resolvedUrl.href); // Using .href to get the absolute URL
+            }
+          }
+        }
+      } catch (e) {
+          console.log('Access to stylesheet blocked:', e);
+      }
+    }
+
+    return fontUrls;
+  };
+
+  const downloadFonts = async(elements, zip) => {
+    await asyncForEach(elements, async elem => {
+      const response = await fetch(elem);
+      const responseBody = await response.blob();
+      const filename = elem.split('/')
+        .pop()
+        .split('?')
+        .shift()
+        .split('#')
+        .shift();
+      const fileFullPath = `webfonts/${filename}`;
+        zip.file(fileFullPath, responseBody);
+    });
+  }
+
   const downloadCardCovers = async (elements, zip, boardSlug) => {
     await asyncForEach(elements, async elem => {
       const response = await fetch(
@@ -197,6 +241,7 @@ window.ExportHtml = Popup => {
     await downloadStylesheets(getStylesheetList(), zip);
     await downloadSrcAttached(getSrcAttached(), zip, boardSlug);
     await downloadCardCovers(getCardCovers(), zip, boardSlug);
+    await downloadFonts(getWebFonts(), zip);
 
     addBoardHTMLToZip(boardSlug, zip);
 

--- a/client/lib/exportHTML.js
+++ b/client/lib/exportHTML.js
@@ -57,6 +57,9 @@ window.ExportHtml = Popup => {
     Array.from(
       document.querySelectorAll('#header-main-bar .board-header-btns'),
     ).forEach(elem => elem.remove());
+    Array.from(
+      document.querySelectorAll('.js-pop-over, .pop-over'),
+    ).forEach(elem => elem.remove());
     Array.from(document.querySelectorAll('.list-composer')).forEach(elem =>
       elem.remove(),
     );


### PR DESCRIPTION
## Summary:

So this is a fix and a feature


## Background:
I contributed HTML export so that folks wouldn't have to host a public mongoDB to share boards in non-interactive format with stakeholders that just want visibility.

Several frontend changes have happened since then, and I've not really had time to revisit the feature (feel free to tag me in issues relating to HTML export)

One change led to the following glitch (note the board is an empty board deliberately)

It's probably not the end of the world, but I wanted to fix it.

The feature added, is exporting webfonts and including them in the zip file.

This was tested on OSx (Apple Silicon) running armv8 wekan in Docker

## Expected outcome

![image of export after this patch](https://github.com/wekan/wekan/assets/2605791/5d81d3b4-34c4-43b4-b017-e2f79a10bc19)

## Actual outcome

![image of a popup still visible in a board exported to HTML](https://github.com/wekan/wekan/assets/2605791/80604913-eb64-4eb3-8705-1add2414efeb)

