### PR TITLE
Remove kadira:dochead

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -99,7 +99,6 @@
     "BlazeComponent": false,
     
     "CollectionHooks": false,
-    "DocHead": false,
     "ESSearchResults": false,
     "FastRender": false,
     "FlowRouter": false,

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -43,7 +43,6 @@ session@1.2.1
 tracker@1.3.3
 underscore@1.0.13
 audit-argument-checks@1.0.7
-kadira:dochead
 mquandalle:autofocus
 ongoworks:speakingurl
 raix:handlebar-helpers

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -50,7 +50,6 @@ id-map@1.1.1
 idmontie:migrations@1.0.3
 inter-process-messaging@0.1.1
 jquery@3.0.0
-kadira:dochead@1.5.0
 konecty:mongo-counter@0.0.5_3
 lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0

--- a/client/components/settings/settingBody.js
+++ b/client/components/settings/settingBody.js
@@ -595,7 +595,7 @@ BlazeComponent.extendComponent({
       this.setLoading(false);
     }
 
-    DocHead.setTitle(productName);
+    document.title = productName;
   },
 
   toggleSupportPage() {

--- a/client/lib/utils.js
+++ b/client/lib/utils.js
@@ -758,9 +758,9 @@ Utils = {
   setCustomUI(data) {
     const currentBoard = Utils.getCurrentBoard();
     if (currentBoard) {
-      DocHead.setTitle(`${currentBoard.title} - ${data.productName}`);
+      document.title = `${currentBoard.title} - ${data.productName}`;
     } else {
-      DocHead.setTitle(`${data.productName}`);
+      document.title = `${data.productName}`;
     }
   },
 

--- a/config/router.js
+++ b/config/router.js
@@ -296,7 +296,7 @@ FlowRouter.route('/global-search', {
 
     Utils.manageCustomUI();
     Utils.manageMatomo();
-    DocHead.setTitle(TAPi18n.__('globalSearch-title'));
+    document.title = TAPi18n.__('globalSearch-title');
 
     if (FlowRouter.getQueryParam('q')) {
       Session.set(

--- a/sandstorm.js
+++ b/sandstorm.js
@@ -479,7 +479,7 @@ if (isSandstorm && Meteor.isClient) {
   ]);
 
   Tracker.autorun(() => {
-    updateSandstormMetaData({ setTitle: DocHead.getTitle() });
+    updateSandstormMetaData({ setTitle: document.title });
   });
 
   // Runtime redirection from the home page to the unique board -- since the


### PR DESCRIPTION
All of the places in Wekan that utilizes https://github.com/kadirahq/meteor-dochead are on the client side so it's an easy replacement with `document.title`