### PR TITLE
WIP: AI: Fix attachment download error with non-ASCII filenames (#6055)

### DIFF
--- a/server/routes/legacyAttachments.js
+++ b/server/routes/legacyAttachments.js
@@ -9,6 +9,49 @@ if (process.env.DEBUG === 'true') {
 }
 
 /**
+ * Helper function to properly encode a filename for the Content-Disposition header
+ * Removes invalid characters (control chars, newlines, etc.) that would break HTTP headers.
+ * For non-ASCII filenames, uses RFC 5987 encoding to preserve the original filename.
+ * This prevents ERR_INVALID_CHAR errors when filenames contain control characters.
+ */
+function sanitizeFilenameForHeader(filename) {
+  if (!filename || typeof filename !== 'string') {
+    return 'download';
+  }
+
+  // First, remove any control characters (0x00-0x1F, 0x7F) that would break HTTP headers
+  // This includes newlines, carriage returns, tabs, and other control chars
+  let sanitized = filename.replace(/[\x00-\x1F\x7F]/g, '');
+
+  // If the filename is all ASCII printable characters (0x20-0x7E), use it directly
+  if (/^[\x20-\x7E]*$/.test(sanitized)) {
+    // Escape any quotes and backslashes in the filename
+    sanitized = sanitized.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return sanitized;
+  }
+
+  // For non-ASCII filenames, provide a fallback and RFC 5987 encoded version
+  const fallback = sanitized.replace(/[^\x20-\x7E]/g, '_').slice(0, 100) || 'download';
+  const encoded = encodeURIComponent(sanitized);
+  
+  // Return special marker format that will be handled by buildContentDispositionHeader
+  // Format: "fallback|RFC5987:encoded"
+  return `${fallback}|RFC5987:${encoded}`;
+}
+
+/**
+ * Helper function to build a complete Content-Disposition header value with RFC 5987 support
+ * Handles the special format returned by sanitizeFilenameForHeader for non-ASCII filenames
+ */
+function buildContentDispositionHeader(disposition, sanitizedFilename) {
+  if (sanitizedFilename.includes('|RFC5987:')) {
+    const [fallback, encoded] = sanitizedFilename.split('|RFC5987:');
+    return `${disposition}; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+  }
+  return `${disposition}; filename="${sanitizedFilename}"`;
+}
+
+/**
  * Legacy attachment download route for CollectionFS compatibility
  * Handles downloads from old CollectionFS structure
  */
@@ -57,7 +100,7 @@ if (Meteor.isServer) {
       // Force attachment disposition for SVG files to prevent XSS attacks
       const isSvgFile = attachment.name && attachment.name.toLowerCase().endsWith('.svg');
       const disposition = isSvgFile ? 'attachment' : 'attachment'; // Always use attachment for legacy files
-      res.setHeader('Content-Disposition', `${disposition}; filename="${attachment.name}"`);
+      res.setHeader('Content-Disposition', buildContentDispositionHeader(disposition, sanitizeFilenameForHeader(attachment.name)));
 
       // Add security headers for SVG files
       if (isSvgFile) {


### PR DESCRIPTION
This pull request features a patch that might help in fixing #6055.

This patch is the result of [this GitHub Copilot conversation](https://hackmd.io/@brlin/S1PAiMbEbx) and is mostly AI-generated.  I unable to verify the patch at the moment so use it at your own risk.