### PR TITLE
Make the contents of the cards grow to the list width

### DIFF
--- a/client/components/cards/minicard.css
+++ b/client/components/cards/minicard.css
@@ -175,7 +175,6 @@
   .minicard .minicard-title .viewer {
     display: block;
     word-wrap: break-word;
-    max-width: 230px;
   }
 }
 .minicard .dates {


### PR DESCRIPTION
Before this change, increasing the width of the list does not give much of a benefit, because the contents of the list are wrapped to 230px, anyway: 

![image](https://github.com/wekan/wekan/assets/2697916/2560b6fc-b6f4-4fc9-93d9-fd94be6ed92b)


After this change, the full width of the card is taken advantage of:

![image](https://github.com/wekan/wekan/assets/2697916/fabaafcf-8070-4fd0-aa67-acb0bcd004e1)
