### PR TITLE
fixed loading of cards if there are more than 20 of them on one swimlane

### DIFF
--- a/client/components/swimlanes/swimlanes.css
+++ b/client/components/swimlanes/swimlanes.css
@@ -11,7 +11,8 @@
   background: #dedede;
   display: flex;
   flex-direction: row;
-  overflow: 0;
+  overflow: auto;
+  max-height: 100%;
 }
 .swimlane-header-menu .swimlane-header-collapse-down {
   font-size: 50%;


### PR DESCRIPTION
If there are more than 20 cards on one swimlane, we see infinite loading of the next cards. The bug appeared in version 7.10 with commit 7f9aa7509314a85a550dd16615429c5e030b5f2b.