### PR TITLE
Add a REST API endpoint to retrieve a card by ID

### DIFF
--- a/models/cards.js
+++ b/models/cards.js
@@ -3302,6 +3302,27 @@ if (Meteor.isServer) {
   });
 
   /**
+   * @operation get_card_by_id
+   * @summary Get a Card by Card ID
+   *
+   * @param {string} cardId the card ID
+   * @return_type Cards
+   */
+  JsonRoutes.add(
+    'GET',
+    '/api/cards/:cardId',
+    function(req, res) {
+      const paramCardId = req.params.cardId;
+      card = ReactiveCache.getCard(paramCardId)
+      Authentication.checkBoardAccess(req.userId, card.boardId);
+      JsonRoutes.sendResult(res, {
+        code: 200,
+        data: ReactiveCache.getCard(paramCardId),
+      });
+    },
+  );
+
+  /**
    * @operation get_card
    * @summary Get a Card
    *

--- a/public/api/wekan.yml
+++ b/public/api/wekan.yml
@@ -2612,6 +2612,29 @@ paths:
                 type: integer
               public:
                 type: integer
+  /api/cards/{card}:
+    get:
+      operationId: get_card_by_id
+      summary: Get a Card by Card ID
+      tags:
+        - Cards
+      parameters:
+        - name: card
+          in: path
+          description: |
+            the card ID
+          type: string
+          required: true
+      produces:
+        - application/json
+      security:
+          - UserSecurity: []
+      responses:
+        '200':
+          description: |-
+            200 response
+          schema:
+            $ref: "#/definitions/Cards"
   /api/users/{user}/boards:
     get:
       operationId: get_boards_from_user


### PR DESCRIPTION
This pull request adds a REST API endpoint to retrieve a card by the card ID only, without list ID and board ID.

This endpoint is neccesary to get the details of a card's parent card, because currently there is no way to get the parent card's list ID and board ID.

See https://wekan.fi/api/v7.92/#tocscards . There is a `parentId` property, but neither `parentListId` nor `parentBoardID` exists.