### PR TITLE
Allow selection of card text via webkit/user-select attributes

### DIFF
--- a/client/components/main/layouts.css
+++ b/client/components/main/layouts.css
@@ -59,8 +59,8 @@ button {
 html {
   font-size: 100%;
   max-height: 100%;
-  -webkit-user-select: none;
-  user-select: none;
+  -webkit-user-select: text;
+  user-select: text;
 
   -webkit-text-size-adjust: 100%;
 text-size-adjust: 100%;
@@ -192,7 +192,7 @@ strong {
   font-weight: bold;
 }
 p {
-  -webkit-user-select: none;
+  -webkit-user-select: text;
   user-select: text;
  
 


### PR DESCRIPTION
Fixes open issue around webkit/user-select attributes. Modifies values to allow "text" values to be selected in cards and on the board.

Should fix changes around PR #5771 