### PR TITLE
Fix buggy behaviours in board dragscrolling

### DIFF
--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -195,6 +195,9 @@ BlazeComponent.extendComponent({
     });
 
     this.autorun(() => {
+      // Always reset dragscroll on view switch
+      dragscroll.reset();
+
       if (Utils.isTouchScreenOrShowDesktopDragHandles()) {
         $swimlanesDom.sortable({
           handle: '.js-swimlane-header-handle',

--- a/client/components/boards/boardHeader.js
+++ b/client/components/boards/boardHeader.js
@@ -1,5 +1,6 @@
 import { ReactiveCache } from '/imports/reactiveCache';
 import { TAPi18n } from '/imports/i18n';
+import dragscroll from '@wekanteam/dragscroll';
 
 /*
 const DOWNCLS = 'fa-sort-down';
@@ -78,6 +79,7 @@ BlazeComponent.extendComponent({
           ReactiveCache.getCurrentUser().toggleBoardStar(Session.get('currentBoard'));
         },
         'click .js-auto-width-board'() {
+          dragscroll.reset();
           ReactiveCache.getCurrentUser().toggleAutoWidth(Utils.getCurrentBoardId());
         },
         'click .js-open-board-menu': Popup.open('boardMenu'),

--- a/client/components/swimlanes/swimlanes.jade
+++ b/client/components/swimlanes/swimlanes.jade
@@ -24,7 +24,7 @@ template(name="swimlane")
             +cardDetails(currentCard)
 
 template(name="listsGroup")
-  .swimlane.list-group.js-lists
+  .swimlane.list-group.js-lists.dragscroll
     if isMiniScreen
       if currentList
         +list(currentList)


### PR DESCRIPTION
I have added dragscroll resets in functions that switch the view to allow for dragscrolling immediately after view switching (currently you have to refresh the page after switching the view mode)

I have also enabled dragscrolling in Lists mode (was previously only enabled in Swimlanes mode).

Fixes https://github.com/wekan/wekan/issues/5613.