### PR TITLE
Feature - Assign members using keyboard shortcut `Ctrl+Alt+[1-9]`

### DIFF
--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -188,23 +188,23 @@ Mousetrap.bind(_.range(1, 10).map(x => `ctrl+alt+${x}`), (evt, key) => {
   if (!ReactiveCache.getCurrentUser().isBoardMember())
     return;
 
-  const pressedNumber = parseInt(key.split("+").pop()) - 1;
+  const memberIndex = parseInt(key.split("+").pop()) - 1;
   const currentBoard = Utils.getCurrentBoard();
   const boardMembers = currentBoard.memberUsers();
 
-  if (pressedNumber > boardMembers.length)
+  if (memberIndex >= boardMembers.length)
     return;
 
   if (MultiSelection.isActive()) {
     for (const cardId of MultiSelection.getSelectedCardIds())
-      ReactiveCache.getCard(cardId).toggleAssignee(boardMembers[pressedNumber]._id);
+      ReactiveCache.getCard(cardId).toggleAssignee(boardMembers[memberIndex]._id);
   } else {
     const cardId = getSelectedCardId();
 
     if (!cardId)
       return;
 
-    ReactiveCache.getCard(cardId).toggleAssignee(boardMembers[pressedNumber]._id);
+    ReactiveCache.getCard(cardId).toggleAssignee(boardMembers[memberIndex]._id);
   }
 });
 

--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -179,6 +179,35 @@ Mousetrap.bind(numArray, (evt, key) => {
   }
 });
 
+Mousetrap.bind(_.range(1, 10).map(x => `ctrl+alt+${x}`), (evt, key) => {
+  // Make sure the current user is defined
+  if (!ReactiveCache.getCurrentUser())
+    return;
+
+  // Make sure the current user is a board member
+  if (!ReactiveCache.getCurrentUser().isBoardMember())
+    return;
+
+  const pressedNumber = parseInt(key.split("+").pop()) - 1;
+  const currentBoard = Utils.getCurrentBoard();
+  const boardMembers = currentBoard.memberUsers();
+
+  if (pressedNumber > boardMembers.length)
+    return;
+
+  if (MultiSelection.isActive()) {
+    for (const cardId of MultiSelection.getSelectedCardIds())
+      ReactiveCache.getCard(cardId).toggleAssignee(boardMembers[pressedNumber]._id);
+  } else {
+    const cardId = getSelectedCardId();
+
+    if (!cardId)
+      return;
+
+    ReactiveCache.getCard(cardId).toggleAssignee(boardMembers[pressedNumber]._id);
+  }
+});
+
 Mousetrap.bind('m', evt => {
   const cardId = getSelectedCardId();
   if (!cardId) {
@@ -332,6 +361,10 @@ Template.keyboardShortcuts.helpers({
     {
       keys: ['shift + number keys 1-9'],
       action: 'remove-labels-multiselect'
+    },
+    {
+      keys: ['ctrl + shift + number keys 1-9'],
+      action: 'toggle-asignees'
     },
   ],
 });

--- a/client/lib/keyboard.js
+++ b/client/lib/keyboard.js
@@ -363,7 +363,7 @@ Template.keyboardShortcuts.helpers({
       action: 'remove-labels-multiselect'
     },
     {
-      keys: ['ctrl + shift + number keys 1-9'],
+      keys: ['ctrl + alt + number keys 1-9'],
       action: 'toggle-asignees'
     },
   ],

--- a/imports/i18n/data/en.i18n.json
+++ b/imports/i18n/data/en.i18n.json
@@ -610,6 +610,7 @@
   "has-spenttime-cards": "Has spent time cards",
   "time": "Time",
   "title": "Title",
+  "toggle-assignees": "Toggle assignees 1-9 for card (By order of addition to board).",
   "toggle-labels": "Toggle labels 1-9 for card. Multi-Selection adds labels 1-9",
   "remove-labels-multiselect": "Multi-Selection removes labels 1-9",
   "tracking": "Tracking",


### PR DESCRIPTION
This feature was requested by a colleague of mine.

The feature assigns members to cards by board joining order, using `Ctrl+Alt+[1-9]`.