### PR TITLE
Fix #5732 list insert position

### DIFF
--- a/client/components/swimlanes/swimlanes.js
+++ b/client/components/swimlanes/swimlanes.js
@@ -250,17 +250,18 @@ BlazeComponent.extendComponent({
     return [
       {
         submit(evt) {
-          evt.preventDefault();
-          const titleInput = this.find('.list-name-input');
-          const title = titleInput.value.trim();
-          const positionInput = this.find('.list-position-input');
+        evt.preventDefault();
+        const titleInput = this.find('.list-name-input');
+        const title = titleInput?.value.trim();
+        const positionInput = this.find('.list-position-input');
 
-          let sortIndex = 0;
+        let sortIndex = 0;
 
-          if (title) {
-            const currentBoardId = Utils.getCurrentBoardId();
+        if (title) {
+          const currentBoardId = Utils.getCurrentBoardId();
+
+          if (positionInput) {
             const position = positionInput.value.trim();
-
             const prevList = Lists.findOne({ _id: position, boardId: currentBoardId, archived: false });
             const nextList = Lists.findOne({
               boardId: currentBoardId,
@@ -274,21 +275,26 @@ BlazeComponent.extendComponent({
               const lastList = Lists.findOne({ boardId: currentBoardId }, { sort: { sort: -1 } });
               sortIndex = lastList ? lastList.sort + 1 : 0;
             }
-
-            Lists.insert({
-              title,
-              boardId: currentBoardId,
-              sort: sortIndex,
-              type: this.isListTemplatesSwimlane ? 'template-list' : 'list',
-              swimlaneId: this.currentBoard.isTemplatesBoard()
-                ? this.currentSwimlane._id
-                : '',
-            });
-
-            titleInput.value = '';
-            titleInput.focus();
+          } else {
+            const lastList = Lists.findOne({ boardId: currentBoardId }, { sort: { sort: -1 } });
+            sortIndex = lastList ? lastList.sort + 1 : 0;
           }
+
+          Lists.insert({
+            title,
+            boardId: currentBoardId,
+            sort: sortIndex,
+            type: this.isListTemplatesSwimlane ? 'template-list' : 'list',
+            swimlaneId: this.currentBoard.isTemplatesBoard()
+              ? this.currentSwimlane._id
+              : '',
+          });
+
+          titleInput.value = '';
+          titleInput.focus();
         }
+        }
+
         ,
         'click .js-list-template': Popup.open('searchElement'),
       },


### PR DESCRIPTION
This PR replaces and improves on #5765  and still addresses #5732 

It fixes two issues:

-Previously, lists added using "Add After" were inserted at the end instead of right after the selected list.
-A runtime error occurred when the .list-position-input

 I have tested this manually:

-Adding a list "after" another works and respects list order
-The browser console shows no JavaScript errors
<img width="984" alt="test1" src="https://github.com/user-attachments/assets/14995a1a-3183-401b-b668-f21b634b951b" />
<img width="1124" alt="yes" src="https://github.com/user-attachments/assets/160e924e-fe36-4bdc-9890-39c422d71dd7" />
