### PR TITLE
Potential bug(fix?) - Add assign-self keyboard shortcut (old shortcut actually adds)

### DIFF
--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -139,6 +139,26 @@ Mousetrap.bind(numArray, (evt, key) => {
   }
 });
 
+Mousetrap.bind('m', evt => {
+  const cardId = getSelectedCardId();
+  if (!cardId) {
+    return;
+  }
+
+  const currentUserId = Meteor.userId();
+  if (currentUserId === null) {
+    return;
+  }
+
+  if (ReactiveCache.getCurrentUser().isBoardMember()) {
+    const card = ReactiveCache.getCard(cardId);
+    card.toggleAssignee(currentUserId);
+    // We should prevent scrolling in card when spacebar is clicked
+    // This should do it according to Mousetrap docs, but it doesn't
+    evt.preventDefault();
+  }
+});
+
 Mousetrap.bind('space', evt => {
   const cardId = getSelectedCardId();
   if (!cardId) {
@@ -219,6 +239,10 @@ Template.keyboardShortcuts.helpers({
     },
     {
       keys: ['SPACE'],
+      action: 'shortcut-add-self',
+    },
+    {
+      keys: ['n'],
       action: 'shortcut-assign-self',
     },
     {

--- a/imports/i18n/data/en.i18n.json
+++ b/imports/i18n/data/en.i18n.json
@@ -574,6 +574,7 @@
   "select-board": "Select Board",
   "set-wip-limit-value": "Set a limit for the maximum number of tasks in this list",
   "setWipLimitPopup-title": "Set WIP Limit",
+  "shortcut-add-self": "Add yourself to current card",
   "shortcut-assign-self": "Assign yourself to current card",
   "shortcut-autocomplete-emoji": "Autocomplete emoji",
   "shortcut-autocomplete-members": "Autocomplete members",


### PR DESCRIPTION
The current `[SPACE]` shortcut toggles the current user as a member of the card, but the translation suggests it should assign.

This PR does not fix that - it retains the original behaviour, but updates the translation.
In addition, a new `[m]` shortcut is defined to actually toggle the current user as an assignee.

This is a potential bug, which could also be fixed by the following patch instead:
```
diff --git a/client/lib/keyboard.js b/client/lib/keyboard.js
index 79f90456c..6d315b984 100644
--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -152,7 +152,7 @@ Mousetrap.bind('space', evt => {
 
   if (ReactiveCache.getCurrentUser().isBoardMember()) {
     const card = ReactiveCache.getCard(cardId);
-    card.toggleMember(currentUserId);
+    card.toggleAssignee(currentUserId);
     // We should prevent scrolling in card when spacebar is clicked
     // This should do it according to Mousetrap docs, but it doesn't
     evt.preventDefault();

```