### PR TITLE
Fix: Add vendor prefixes for user-select and text-size-adjust for better browser compatibility

### DIFF
--- a/client/components/forms/forms.css
+++ b/client/components/forms/forms.css
@@ -98,6 +98,7 @@ textarea:disabled {
   border-color: #bfbfbf;
   color: #8c8c8c;
   -webkit-touch-callout: none;
+   -webkit-user-select: none;
   user-select: none;
 }
 select {
@@ -322,6 +323,7 @@ textarea::-moz-placeholder {
   background: linear-gradient(#fff, #f5f5f5);
   border-radius: 3px;
   box-sizing: border-box;
+   -webkit-user-select: none;
   user-select: none;
   border: 1px solid #e3e3e3;
   border-bottom-color: #c2c2c2;
@@ -505,6 +507,7 @@ button.loud-text-button:hover {
 .emphasis-button,
 .quiet-button {
   border-radius: 3px;
+   -webkit-user-select: none;
   user-select: none;
   color: #8c8c8c;
   display: block;

--- a/client/components/main/layouts.css
+++ b/client/components/main/layouts.css
@@ -59,8 +59,12 @@ button {
 html {
   font-size: 100%;
   max-height: 100%;
+  -webkit-user-select: none;
   user-select: none;
+
   -webkit-text-size-adjust: 100%;
+text-size-adjust: 100%;
+
 }
 body {
   background: #dedede;
@@ -188,7 +192,10 @@ strong {
   font-weight: bold;
 }
 p {
+  -webkit-user-select: none;
   user-select: text;
+ 
+
 }
 p a {
   text-decoration: underline;


### PR DESCRIPTION
this fix updates the CSS to improve cross-browser compatibility by:

Adding -webkit-user-select before user-select to support Safari and iOS browsers.
Adding both -webkit-text-size-adjust and text-size-adjust to ensure consistent text sizing across browsers.
Ordering vendor-prefixed properties before standard properties as per best practices.