### PR TITLE
fix in imports\i18n\index.js

### DIFF
--- a/imports/i18n/index.js
+++ b/imports/i18n/index.js
@@ -2,13 +2,16 @@ import { TAPi18n } from './tap';
 import './accounts';
 import './moment';
 
-if (Meteor.isClient) {
-  import './blaze';
-}
-
 export { TAPi18n };
 
-(async () => {
-  await TAPi18n.init();
-})();
+if (Meteor.isClient) {
+  (async () => {
+    await import('./blaze');
+    await TAPi18n.init();
+  })();
+} else {
+  (async () => {
+    await TAPi18n.init();
+  })();
+}
 


### PR DESCRIPTION
The previous version immediately executed an async function at the top level, which could lead to runtime errors if dependencies like blaze or other Meteor packages were not fully loaded yet.

I moved the TAPi18n.init() call inside a Meteor.startup block to ensure it only runs after the client/server is fully ready.

Reason for change: Prevent errors like TAPi18n.init is not a function or race conditions during early loading.