### PR TITLE
Fix list header too wide in cleanlight and cleandark themes

### DIFF
--- a/client/components/boards/boardColors.css
+++ b/client/components/boards/boardColors.css
@@ -3268,6 +3268,11 @@ THEME - Clean Light
   background: none;
 }
 
+.board-color-cleanlight .list .list-header div:has(.list-header-name),
+.board-color-cleandark .list .list-header div:has(.list-header-name) {
+  display: contents;
+}
+
 .board-color-cleanlight .list .list-header-name {
   color: rgba(10, 10, 20, 1);
 }


### PR DESCRIPTION
Before fix:
![image](https://github.com/user-attachments/assets/c72d4fc5-5743-457b-a85e-69338797b531)

After fix:
![image](https://github.com/user-attachments/assets/6d65fd4f-de92-4be4-bf55-bc10fe7e6042)
