### PR TITLE
renaming list shows in activities

### DIFF
--- a/client/components/activities/activities.jade
+++ b/client/components/activities/activities.jade
@@ -206,6 +206,9 @@ template(name="activity")
         if($eq activity.activityType 'archivedList')
           | {{_ 'activity-archived' (sanitize listLabel)}}.
 
+        if($eq activity.activityType 'changedListTitle')
+          {{_ 'activity-changedListTitle' (sanitize listLabel) boardLabelLink}}
+
       //- member activity ----------------------------------------------------
       if($eq activity.activityType 'joinMember')
         if($eq user._id activity.member._id)

--- a/imports/i18n/data/en.i18n.json
+++ b/imports/i18n/data/en.i18n.json
@@ -49,6 +49,7 @@
   "activity-archived": "%s moved to Archive",
   "activity-attached": "attached %s to %s",
   "activity-created": "created %s",
+  "activity-changedListTitle": "renamed list to %s",
   "activity-customfield-created": "created custom field %s",
   "activity-excluded": "excluded %s from %s",
   "activity-imported": "imported %s into %s from %s",


### PR DESCRIPTION
There was a bug when renaming the list it would only show the username in the activities list and not a description of what happened. Added the changedListTitle from list.js into activities.jade so that it will correctly show the list in the activities.