### PR TITLE
By default, use localized long date-time format

### DIFF
--- a/client/config/blazeHelpers.js
+++ b/client/config/blazeHelpers.js
@@ -47,7 +47,7 @@ Blaze.registerHelper('isTouchScreenOrShowDesktopDragHandles', () =>
 Blaze.registerHelper('moment', (...args) => {
   args.pop(); // hash
   const [date, format] = args;
-  return moment(date).format(format);
+  return moment(date).format(format ?? 'LLLL');
 });
 
 Blaze.registerHelper('canModifyCard', () =>


### PR DESCRIPTION
because ISO 8601 is not easy to the eye (at least for non-tech people).

We are currently adopting Wekan (moving away from trello) and the date format on the comment activity was found to be hard to read by many. If existing users love the previous ISO format, it might make sense to make the format customizable. Though, I would expect the locale selection to allow to take care of that already.