### PR TITLE
Replace konecty:mongo-counter with inline implementation

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -60,7 +60,6 @@ msavin:usercache
 meteorhacks:subs-manager
 meteorhacks:aggregate@1.3.0
 wekan-markdown
-konecty:mongo-counter
 quave:synced-cron
 ostrio:cookies
 ostrio:files@2.3.0

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -48,7 +48,6 @@ http@2.0.0
 id-map@1.1.1
 inter-process-messaging@0.1.1
 jquery@3.0.0
-konecty:mongo-counter@0.0.5_3
 lmieulet:meteor-coverage@1.1.4
 localstorage@1.2.0
 logging@1.3.4

--- a/models/counters.js
+++ b/models/counters.js
@@ -1,1 +1,25 @@
+import { Meteor } from 'meteor/meteor';
+
 Counters = new Mongo.Collection('counters');
+
+// Async version (for future Meteor 3.0 migration)
+async function incrementCounterAsync(counterName, amount = 1) {
+  const result = await Counters.rawCollection().findOneAndUpdate(
+    { _id: counterName },
+    { $inc: { next_val: amount } },
+    { upsert: true, returnDocument: 'after' },
+  );
+  return result.value ? result.value.next_val : result.next_val;
+}
+
+// Sync version (for Meteor 2.x autoValue compatibility)
+const incrementCounter = Meteor.wrapAsync(async (counterName, amount, callback) => {
+  try {
+    const result = await incrementCounterAsync(counterName, amount);
+    callback(null, result);
+  } catch (err) {
+    callback(err);
+  }
+});
+
+export { incrementCounter, incrementCounterAsync };

--- a/models/orgUser.js
+++ b/models/orgUser.js
@@ -1,3 +1,5 @@
+import { incrementCounter } from './counters';
+
 OrgUser = new Mongo.Collection('orgUser');
 
 /**
@@ -14,7 +16,7 @@ OrgUser.attachSchema(
       // eslint-disable-next-line consistent-return
       autoValue() {
         if (this.isInsert && !this.isSet) {
-          return incrementCounter('counters', 'orgUserId', 1);
+          return incrementCounter('orgUserId', 1);
         }
       },
     },

--- a/models/usersessiondata.js
+++ b/models/usersessiondata.js
@@ -1,3 +1,5 @@
+import { incrementCounter } from './counters';
+
 SessionData = new Mongo.Collection('sessiondata');
 
 /**
@@ -14,7 +16,7 @@ SessionData.attachSchema(
       // eslint-disable-next-line consistent-return
       autoValue() {
         if (this.isInsert && !this.isSet) {
-          return incrementCounter('counters', 'orgId', 1);
+          return incrementCounter('orgId', 1);
         }
       },
     },


### PR DESCRIPTION
## Summary
- Removes the `konecty:mongo-counter` Meteor package dependency
- Replaces it with a minimal inline `incrementCounter` function in `models/counters.js` using raw MongoDB `findOneAndUpdate` with `$inc` and `upsert`
- Also exports an `incrementCounterAsync` version to ease future Meteor 3.0 migration (where Fibers/wrapAsync are dropped)
- No data migration needed — uses the same `next_val` field in the `counters` collection