### PR TITLE
Change move-to-archive keyboard shortcut to '-', because of Ctrl + C shortcut

### DIFF
--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -159,7 +159,7 @@ Mousetrap.bind('space', evt => {
   }
 });
 
-Mousetrap.bind('c', evt => {
+Mousetrap.bind('-', evt => {
   const cardId = getSelectedCardId();
   if (!cardId) {
     return;
@@ -222,7 +222,7 @@ Template.keyboardShortcuts.helpers({
       action: 'shortcut-assign-self',
     },
     {
-      keys: ['c'],
+      keys: ['-'],
       action: 'archive-card',
     },
     {


### PR DESCRIPTION
Ctrl + C from card text would cause the card to be archived :(