### PR TITLE
Bugfix/due date parsing1

### DIFF
--- a/client/components/cards/cardDate.js
+++ b/client/components/cards/cardDate.js
@@ -3,6 +3,13 @@ import moment from 'moment/min/moment-with-locales';
 import { TAPi18n } from '/imports/i18n';
 import { DatePicker } from '/client/lib/datepicker';
 
+// Add this helper function at the top level
+const formatDate = (date, format) => {
+  if (!date) return '';
+  const normalizedDate = Utils.normalizeDigits(moment(date).format(format));
+  return normalizedDate;
+};
+
 // editCardReceivedDatePopup
 (class extends DatePicker {
   onCreated() {
@@ -166,6 +173,10 @@ class CardReceivedDate extends CardDate {
       'click .js-edit-date': Popup.open('editCardReceivedDate'),
     });
   }
+
+  showDate() {
+    return formatDate(this.date.get(), 'L');
+  }
 }
 CardReceivedDate.register('cardReceivedDate');
 
@@ -200,6 +211,10 @@ class CardStartDate extends CardDate {
     return super.events().concat({
       'click .js-edit-date': Popup.open('editCardStartDate'),
     });
+  }
+
+  showDate() {
+    return formatDate(this.date.get(), 'L');
   }
 }
 CardStartDate.register('cardStartDate');
@@ -237,6 +252,10 @@ class CardDueDate extends CardDate {
       'click .js-edit-date': Popup.open('editCardDueDate'),
     });
   }
+
+  showDate() {
+    return formatDate(this.date.get(), 'L');
+  }
 }
 CardDueDate.register('cardDueDate');
 
@@ -267,6 +286,10 @@ class CardEndDate extends CardDate {
     return super.events().concat({
       'click .js-edit-date': Popup.open('editCardEndDate'),
     });
+  }
+
+  showDate() {
+    return formatDate(this.date.get(), 'L');
   }
 }
 CardEndDate.register('cardEndDate');
@@ -317,31 +340,31 @@ CardCustomFieldDate.register('cardCustomFieldDate');
 
 (class extends CardReceivedDate {
   showDate() {
-    return this.date.get().format('L');
+    return formatDate(this.date.get(), 'L');
   }
 }.register('minicardReceivedDate'));
 
 (class extends CardStartDate {
   showDate() {
-    return this.date.get().format('YYYY-MM-DD HH:mm');
+    return formatDate(this.date.get(), 'YYYY-MM-DD HH:mm');
   }
 }.register('minicardStartDate'));
 
 (class extends CardDueDate {
   showDate() {
-    return this.date.get().format('YYYY-MM-DD HH:mm');
+    return formatDate(this.date.get(), 'YYYY-MM-DD HH:mm');
   }
 }.register('minicardDueDate'));
 
 (class extends CardEndDate {
   showDate() {
-    return this.date.get().format('YYYY-MM-DD HH:mm');
+    return formatDate(this.date.get(), 'YYYY-MM-DD HH:mm');
   }
 }.register('minicardEndDate'));
 
 (class extends CardCustomFieldDate {
   showDate() {
-    return this.date.get().format('L');
+    return formatDate(this.date.get(), 'L');
   }
 }.register('minicardCustomFieldDate'));
 
@@ -358,7 +381,7 @@ class VoteEndDate extends CardDate {
     return classes;
   }
   showDate() {
-    return this.date.get().format('L LT');
+    return formatDate(this.date.get(), 'L LT');
   }
   showTitle() {
     return `${TAPi18n.__('card-end-on')} ${this.date.get().format('LLLL')}`;
@@ -385,7 +408,7 @@ class PokerEndDate extends CardDate {
     return classes;
   }
   showDate() {
-    return this.date.get().format('l LT');
+    return formatDate(this.date.get(), 'L LT');
   }
   showTitle() {
     return `${TAPi18n.__('card-end-on')} ${this.date.get().format('LLLL')}`;

--- a/client/lib/datepicker.js
+++ b/client/lib/datepicker.js
@@ -1,15 +1,12 @@
 import { ReactiveCache } from '/imports/reactiveCache';
 import { TAPi18n } from '/imports/i18n';
 import moment from 'moment/min/moment-with-locales';
+import { Utils } from './utils';
 
-// Helper function to replace HH with H for 24 hours format, because H allows also single-digit hours
+// Helper function to replace HH with H for 24 hours format
 function adjustedTimeFormat() {
-  return moment
-    .localeData()
-    .longDateFormat('LT');
+  return moment.localeData().longDateFormat('LT');
 }
-
-//   .replace(/HH/i, 'H');
 
 export class DatePicker extends BlazeComponent {
   template() {
@@ -40,26 +37,32 @@ export class DatePicker extends BlazeComponent {
         language: TAPi18n.getLanguage(),
         weekStart: this.startDayOfWeek(),
         calendarWeeks: true,
+        beforeParse: (value) => Utils.normalizeDigits(value),
       })
       .on(
         'changeDate',
         function(evt) {
-          this.find('#date').value = moment(evt.date).format('L');
+          const normalizedDate = moment(evt.date).format('L');
+          this.find('#date').value = normalizedDate;
           this.error.set('');
-          const timeInput = this.find('#time');
-          timeInput.focus();
-          if (!timeInput.value && this.defaultTime) {
-            const currentHour = evt.date.getHours();
-            const defaultMoment = moment(
-              currentHour > 0 ? evt.date : this.defaultTime,
-            ); // default to 8:00 am local time
-            timeInput.value = defaultMoment.format('LT');
-          }
+          this._handleTimeInput(evt);
         }.bind(this),
       );
 
     if (this.date.get().isValid()) {
       $picker.datepicker('update', this.date.get().toDate());
+    }
+  }
+
+  _handleTimeInput(evt) {
+    const timeInput = this.find('#time');
+    timeInput.focus();
+    if (!timeInput.value && this.defaultTime) {
+      const currentHour = evt.date.getHours();
+      const defaultMoment = moment(
+        currentHour > 0 ? evt.date : this.defaultTime,
+      );
+      timeInput.value = defaultMoment.format('LT');
     }
   }
 
@@ -79,67 +82,68 @@ export class DatePicker extends BlazeComponent {
   }
 
   events() {
-    return [
-      {
-        'keyup .js-date-field'() {
-          // parse for localized date format in strict mode
-         const normalizedValue = Utils.normalizeDigits(this.find('#date').value);
-          const dateMoment = moment(normalizedValue, 'L', true);
-          if (dateMoment.isValid()) {
-            this.error.set('');
-            this.$('.js-datepicker').datepicker('update', dateMoment.toDate());
-          }
-        },
-        'keyup .js-time-field'() {
-          // parse for localized time format in strict mode
-          const normalizedValue = Utils.normalizeDigits(this.find('#time').value);
-          const dateMoment = moment(
-           normalizedValue,
-           adjustedTimeFormat(),
-            true,
-          );
-          if (dateMoment.isValid()) {
-            this.error.set('');
-          }
-        },
-        'submit .edit-date'(evt) {
-          evt.preventDefault();
+    return [{
+      'keyup .js-date-field'() {
+        const rawValue = this.find('#date').value;
+        const normalizedValue = Utils.normalizeDigits(rawValue);
+        const dateMoment = moment(normalizedValue, 'L', true);
 
-          // if no time was given, init with 12:00
-          const timeValue = Utils.normalizeDigits(evt.target.time.value);
-          const time =
-           timeValue ||
-           moment(new Date().setHours(12, 0, 0)).format('LT');
-          const newTime = moment(time, adjustedTimeFormat(), true);
-          const dateValue = Utils.normalizeDigits(evt.target.date.value);
-          const newDate = moment(dateValue, 'L', true);
-          const dateString = `${dateValue} ${time}`;
-          const newCompleteDate = moment(
-            dateString,
-            `L ${adjustedTimeFormat()}`,
-            true,
-          );
-          if (!newTime.isValid()) {
-            this.error.set('invalid-time');
-            evt.target.time.focus();
-          }
-          if (!newDate.isValid()) {
-            this.error.set('invalid-date');
-            evt.target.date.focus();
-          }
-          if (newCompleteDate.isValid()) {
-            this._storeDate(newCompleteDate.toDate());
-            Popup.back();
-          } else if (!this.error) {
-            this.error.set('invalid');
-          }
-        },
-        'click .js-delete-date'(evt) {
-          evt.preventDefault();
-          this._deleteDate();
-          Popup.back();
-        },
+        if (dateMoment.isValid()) {
+          this.error.set('');
+          this.$('.js-datepicker').datepicker('update', dateMoment.toDate());
+        }
       },
-    ];
+
+      'keyup .js-time-field'() {
+        const rawValue = this.find('#time').value;
+        const normalizedValue = Utils.normalizeDigits(rawValue);
+        const timeMoment = moment(normalizedValue, adjustedTimeFormat(), true);
+
+        if (timeMoment.isValid()) {
+          this.error.set('');
+        }
+      },
+
+      'submit .edit-date'(evt) {
+        evt.preventDefault();
+
+        const dateValue = Utils.normalizeDigits(evt.target.date.value);
+        const timeValue = Utils.normalizeDigits(evt.target.time.value) ||
+                         moment(new Date().setHours(12, 0, 0)).format('LT');
+
+        const dateString = `${dateValue} ${timeValue}`;
+        const format = `L ${adjustedTimeFormat()}`;
+        const newDate = moment(dateString, format, true);
+
+        if (!newDate.isValid()) {
+          this._handleDateTimeError(evt, dateValue, timeValue);
+          return;
+        }
+
+        this._storeDate(newDate.toDate());
+        Popup.back();
+      },
+
+      'click .js-delete-date'(evt) {
+        evt.preventDefault();
+        this._deleteDate();
+        Popup.back();
+      }
+    }];
+  }
+
+  _handleDateTimeError(evt, dateValue, timeValue) {
+    const dateMoment = moment(dateValue, 'L', true);
+    const timeMoment = moment(timeValue, adjustedTimeFormat(), true);
+
+    if (!timeMoment.isValid()) {
+      this.error.set('invalid-time');
+      evt.target.time.focus();
+    } else if (!dateMoment.isValid()) {
+      this.error.set('invalid-date');
+      evt.target.date.focus();
+    } else {
+      this.error.set('invalid');
+    }
   }
 }

--- a/client/lib/utils.js
+++ b/client/lib/utils.js
@@ -1,7 +1,17 @@
 import { ReactiveCache } from '/imports/reactiveCache';
+import { Session } from 'meteor/session';
+import { FlowRouter } from 'meteor/kadira:flow-router';
+import { Tracker } from 'meteor/tracker';
+import { $ } from 'meteor/jquery';
+import { Meteor } from 'meteor/meteor';
 
-// Create Utils as a global object and export it
-export const Utils = {
+// Initialize global Utils first
+if (typeof window.Utils === 'undefined') {
+  window.Utils = {};
+}
+
+// Create Utils object
+const Utils = {
   setBackgroundImage(url) {
     const currentBoard = Utils.getCurrentBoard();
     if (currentBoard.backgroundImageURL !== undefined) {
@@ -16,12 +26,19 @@ export const Utils = {
   // This helps with date parsing in non-English languages
   normalizeDigits(str) {
     if (!str) return str;
-    const persian = [/۰/g, /۱/g, /۲/g, /۳/g, /۴/g, /۵/g, /۶/g, /۷/g, /۸/g, /۹/g];
-    const arabic  = [/٠/g, /١/g, /٢/g, /٣/g, /٤/g, /٥/g, /٦/g, /٧/g, /٨/g, /٩/g];
-    for (let i = 0; i < 10; i++) {
-      str = str.replace(persian[i], i).replace(arabic[i], i);
-    }
-    return str;
+    // Convert Persian and Arabic numbers to English
+    const persianNumbers = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
+    const arabicNumbers  = ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'];
+
+    return str.split('')
+      .map(c => {
+        const pIndex = persianNumbers.indexOf(c);
+        const aIndex = arabicNumbers.indexOf(c);
+        if (pIndex >= 0) return pIndex.toString();
+        if (aIndex >= 0) return aIndex.toString();
+        return c;
+      })
+      .join('');
   },
   /** returns the current board id
    * <li> returns the current board id or the board id of the popup card if set
@@ -592,8 +609,11 @@ export const Utils = {
   },
 };
 
-// Make Utils available globally for legacy code
-window.Utils = Utils;
+// Update global Utils with all methods
+Object.assign(window.Utils, Utils);
+
+// Export for ES modules
+export { Utils };
 
 // A simple tracker dependency that we invalidate every time the window is
 // resized. This is used to reactively re-calculate the popup position in case

--- a/client/lib/utils.js
+++ b/client/lib/utils.js
@@ -1,6 +1,7 @@
 import { ReactiveCache } from '/imports/reactiveCache';
 
-Utils = {
+// Create Utils as a global object and export it
+export const Utils = {
   setBackgroundImage(url) {
     const currentBoard = Utils.getCurrentBoard();
     if (currentBoard.backgroundImageURL !== undefined) {
@@ -590,6 +591,9 @@ Utils = {
     }
   },
 };
+
+// Make Utils available globally for legacy code
+window.Utils = Utils;
 
 // A simple tracker dependency that we invalidate every time the window is
 // resized. This is used to reactively re-calculate the popup position in case


### PR DESCRIPTION
title: Fix Due Date Problem in Non-English Numbers https://github.com/wekan/wekan/issues/5752

In utils.js:
Added a normalizeDigits() utility function that converts Persian (۰-۹) and Arabic (٠-٩) numbers to Western Arabic numerals (0-9)
This is the core function that handles number normalization across the application
In datepicker.js:
Integrated the number normalization with the date picker component
Modified date parsing to handle normalized numbers before processing
Added support for converting numbers during date selection and display
In cardDate.js:
Updated the date formatting to use normalized numbers
Added number conversion when displaying dates in cards
Ensured proper date handling for Persian/Arabic locales
The solution works by:

Converting non-Western numbers to Western numbers before any date operations
Maintaining the original display format while handling dates internally in a consistent format
Ensuring dates work correctly regardless of the user's language settings.