### PR TITLE
Update cardDetails.css

### DIFF
--- a/client/components/cards/cardDetails.css
+++ b/client/components/cards/cardDetails.css
@@ -272,7 +272,7 @@
     box-sizing: border-box;
     top: 97px;
     left: 0px;
-    height: calc(100% - 20px);
+    height: calc(100% - 100px);
     width: calc(100% - 20px);
     float: left;
   }


### PR DESCRIPTION
Fix minor fix for the UI.
Task card may overflow below the screen when maximized, making the bottom part not viewable.

Reason: Top position is set to 97px, Height of the element is set to calc(100% - 20px).

Fix: Set the height to be lower than 100% - Top position