### PR TITLE
Reduce Member Settings Overflow for Better UI

### DIFF
--- a/client/components/main/popup.css
+++ b/client/components/main/popup.css
@@ -93,6 +93,25 @@
   max-height: inherit;
 }
 
+/* Fix overflow in the Member Settings (member menu) popup:
+   the popup itself gets a max-height inline style, but the header consumes space.
+   Make the header overlay the scrollable area so the list can't spill out. */
+.pop-over[data-popup="memberMenuPopup"] {
+  overflow: hidden;
+}
+.pop-over[data-popup="memberMenuPopup"] > .header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin-bottom: 0;
+  z-index: 1;
+}
+.pop-over[data-popup="memberMenuPopup"] > .content-wrapper {
+  padding-top: calc(4.5vh + 1vh);
+  box-sizing: border-box;
+}
+
 /* Admin edit popups: use full height */
 .pop-over[data-popup="editUserPopup"],
 .pop-over[data-popup="editOrgPopup"],


### PR DESCRIPTION
### Problem
The **Member Settings** list currently overflows its container, causing it to extend outside the intended UI area.  
This creates a broken layout and can make the scroll behavior feel awkward.  

### Solution
This update constrains the height of the list and enables internal scrolling, which significantly reduces the overflow issue.  
While the problem is not completely solved in all edge cases, the overflow is now much less noticeable and the UI behaves more consistently.  

### Notes
- The underlying cause of the overflow may still appear in extreme cases.  
- Further improvements could involve dynamically adjusting the container height or redesigning the list layout.  

Fixes #6097
