### PR TITLE
Opinion - Change archive-card shortcut to backtick for better ergonomics

### DIFF
--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -190,7 +190,7 @@ Mousetrap.bind('space', evt => {
   }
 });
 
-Mousetrap.bind('-', evt => {
+Mousetrap.bind('`', evt => {
   const cardId = getSelectedCardId();
   if (!cardId) {
     return;
@@ -285,7 +285,7 @@ Template.keyboardShortcuts.helpers({
       action: 'shortcut-assign-self',
     },
     {
-      keys: ['-'],
+      keys: ['`'],
       action: 'archive-card',
     },
     {


### PR DESCRIPTION
This was requested [here](https://github.com/wekan/wekan/pull/5576) by @mohammadZahedian.

This improves the ergonomics by allowing single left-handed handling of shortcuts.

IMO, this shortcut is a bit too close to the `ESC` button, which might cause misclicks.

@xet7 - What do you think?