### PR TITLE
Adding Development information to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ that by providing one-click installation on various platforms.
 We also welcome sponsors for features and bugfixes.
 By working directly with WeKan ® you get the benefit of active maintenance and new features added by growing WeKan ® developer community.
 
+## Getting Started with Development
+
+The default branch uses [Meteor 2 with Node.js 14](https://wekan.github.io/install/). Migration to Meteor 3 is currently [in progress](https://github.com/wekan/wekan/wiki/Emoji#meteor-3).
+
+To contribute, [create a fork](https://github.com/wekan/wekan/wiki/Emoji#2-create-fork-of-httpsgithubcomwekanwekan-at-github-web-page) and run `./rebuild-wekan.sh` (or `./rebuild-wekan.bat` on Windows) as detailed [here](https://github.com/wekan/wekan/wiki/Emoji#3-select-option-1-to-install-dependencies-and-then-enter). Once you're ready, please test your code and [submit a pull request (PR)](https://github.com/wekan/wekan/wiki/Emoji#7-test).
+
 ## Screenshot
 
 [More screenshots at Features page](https://github.com/wekan/wekan/wiki/Features)


### PR DESCRIPTION
I added a short paragraph to the Readme on how to get started with contributing code. I found it difficult by just looking on the package.json what to do in order to build and run tests. 

The new section should help new contributors find easier access to that project.