### PR TITLE
Make lists fill up space evenly, change listWidth to max-width

### DIFF
--- a/client/components/lists/list.css
+++ b/client/components/lists/list.css
@@ -7,12 +7,14 @@
   border-left: 1px solid #ccc;
   padding: 0;
   float: left;
+  flex: 1;
 }
 [id^="swimlane-"] .list:first-child {
   min-width: 20px;
 }
 .list:first-child {
   border-left: none;
+  flex: none;
 }
 .card-details + .list {
   border-left: none;
@@ -30,6 +32,9 @@
   border-color: transparent;
   box-shadow: none;
   height: 100px;
+}
+.list.list-collapsed {
+  flex: none;
 }
 .list.list-composer .open-list-composer,
 .list .list-composer .open-list-composer {

--- a/client/components/lists/list.jade
+++ b/client/components/lists/list.jade
@@ -1,6 +1,6 @@
 template(name='list')
   .list.js-list(id="js-list-{{_id}}"
-                style="{{#unless collapsed}}width:{{listWidth}}px;{{/unless}}"
+                style="{{#unless collapsed}}max-width:{{listWidth}}px;{{/unless}}"
                 class="{{#if collapsed}}list-collapsed{{/if}}")
     +listHeader
     +listBody

--- a/client/components/swimlanes/swimlanes.css
+++ b/client/components/swimlanes/swimlanes.css
@@ -1,8 +1,3 @@
-@media screen and (min-width: 801px) {
-  .swimlane.ui-sortable {
-    width: max-content;
-  }
-}
 [class=swimlane] {
   position: sticky;
   left: 0;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/9dabb0dc-b01f-4c8b-9a06-cd9b6ce8d6f6)

After:
![image](https://github.com/user-attachments/assets/71736aa5-9982-4d3c-835e-d3ed41c26f15)

With large values in list width:
![image](https://github.com/user-attachments/assets/db9bead3-babc-4a6f-90a6-ef0ab027afee)

This looks nicer and more even when large widths are set on all lists, but retains current behaviour.