### PR TITLE
Replace cottz:publish-relations with reywood:publish-composite

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -16,7 +16,7 @@ es5-shim@4.8.0
 
 # Collections
 aldeed:collection2
-cottz:publish-relations
+reywood:publish-composite
 dburles:collection-helpers
 idmontie:migrations
 mongo@1.16.8

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -23,7 +23,6 @@ check@1.4.1
 coffeescript@2.7.0
 coffeescript-compiler@2.4.1
 communitypackages:picker@1.1.1
-cottz:publish-relations@2.0.8
 dburles:collection-helpers@1.1.0
 ddp@1.4.1
 ddp-client@2.6.2
@@ -116,6 +115,7 @@ reactive-dict@1.3.1
 reactive-var@1.0.12
 reload@1.3.1
 retry@1.1.0
+reywood:publish-composite@1.9.0
 routepolicy@1.1.1
 service-configuration@1.3.4
 session@1.2.1


### PR DESCRIPTION
https://github.com/lfades/cottz-publish-relations is old and deprecated so we need to move to some other package that works with 3.0. While my go-to package nowadays is https://github.com/nachocodoner/meteor-reactive-publish by @nachocodoner unfortunately it only supports [3.0.1](https://github.com/nachocodoner/meteor-reactive-publish/blob/master/package.js#L10) so for the time being I chose https://github.com/Meteor-Community-Packages/meteor-publish-composite which is under MCP