### PR TITLE
Opinion - Disable week-of-year in date displays

### DIFF
--- a/client/components/cards/cardCustomFields.jade
+++ b/client/components/cards/cardCustomFields.jade
@@ -79,13 +79,11 @@ template(name="cardCustomField-currency")
 
 template(name="cardCustomField-date")
     if canModifyCard
-      a.js-edit-date(title="{{showTitle}} {{_ 'predicate-week'}} {{showWeek}}" class="{{classes}}")
+      a.js-edit-date(title="{{showTitle}} {{_ 'predicate-week'}}" class="{{classes}}")
         if value
           div.card-date
             time(datetime="{{showISODate}}")
               | {{showDate}}
-              b
-                | {{showWeek}}
         else
           | {{_ 'edit'}}
     else
@@ -93,8 +91,6 @@ template(name="cardCustomField-date")
         div.card-date
           time(datetime="{{showISODate}}")
             | {{showDate}}
-            b
-              | {{showWeek}}
 
 template(name="cardCustomField-dropdown")
     if canModifyCard

--- a/client/components/cards/cardDate.jade
+++ b/client/components/cards/cardDate.jade
@@ -1,20 +1,11 @@
 template(name="dateBadge")
   if canModifyCard
-    a.js-edit-date.card-date(title="{{showTitle}} {{_ 'predicate-week'}} {{showWeek}}" class="{{classes}}")
+    a.js-edit-date.card-date(title="{{showTitle}} {{_ 'predicate-week'}}" class="{{classes}}")
       time(datetime="{{showISODate}}")
-        | {{showDate}}
-        b
-          | {{showWeek}}
   else
-    a.card-date(title="{{showTitle}} {{_ 'predicate-week'}} {{showWeek}}" class="{{classes}}")
+    a.card-date(title="{{showTitle}} {{_ 'predicate-week'}}" class="{{classes}}")
       time(datetime="{{showISODate}}")
-        | {{showDate}}
-        b
-          | {{showWeek}}
 
 template(name="dateCustomField")
-  a(title="{{showTitle}} {{_ 'predicate-week'}} {{showWeek}}" class="{{classes}}")
+  a(title="{{showTitle}} {{_ 'predicate-week'}}" class="{{classes}}")
     time(datetime="{{showISODate}}")
-      | {{showDate}}
-      b
-        | {{showWeek}}


### PR DESCRIPTION
I think this feature does not improve the overall WeKan experience.

This number does not mean anything for the regular user.
It is difficult to understant what this number means without looking at the code, and it makes the UI too crowded.

I suggest removing this feature.