### PR TITLE
remove attachment storage name from attachment list

### DIFF
--- a/client/components/cards/attachments.jade
+++ b/client/components/cards/attachments.jade
@@ -117,8 +117,6 @@ template(name="attachmentActionsPopup")
               | {{_ 'remove-background-image'}}
             else
               | {{_ 'add-background-image'}}
-        p.attachment-storage
-          | {{versions.original.storage}}
 
         if $neq versions.original.storage "fs"
           a.js-move-storage-fs


### PR DESCRIPTION
- this was for debugging, now not necessary anymore