### PR TITLE
Migrate wekan-accounts-cas to async API for Meteor 3.0

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -137,7 +137,7 @@ useraccounts:flow-routing-extra@1.1.0
 useraccounts:unstyled@1.14.2
 webapp@1.13.8
 webapp-hashing@1.1.1
-wekan-accounts-cas@0.1.0
+wekan-accounts-cas@0.2.0
 wekan-accounts-lockout@1.1.0
 wekan-accounts-oidc@1.0.10
 wekan-accounts-sandstorm@0.8.0

--- a/packages/wekan-accounts-cas/cas_server.js
+++ b/packages/wekan-accounts-cas/cas_server.js
@@ -252,7 +252,7 @@ const casValidate = (req, ticket, token, service, callback) => {
     if (attrs.debug) {
       console.log(`Creating user account ${JSON.stringify(options)}`);
     }
-    const userId = Accounts.insertUserDoc({}, options);
+    const userId = await Accounts.insertUserDoc({}, options);
     user = await Meteor.users.findOneAsync(userId);
   }
   if (attrs.debug) {
@@ -262,7 +262,7 @@ const casValidate = (req, ticket, token, service, callback) => {
 });
 
 const _hasCredential = (credentialToken) => {
-  return _.has(_casCredentialTokens, credentialToken);
+  return Object.prototype.hasOwnProperty.call(_casCredentialTokens, credentialToken);
 }
 
 /*

--- a/packages/wekan-accounts-cas/package.js
+++ b/packages/wekan-accounts-cas/package.js
@@ -6,12 +6,12 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
+  api.use('ecmascript');
   api.use('routepolicy', 'server');
   api.use('webapp', 'server');
   api.use('accounts-base', ['client', 'server']);
   // Export Accounts (etc) to packages using this one.
   api.imply('accounts-base', ['client', 'server']);
-  api.use('underscore');
   api.addFiles('cas_client.js', 'web.browser');
   api.addFiles('cas_client_cordova.js', 'web.cordova');
   api.addFiles('cas_server.js', 'server');


### PR DESCRIPTION
- Remove Fiber dependency (Npm.require('fibers'))
- Use Meteor.bindEnvironment for WebApp handler
- Convert login handler to async with findOneAsync
- Bump version 0.1.0 → 0.2.0