### PR TITLE
Migrate from percolate:synced-cron to quave:synced-cron

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -69,7 +69,7 @@ meteorhacks:subs-manager
 meteorhacks:aggregate@1.3.0
 wekan-markdown
 konecty:mongo-counter
-percolate:synced-cron
+quave:synced-cron
 ostrio:cookies
 ostrio:files@2.3.0
 lmieulet:meteor-coverage

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -105,8 +105,8 @@ peerlibrary:blaze-components@0.23.0
 peerlibrary:computed-field@0.10.0
 peerlibrary:data-lookup@0.3.0
 peerlibrary:reactive-field@0.6.0
-percolate:synced-cron@1.5.2
 promise@0.12.2
+quave:synced-cron@2.2.1
 raix:eventemitter@0.1.3
 raix:handlebar-helpers@0.2.5
 random@1.2.1

--- a/models/users.js
+++ b/models/users.js
@@ -1,6 +1,6 @@
 import { ReactiveCache, ReactiveMiniMongoIndex } from '/imports/reactiveCache';
 import { Random } from 'meteor/random';
-import { SyncedCron } from 'meteor/percolate:synced-cron';
+import { SyncedCron } from 'meteor/quave:synced-cron';
 import { TAPi18n } from '/imports/i18n';
 import ImpersonatedUsers from './impersonatedUsers';
 // import { Index, MongoDBEngine } from 'meteor/easy:search'; // Temporarily disabled due to compatibility issues

--- a/packages/wekan-ldap/package.js
+++ b/packages/wekan-ldap/package.js
@@ -20,7 +20,7 @@ Package.onUse(function(api) {
 
 	api.use('accounts-base', 'server');
 	api.use('accounts-password', 'server');
-	api.use('percolate:synced-cron', 'server');
+	api.use('quave:synced-cron', 'server');
 	api.addFiles('client/loginHelper.js', 'client');
 
 	api.mainModule('server/index.js', 'server');

--- a/packages/wekan-ldap/server/sync.js
+++ b/packages/wekan-ldap/server/sync.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import SyncedCron from 'meteor/percolate:synced-cron';
+import { SyncedCron } from 'meteor/quave:synced-cron';
 import LDAP from './ldap';
 import { log_debug, log_info, log_warn, log_error } from './logger';
 
@@ -440,7 +440,7 @@ function sync() {
 const jobName = 'LDAP_Sync';
 
 const addCronJob = _.debounce(Meteor.bindEnvironment(function addCronJobDebounced() {
-  let sc=SyncedCron.SyncedCron; //Why ?? something must be wrong in the import
+  let sc = SyncedCron;
   if (LDAP.settings_get('LDAP_BACKGROUND_SYNC') !== true) {
     log_info('Disabling LDAP Background Sync');
     if (sc.nextScheduledAtDate(jobName)) {

--- a/server/00checkStartup.js
+++ b/server/00checkStartup.js
@@ -4,7 +4,7 @@ const os = require('os');
 // Configure SyncedCron to suppress console logging
 // This must be done before any SyncedCron operations
 if (Meteor.isServer) {
-  const { SyncedCron } = require('meteor/percolate:synced-cron');
+  const { SyncedCron } = require('meteor/quave:synced-cron');
   SyncedCron.config({
     log: false, // Disable console logging
     collectionName: 'cronJobs', // Use custom collection name


### PR DESCRIPTION
I'm focusing right now on shifting as many packages as we can to more 3.0 friendly ones. Once this phase is done I'll move onto the actual app code. 

This PR utilizes [quave:synced-cron](https://github.com/quavedev/meteor-packages/tree/main/synced-cron) which is a much more updated version.