### PR TITLE
openapi: fix breakage introduced with blank return

### DIFF
--- a/openapi/generate_openapi.py
+++ b/openapi/generate_openapi.py
@@ -66,7 +66,8 @@ def get_req_body_elems(obj, elems):
         get_req_body_elems(obj.left, elems)
         get_req_body_elems(obj.right, elems)
     elif obj.type in ('ReturnStatement', 'UnaryExpression'):
-        get_req_body_elems(obj.argument, elems)
+        if obj.argument is not None:
+            get_req_body_elems(obj.argument, elems)
     elif obj.type == 'Identifier':
         return obj.name
     elif obj.type in ['Literal', 'FunctionDeclaration', 'ThrowStatement']:


### PR DESCRIPTION
Introduced by commit f8ef2e33de2d ("cards.js Added a control to check error if card is not updated"), a blank return was added at line 3914.

The generate_openapi script assumed a return statement always has an argument, and this was crashing.

Fixes #5320