### PR TITLE
Restore keyboard shortcuts, enable per-user toggle, fix `Ctrl + C` bug by checking the text selection range

### DIFF
--- a/client/components/boards/boardHeader.jade
+++ b/client/components/boards/boardHeader.jade
@@ -27,6 +27,10 @@ template(name="boardHeaderBar")
             title="{{#if isAutoWidth}}{{_ 'click-to-disable-auto-width'}}{{else}}{{_ 'click-to-enable-auto-width'}}{{/if}}")
             i.fa(class="fa-solid fa-{{#if isAutoWidth}}compress{{else}}expand{{/if}}")
 
+          a.board-header-btn.js-keyboard-shortcuts-toggle(
+            title="{{#if isKeyboardShortcuts}}{{_ 'click-to-disable-keyboard-shortcuts'}}{{else}}{{_ 'click-to-enable-keyboard-shortcuts'}}{{/if}}")
+            i.fa(class="fa-solid fa-{{#if isKeyboardShortcuts}}computer-mouse{{else}}keyboard{{/if}}")
+
           a.board-header-btn(
             class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}"
             title="{{_ currentBoard.permission}}")
@@ -73,6 +77,10 @@ template(name="boardHeaderBar")
           a.board-header-btn.js-auto-width-board(
             title="{{#if isAutoWidth}}{{_ 'click-to-disable-auto-width'}}{{else}}{{_ 'click-to-enable-auto-width'}}{{/if}}")
             i.fa(class="fa-solid fa-{{#if isAutoWidth}}compress{{else}}expand{{/if}}")
+
+          a.board-header-btn.js-keyboard-shortcuts-toggle(
+            title="{{#if isKeyboardShortcuts}}{{_ 'click-to-disable-keyboard-shortcuts'}}{{else}}{{_ 'click-to-enable-keyboard-shortcuts'}}{{/if}}")
+            i.fa(class="fa-solid fa-{{#if isKeyboardShortcuts}}computer-mouse{{else}}keyboard{{/if}}")
 
           a.board-header-btn(
             class="{{#if currentUser.isBoardAdmin}}js-change-visibility{{else}}is-disabled{{/if}}"

--- a/client/components/boards/boardHeader.js
+++ b/client/components/boards/boardHeader.js
@@ -45,6 +45,11 @@ BlazeComponent.extendComponent({
     return user && user.isAutoWidth(boardId);
   },
 
+  isKeyboardShortcuts() {
+    const user = ReactiveCache.getCurrentUser();
+    return user && user.isKeyboardShortcuts();
+  },
+
   // Only show the star counter if the number of star is greater than 2
   showStarCounter() {
     const currentBoard = Utils.getCurrentBoard();
@@ -81,6 +86,9 @@ BlazeComponent.extendComponent({
         'click .js-auto-width-board'() {
           dragscroll.reset();
           ReactiveCache.getCurrentUser().toggleAutoWidth(Utils.getCurrentBoardId());
+        },
+        'click .js-keyboard-shortcuts-toggle'() {
+          ReactiveCache.getCurrentUser().toggleKeyboardShortcuts();
         },
         'click .js-open-board-menu': Popup.open('boardMenu'),
         'click .js-change-visibility': Popup.open('boardChangeVisibility'),

--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -6,8 +6,8 @@ template(name="sidebar")
     //  i.fa.fa-navicon
     .sidebar-actions
       .sidebar-shortcuts
-        | &nbsp;
-        | &nbsp;
+        &nbsp;
+        &nbsp;
         //a.board-header-btn.js-shortcuts(title="{{_ 'keyboard-shortcuts' }}")
         //  i.fa.fa-keyboard-o
         //  span {{_ 'keyboard-shortcuts' }}

--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -5,12 +5,10 @@ template(name="sidebar")
     //  title="{{showTongueTitle}}")
     //  i.fa.fa-navicon
     .sidebar-actions
-      .sidebar-shortcuts
-        &nbsp;
-        &nbsp;
-        //a.board-header-btn.js-shortcuts(title="{{_ 'keyboard-shortcuts' }}")
-        //  i.fa.fa-keyboard-o
-        //  span {{_ 'keyboard-shortcuts' }}
+      //.sidebar-shortcuts
+      //  a.board-header-btn.js-shortcuts(title="{{_ 'keyboard-shortcuts' }}")
+      //    i.fa.fa-keyboard-o
+      //    span {{_ 'keyboard-shortcuts' }}
       a.sidebar-xmark.js-close-sidebar &#10005;
     .sidebar-content.js-board-sidebar-content
       //a.hide-btn.js-hide-sidebar

--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -5,10 +5,10 @@ template(name="sidebar")
     //  title="{{showTongueTitle}}")
     //  i.fa.fa-navicon
     .sidebar-actions
-      //.sidebar-shortcuts
-      //  a.board-header-btn.js-shortcuts(title="{{_ 'keyboard-shortcuts' }}")
-      //    i.fa.fa-keyboard-o
-      //    span {{_ 'keyboard-shortcuts' }}
+      .sidebar-shortcuts
+        a.board-header-btn.js-shortcuts(title="{{_ 'keyboard-shortcuts' }}")
+          i.fa.fa-keyboard-o
+          span {{_ 'keyboard-shortcuts' }}
       a.sidebar-xmark.js-close-sidebar &#10005;
     .sidebar-content.js-board-sidebar-content
       //a.hide-btn.js-hide-sidebar

--- a/client/components/sidebar/sidebar.js
+++ b/client/components/sidebar/sidebar.js
@@ -123,11 +123,9 @@ BlazeComponent.extendComponent({
             location.reload();
           }
         },
-/*
         'click .js-shortcuts'() {
           FlowRouter.go('shortcuts');
         },
-*/
         'click .js-close-sidebar'() {
           Sidebar.toggle()
         },

--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -1,6 +1,5 @@
 import { ReactiveCache } from '/imports/reactiveCache';
 
-/*
 // XXX There is no reason to define these shortcuts globally, they should be
 // attached to a template (most of them will go in the `board` template).
 
@@ -256,11 +255,8 @@ Mousetrap.bind('n', evt => {
     evt.preventDefault();
   }
 });
-*/
-
 
 Template.keyboardShortcuts.helpers({
-/*
   mapping: [
     {
       keys: ['w'],
@@ -323,5 +319,4 @@ Template.keyboardShortcuts.helpers({
       action: 'remove-labels-multiselect'
     },
   ],
-*/
 });

--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -14,6 +14,22 @@ window.addEventListener('keydown', (e) => {
   Mousetrap.trigger(String.fromCharCode(e.which).toLowerCase());
 });
 
+// Store the original stopCallback in a global
+const originalStopCallback = Mousetrap.stopCallback;
+
+// Overwrite the stopCallback to allow for more keyboard shortcut customizations
+Mousetrap.stopCallback = (e, element) => {
+  // Are shortcuts enabled for the user?
+  if (!ReactiveCache.getCurrentUser().isKeyboardShortcuts())
+    return true;
+
+  // Make sure there are no selected characters
+  if (window.getSelection().type === "Range")
+    return true;
+
+  return originalStopCallback(e, element);
+}
+
 function getHoveredCardId() {
   const card = $('.js-minicard:hover').get(0);
   if (!card) return null;

--- a/imports/i18n/data/en.i18n.json
+++ b/imports/i18n/data/en.i18n.json
@@ -90,6 +90,8 @@
   "set-list-width": "Set Widths",
   "set-list-width-value": "Set Min & Max Widths (pixels)",
   "list-width-error-message": "List widths must be integers greater than 100",
+  "click-to-enable-keyboard-shortcuts": "Click to enable keyboard shortcuts",
+  "click-to-disable-keyboard-shortcuts": "Click to disable keyboard shortcuts",
   "setSwimlaneHeightPopup-title": "Set Swimlane Height",
   "set-swimlane-height": "Set Swimlane Height",
   "set-swimlane-height-value": "Swimlane Height (pixels)",

--- a/models/users.js
+++ b/models/users.js
@@ -444,6 +444,13 @@ Users.attachSchema(
       defaultValue: {},
       blackbox: true,
     },
+    'profile.keyboardShortcuts': {
+      /**
+       * User-specified state of keyboard shortcut activation.
+       */
+      type: Boolean,
+      defaultValue: true,
+    },
     services: {
       /**
        * services field of the user
@@ -954,6 +961,11 @@ Users.helpers({
     return 'templates';
   },
 
+  isKeyboardShortcuts() {
+    const { keyboardShortcuts = false } = this.profile || {};
+    return keyboardShortcuts;
+  },
+
   remove() {
     User.remove({
       _id: this._id,
@@ -1015,6 +1027,14 @@ Users.mutations({
     return {
       $set: {
         'profile.autoWidthBoards': autoWidthBoards,
+      },
+    };
+  },
+  toggleKeyboardShortcuts() {
+    const { keyboardShortcuts = false } = this.profile || {};
+    return {
+      $set: {
+        'profile.keyboardShortcuts': !keyboardShortcuts,
       },
     };
   },


### PR DESCRIPTION
This PR reverts recent keyboard shortcut disabling commits:
https://github.com/wekan/wekan/commit/5606414f8975fa0f75642d2e3a6b48c7559186f9
https://github.com/wekan/wekan/commit/94391d4cde7aed6e37efc6a9127b23ef0c2bd323
https://github.com/wekan/wekan/commit/8b73c702c39a1fd546e591a096d703a53577ffec

It also introduces a new button in the board header, which allows toggling keyboard shortcuts, per user:
This is when shortcuts are disabled:
![image](https://github.com/user-attachments/assets/21feb336-cce1-4f25-aea7-c49255498387)

This is when shortcuts are enabled:
![image](https://github.com/user-attachments/assets/94f00105-1651-4949-9b90-704b4faa26f5)

This PR also fixes the `Ctrl + [char]` bugs by checking that there is no selected text before triggering the keyboard shortcut.
This is done using the `stopCallback` of the `mousetrap` library.