### PR TITLE
Enable keyboard shortcuts by default

### DIFF
--- a/models/users.js
+++ b/models/users.js
@@ -962,7 +962,7 @@ Users.helpers({
   },
 
   isKeyboardShortcuts() {
-    const { keyboardShortcuts = false } = this.profile || {};
+    const { keyboardShortcuts = true } = this.profile || {};
     return keyboardShortcuts;
   },
 
@@ -1031,7 +1031,7 @@ Users.mutations({
     };
   },
   toggleKeyboardShortcuts() {
-    const { keyboardShortcuts = false } = this.profile || {};
+    const { keyboardShortcuts = true } = this.profile || {};
     return {
       $set: {
         'profile.keyboardShortcuts': !keyboardShortcuts,


### PR DESCRIPTION
I got complaints about keyboard shortcuts suddenly being disabled (by default).

This PR only makes the default state "enabled" as it was before keyboard shortcuts were optional.