### PR TITLE
Bugfix: Strikethrough inactive Teams and orginizations logic was inverted

### DIFF
--- a/client/components/users/userAvatar.jade
+++ b/client/components/users/userAvatar.jade
@@ -26,9 +26,9 @@ template(name="orgAvatar")
 template(name="boardOrgRow")
   tr
     if orgData.orgIsActive
-      td <s>{{ orgData.orgDisplayName }}</s>
-    else
       td {{ orgData.orgDisplayName }}
+    else
+      td <s>{{ orgData.orgDisplayName }}</s>
     td
       if currentUser.isBoardAdmin
         a.member.orgOrTeamMember.add-member.js-manage-board-removeOrg(title="{{_ 'remove-from-board'}}")
@@ -39,9 +39,9 @@ template(name="boardOrgRow")
 template(name="boardTeamRow")
   tr
     if teamData.teamIsActive
-      td <s>{{ teamData.teamDisplayName }}</s>
-    else
       td {{ teamData.teamDisplayName }}
+    else
+      td <s>{{ teamData.teamDisplayName }}</s>
     td
       if currentUser.isBoardAdmin
         a.member.orgOrTeamMember.add-member.js-manage-board-removeTeam(title="{{_ 'remove-from-board'}}")


### PR DESCRIPTION
This fixes #5352.
If an organization or team was marked as inactive then their name did *not* not have a line across their name in the sidebar for Boards, where as if an organization or team was marked as active then their name had a strikethrough as shown in this screen shot below.
![image](https://github.com/wekan/wekan/assets/105611542/a9916520-dd74-44f5-981b-3518519519b6)