### PR TITLE
Fix copy to clipboard feature for code

### DIFF
--- a/client/components/main/editor.css
+++ b/client/components/main/editor.css
@@ -17,3 +17,23 @@
   top: 20px;
   right: 6px;
 }
+/* Copy Button Notification */
+.copy-toast {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 200px 400px;
+  border-radius: 20px;
+  font-size: 5.5rem;
+  font-weight: bold;
+  z-index: 9999;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+.copy-toast.visible {
+  opacity: 1;
+}

--- a/client/components/main/editor.js
+++ b/client/components/main/editor.js
@@ -145,48 +145,7 @@ BlazeComponent.extendComponent({
     });
 
     // End: Copy <pre> code
-
-    const textareaSelector = 'textarea';
-    const mentions = [
-      // User mentions
-      {
-        match: /\B@([\w.-]*)$/,
-        search(term, callback) {
-          const currentBoard = Utils.getCurrentBoard();
-          callback(
-            _.union(
-            currentBoard
-              .activeMembers()
-              .map(member => {
-                const user = ReactiveCache.getUser(member.userId);
-                const username = user.username;
-                const fullName = user.profile && user.profile !== undefined && user.profile.fullname ? user.profile.fullname : "";
-                return username.includes(term) || fullName.includes(term) ? user : null;
-              })
-              .filter(Boolean), [...specialHandles])
-          );
-        },
-        template(user) {
-          if (user.profile && user.profile.fullname) {
-            return (user.profile.fullname + " (" + user.username + ")");
-          }
-          return user.username;
-        },
-        replace(user) {
-          if (user.profile && user.profile.fullname) {
-            return `@${user.username} (${user.profile.fullname}) `;
-          }
-          return `@${user.username} `;
-        },
-        index: 1,
-      },
-    ];
-
-    const enableTextarea = function() {
-      const $textarea = this.$(textareaSelector);
-      autosize($textarea);
-      $textarea.escapeableTextComplete(mentions);
-    };
+	
 /*
     if (Meteor.settings.public.RICHER_CARD_COMMENT_EDITOR === true || Meteor.settings.public.RICHER_CARD_COMMENT_EDITOR === 'true') {
       const isSmall = Utils.isMiniScreen();
@@ -409,7 +368,6 @@ BlazeComponent.extendComponent({
       enableTextarea();
     }
 */
-    enableTextarea();
   },
   events() {
     return [

--- a/client/components/main/editor.js
+++ b/client/components/main/editor.js
@@ -145,7 +145,48 @@ BlazeComponent.extendComponent({
     });
 
     // End: Copy <pre> code
-	
+
+    const textareaSelector = 'textarea';
+    const mentions = [
+      // User mentions
+      {
+        match: /\B@([\w.-]*)$/,
+        search(term, callback) {
+          const currentBoard = Utils.getCurrentBoard();
+          callback(
+            _.union(
+            currentBoard
+              .activeMembers()
+              .map(member => {
+                const user = ReactiveCache.getUser(member.userId);
+                const username = user.username;
+                const fullName = user.profile && user.profile !== undefined && user.profile.fullname ? user.profile.fullname : "";
+                return username.includes(term) || fullName.includes(term) ? user : null;
+              })
+              .filter(Boolean), [...specialHandles])
+          );
+        },
+        template(user) {
+          if (user.profile && user.profile.fullname) {
+            return (user.profile.fullname + " (" + user.username + ")");
+          }
+          return user.username;
+        },
+        replace(user) {
+          if (user.profile && user.profile.fullname) {
+            return `@${user.username} (${user.profile.fullname}) `;
+          }
+          return `@${user.username} `;
+        },
+        index: 1,
+      },
+    ];
+
+    const enableTextarea = function() {
+      const $textarea = this.$(textareaSelector);
+      autosize($textarea);
+      $textarea.escapeableTextComplete(mentions);
+    };
 /*
     if (Meteor.settings.public.RICHER_CARD_COMMENT_EDITOR === true || Meteor.settings.public.RICHER_CARD_COMMENT_EDITOR === 'true') {
       const isSmall = Utils.isMiniScreen();
@@ -368,6 +409,7 @@ BlazeComponent.extendComponent({
       enableTextarea();
     }
 */
+    enableTextarea();
   },
   events() {
     return [

--- a/imports/i18n/data/en.i18n.json
+++ b/imports/i18n/data/en.i18n.json
@@ -1270,5 +1270,7 @@
   "supportPopup-title": "Support",
   "accessibility-page-enabled": "Accessibility page enabled",
   "accessibility-title": "Accessibility topic",
-  "accessibility-content": "Accessibility content"
+  "accessibility-content": "Accessibility content",
+  "copy-text-to-clipboard": "Copy text to clipboard",
+  "copied": "Copied"
 }


### PR DESCRIPTION
- Fix copy to clipboard feature showing multiple buttons #5773 
- Added translations for i8n for "Copy text to clipboard" mouse hover and "Copied" text for new toast notification
- Added large toast notification shown after clicking copy (for better visibility), can be styled from editor.css

Checks
- Added check to update buttons and add/remove on card click if text updated/code moved etc. 
- Tested these edits on my dev server extensively for issues. 

Known bugs - Not integral but may cause some unwanted behaviour. 
- Copy button will not show on minicard descriptions containing code on initial board load. However as soon as a card is opened the buttons are present. I'm not quite sure where to call the addcopybutton function from to enable it to load on board load?
- Error in console regarding textareaSelector is not defined with regards to calling Tracker afterFlush function. Was thinking it was something to do with it not waiting until DOM load, but still need to play around with it a bit more. 