### PR TITLE
CleanDark Theme Fixes

### DIFF
--- a/client/components/boards/boardColors.css
+++ b/client/components/boards/boardColors.css
@@ -2811,6 +2811,7 @@ THEME - Clean Dark
 
 .board-color-cleandark .card-details {
   background: #23232B;
+  scrollbar-color: #ffffff #2e2e39;
   border-radius: 20px;
   box-shadow: none;
 }

--- a/client/components/boards/boardColors.css
+++ b/client/components/boards/boardColors.css
@@ -3492,7 +3492,7 @@ THEME - Clean Light
 
 .board-color-cleandark .card-details-header {
   background: #2E2E39 !important;
-  color: rgba(255, 255, 255, 1);
+  color:#FFF !important;
 }
 
 .board-color-cleanlight .card-details-header .card-details-title,

--- a/client/components/boards/boardColors.css
+++ b/client/components/boards/boardColors.css
@@ -3492,7 +3492,7 @@ THEME - Clean Light
 
 .board-color-cleandark .card-details-header {
   background: #2E2E39 !important;
-  color:#FFF !important;
+  color: #FFF !important;
 }
 
 .board-color-cleanlight .card-details-header .card-details-title,


### PR DESCRIPTION
- Fixes scrollbars not being visible properly on cleandark cards. 
- Fixes black card titles which is low contrast and an accessibility issue. Have made scrollbar white with same colour background as the card header, and card title white to contrast the theme colour. 