### PR TITLE
List widths

### DIFF
--- a/client/components/lists/list.js
+++ b/client/components/lists/list.js
@@ -290,7 +290,7 @@ BlazeComponent.extendComponent({
     let isResizing = false;
     let startX = 0;
     let startWidth = 0;
-    let minWidth = 100; // Minimum width as defined in the existing code
+    let minWidth = 270; // Minimum width matching system default
     let listConstraint = this.listConstraint(); // Store constraint value for use in event handlers
     const component = this; // Store reference to component for use in event handlers
 

--- a/client/components/lists/listHeader.jade
+++ b/client/components/lists/listHeader.jade
@@ -221,8 +221,8 @@ template(name="setListWidthPopup")
   #js-list-width-edit
     label {{_ 'set-list-width-value'}}
       p
-        input.list-width-value(type="number" value="{{ listWidthValue }}" min="100")
-        input.list-constraint-value(type="number" value="{{ listConstraintValue }}" min="100")
+        input.list-width-value(type="number" value="{{ listWidthValue }}" min="270")
+        input.list-constraint-value(type="number" value="{{ listConstraintValue }}" min="270")
         input.list-width-apply(type="submit" value="{{_ 'apply'}}")
         input.list-width-error
         br
@@ -233,7 +233,7 @@ template(name="setListWidthPopup")
 
 template(name="listWidthErrorPopup")
   .list-width-invalid
-    p {{_ 'list-width-error-message'}} '&gt;=100'
+    p {{_ 'list-width-error-message'}} '&gt;=270'
     button.full.js-back-view(type="submit") {{_ 'cancel'}}
 
 template(name="setListColorPopup")

--- a/client/components/lists/listHeader.js
+++ b/client/components/lists/listHeader.js
@@ -403,7 +403,7 @@ BlazeComponent.extendComponent({
     );
 
     // FIXME(mark-i-m): where do we put constants?
-    if (width < 100 || !width || constraint < 100 || !constraint) {
+    if (width < 270 || !width || constraint < 270 || !constraint) {
       Template.instance()
         .$('.list-width-error')
         .click();

--- a/models/users.js
+++ b/models/users.js
@@ -1330,7 +1330,7 @@ Users.helpers({
         if (widths[boardId] && widths[boardId][listId]) {
           const width = widths[boardId][listId];
           // Validate it's a valid number
-          if (validators.isValidNumber(width, 100, 1000)) {
+          if (validators.isValidNumber(width, 270, 1000)) {
             return width;
           }
         }
@@ -1349,7 +1349,7 @@ Users.helpers({
     }
     
     // Validate width before storing
-    if (!validators.isValidNumber(width, 100, 1000)) {
+    if (!validators.isValidNumber(width, 270, 1000)) {
       console.warn('Invalid list width:', width);
       return false;
     }


### PR DESCRIPTION
**Problem:**
Previously, users could set list widths as low as 100px via drag-resize or the ☰ Set Width popup, causing lists to become too narrow and unusable.

**Solution:**
This PR raises the minimum allowed list width from 100px to 270px everywhere in the existing configurable system:

Drag-resize handler minimum is now 270
☰ Set Width popup input fields and validation use 270 as the minimum
Error message updated to show >= 270

**Summary:**
Users can still configure their own list widths, but cannot set them below 270px, preventing lists from being squished together. No unrelated changes included.

**Related issue:**
closes #6118