### PR TITLE
Remove idmontie:migrations

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -18,7 +18,6 @@ es5-shim@4.8.0
 aldeed:collection2
 reywood:publish-composite
 dburles:collection-helpers
-idmontie:migrations
 mongo@1.16.8
 
 # Account system

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -46,7 +46,6 @@ html-tools@1.1.3
 htmljs@1.1.1
 http@2.0.0
 id-map@1.1.1
-idmontie:migrations@1.0.3
 inter-process-messaging@0.1.1
 jquery@3.0.0
 konecty:mongo-counter@0.0.5_3


### PR DESCRIPTION
It wasn't being used. For future migrations you might want to consider using https://github.com/meteor/meteor-migrations which is under official support