### PR TITLE
Fix unhandled Promise rejection in cron migration job callback

### DIFF
--- a/server/cronMigrationManager.js
+++ b/server/cronMigrationManager.js
@@ -1646,8 +1646,8 @@ class CronMigrationManager {
     SyncedCron.add({
       name: step.cronName,
       schedule: (parser) => parser.text(step.schedule),
-      job: () => {
-        this.runMigrationStep(step);
+      job: async () => {
+        await this.runMigrationStep(step);
       },
     });
   }


### PR DESCRIPTION
The createCronJob method's job callback was not async and did not await this.runMigrationStep(step), causing the returned Promise to float. When runMigrationStep threw, the unhandled rejection triggered quave:synced-cron's global handler which called process.exit(0), crashing the app on startup.