### PR TITLE
Hide scrollbars where they interrupt

### DIFF
--- a/client/components/cards/cardDetails.css
+++ b/client/components/cards/cardDetails.css
@@ -90,6 +90,10 @@
   transition: flex-basis 0.1s;
   box-sizing: border-box;
 }
+.card-details::-webkit-scrollbar {
+  /* Hide scroll bars from middle of the screen */
+  display: none !important;
+}
 .card-details .mCustomScrollBox {
   padding-left: 0;
 }

--- a/client/components/lists/list.css
+++ b/client/components/lists/list.css
@@ -148,6 +148,10 @@
   overflow-y: auto;
   padding: 5px 11px;
 }
+.list-body::-webkit-scrollbar {
+  /* Hide scroll bars from middle of the screen */
+  display: none !important;
+}
 .list-body .minicards {
   flex-grow: 1;
   flex-shrink: 0;


### PR DESCRIPTION
* Hide scrollbars from card details view
* Hide scrollbars from card lists, which are annoying because they are in the middle of the screen