### PR TITLE
Fix contrast issue checkbox

### DIFF
--- a/client/components/boards/boardColors.css
+++ b/client/components/boards/boardColors.css
@@ -2544,8 +2544,8 @@ THEME - Exodark
   background: #1b1b1b;
 }
 .board-color-exodark .materialCheckBox.is-checked {
-  border-bottom: 2px solid #222;
-  border-right: 2px solid #222;
+  border-bottom: 2px solid #dbdbdb!important;/*Fix contrast of checkbox*/
+  border-right: 2px solid #dbdbdb!important;
 }
 .board-color-exodark .is-multiselection-active .multi-selection-checkbox.is-checked + .minicard {
   background: #e9e9e9;


### PR DESCRIPTION
- Fixed contrasting issue with tick check on custom fields, also fixed the green tick coming up on the checklists in cards by utilisation of the !important tag to override it with the checkbox colour for custom fields also.

See Issue #5674 
![ContrastfixExo-1](https://github.com/user-attachments/assets/e000d5b7-fd7e-4bea-92a9-ae77b993f11c)
![Exodarkfix2](https://github.com/user-attachments/assets/d986cf30-b172-4994-873b-1c95b69641f3)
