### PR TITLE
Fix DEBUG environment variable check

### DIFF
--- a/imports/i18n/tap.js
+++ b/imports/i18n/tap.js
@@ -20,7 +20,7 @@ export const TAPi18n = {
       cleanCode: true,
       // Show translations debug messages only when DEBUG=true
       // OLD: debug: Meteor.isDevelopment,
-      debug: process.env.DEBUG,
+      debug: process.env.DEBUG === 'true',
       supportedLngs: Object.values(languages).map(({ tag }) => tag),
       ns: DEFAULT_NAMESPACE,
       defaultNs: DEFAULT_NAMESPACE,

--- a/packages/wekan-oidc/oidc_server.js
+++ b/packages/wekan-oidc/oidc_server.js
@@ -19,7 +19,7 @@ var serviceData = {};
 var userinfo = {};
 
 OAuth.registerService('oidc', 2, null, function (query) {
-  var debug = process.env.DEBUG || false;
+  var debug = process.env.DEBUG === 'true';
 
   var token = getToken(query);
   if (debug) console.log('XXX: register token:', token);
@@ -135,7 +135,7 @@ if (Meteor.release) {
 
 if (process.env.ORACLE_OIM_ENABLED !== 'true' && process.env.ORACLE_OIM_ENABLED !== true) {
   var getToken = function (query) {
-    var debug = process.env.DEBUG || false;
+    var debug = process.env.DEBUG === 'true';
     var config = getConfiguration();
     if(config.tokenEndpoint.includes('https://')){
       var serverTokenEndpoint = config.tokenEndpoint;
@@ -181,7 +181,7 @@ if (process.env.ORACLE_OIM_ENABLED !== 'true' && process.env.ORACLE_OIM_ENABLED 
 if (process.env.ORACLE_OIM_ENABLED === 'true' || process.env.ORACLE_OIM_ENABLED === true) {
 
   var getToken = function (query) {
-    var debug = (process.env.DEBUG === 'true' || process.env.DEBUG === true) || false;
+    var debug = process.env.DEBUG === 'true';
     var config = getConfiguration();
     if(config.tokenEndpoint.includes('https://')){
       var serverTokenEndpoint = config.tokenEndpoint;
@@ -240,7 +240,7 @@ if (process.env.ORACLE_OIM_ENABLED === 'true' || process.env.ORACLE_OIM_ENABLED 
 
 
 var getUserInfo = function (accessToken) {
-  var debug = process.env.DEBUG || false;
+  var debug = process.env.DEBUG === 'true';
   var config = getConfiguration();
   // Some userinfo endpoints use a different base URL than the authorization or token endpoints.
   // This logic allows the end user to override the setting by providing the full URL to userinfo in their config.

--- a/server/authentication.js
+++ b/server/authentication.js
@@ -129,7 +129,7 @@ Meteor.startup(() => {
             validateUrl: process.env.CASE_VALIDATE_URL,
             casVersion: 3.0,
             attributes: {
-              debug: process.env.DEBUG,
+              debug: process.env.DEBUG === 'true',
             },
           },
         },


### PR DESCRIPTION
In JS, the values of environment variables are [converted to string](https://nodejs.org/api/process.html#process_process_env) when checked, so the check for the `false` in value was incorrect.

Fix #5379