### PR TITLE
Fill out Org and Team in adminReports

### DIFF
--- a/client/components/settings/adminReports.jade
+++ b/client/components/settings/adminReports.jade
@@ -138,7 +138,6 @@ template(name="boardsReport")
           th Members
           th Organizations
           th Teams
-
       each board in results
         tbody
           tr
@@ -148,5 +147,7 @@ template(name="boardsReport")
             td
               = yesOrNo(board.archived)
             td {{userNames board.members }}
+            td {{orgs board.orgs }}
+            td {{teams board.teams }}
   else
     div {{_ 'no-results' }}

--- a/client/components/settings/adminReports.js
+++ b/client/components/settings/adminReports.js
@@ -170,7 +170,26 @@ class AdminReport extends BlazeComponent {
       .join(", ");
     return ret;
   }
+  teams(memberTeams) {
+    const ret = (memberTeams || [])
+      .map(_memberTeam => {
+        const _ret = ReactiveCache.getTeam(_memberTeam.teamId)?.teamDisplayName || _memberTeam.teamId;
+        return _ret;
+      })
+      .join(", ");
+    return ret;
+  }
+  orgs(orgs) {
+    const ret = (orgs || [])
+      .map(_orgs => {
+        const _ret = ReactiveCache.getOrg(_orgs.orgId)?.orgDisplayName || _orgs.orgId;
+        return _ret;
+      })
+      .join(", ");
+    return ret;
+  }
 }.register('boardsReport'));
+
 
 (class extends AdminReport {
   collection = Cards;


### PR DESCRIPTION
Teams and Orgs are missing from Admin Reports. This adds them back in.

Note: Inactive Teams and orgs are not styles with a strike-though. which may or may not be relevant there. Honestly I couldn't get Jade/Pug to comply with what I wanted to do and you do not appear to place HTML in the javascript files.

<img width="698" alt="image" src="https://github.com/wekan/wekan/assets/105611542/59204a36-3969-4926-a577-a3608ad654c7">
