### PR TITLE
fixed linked card swimlane routing

### DIFF
--- a/client/components/cards/minicard.js
+++ b/client/components/cards/minicard.js
@@ -115,11 +115,7 @@ BlazeComponent.extendComponent({
         },
         'click span.badge-icon.fa.fa-sort, click span.badge-text.check-list-sort' : Popup.open("editCardSortOrder"),
         'click .minicard-labels' : this.cardLabelsPopup,
-        'click .js-open-minicard-details-menu'(event) {
-          event.preventDefault();
-          event.stopPropagation();
-          Popup.open('cardDetailsActions').call(this, event);
-        },
+        'click .js-open-minicard-details-menu': Popup.open('cardDetailsActions'),
         // Drag and drop file upload handlers
         'dragover .minicard'(event) {
           // Only prevent default for file drags to avoid interfering with sortable
@@ -203,7 +199,7 @@ BlazeComponent.extendComponent({
   visibleItems() {
     const checklist = this.currentData().checklist || this.currentData();
     const items = checklist.items();
-
+    
     return items.filter(item => {
       // Hide finished items if hideCheckedChecklistItems is true
       if (item.isFinished && checklist.hideCheckedChecklistItems) {
@@ -310,3 +306,35 @@ BlazeComponent.extendComponent({
   }
 }).register('editCardSortOrderPopup');
 
+Template.cardDetailsActionsPopup.events({
+  'click .js-due-date': Popup.open('editCardDueDate'),
+  'click .js-move-card': Popup.open('moveCard'),
+  'click .js-copy-card': Popup.open('copyCard'),
+  'click .js-set-card-color': Popup.open('setCardColor'),
+  'click .js-add-labels': Popup.open('cardLabels'),
+  'click .js-link': Popup.open('linkCard'),
+  'click .js-move-card-to-top'(event) {
+    event.preventDefault();
+    const minOrder = this.getMinSort();
+    this.move(this.boardId, this.swimlaneId, this.listId, minOrder - 1);
+    Popup.back();
+  },
+  async 'click .js-move-card-to-bottom'(event) {
+    event.preventDefault();
+    const maxOrder = this.getMaxSort();
+    await this.move(this.boardId, this.swimlaneId, this.listId, maxOrder + 1);
+    Popup.back();
+  },
+  'click .js-archive': Popup.afterConfirm('cardArchive', async function () {
+    Popup.close();
+    await this.archive();
+    Utils.goBoardId(this.boardId);
+  }),
+  'click .js-toggle-watch-card'() {
+    const currentCard = this;
+    const level = currentCard.findWatcher(Meteor.userId()) ? null : 'watching';
+    Meteor.call('watch', 'card', currentCard._id, level, (err, ret) => {
+      if (!err && ret) Popup.back();
+    });
+  },
+});

--- a/client/components/cards/subtasks.js
+++ b/client/components/cards/subtasks.js
@@ -135,6 +135,8 @@ BlazeComponent.extendComponent({
               boardId: board._id,
               slug: board.slug,
               cardId: subtask._id,
+              swimlaneId: subtask.swimlaneId,
+              listId: subtask.listId,
             });
           }
         },

--- a/client/lib/utils.js
+++ b/client/lib/utils.js
@@ -503,6 +503,8 @@ Utils = {
         cardId: card._id,
         boardId: board._id,
         slug: board.slug,
+        swimlaneId: card.swimlaneId,
+        listId: card.listId,
       })
     );
   },

--- a/models/cards.js
+++ b/models/cards.js
@@ -1035,6 +1035,8 @@ Cards.helpers({
       boardId: board._id,
       slug: board.slug || 'board',
       cardId: this._id,
+      swimlaneId: this.swimlaneId,
+      listId: this.listId,
     });
   },
   originRelativeUrl() {
@@ -1044,6 +1046,8 @@ Cards.helpers({
       boardId: board._id,
       slug: board.slug || 'board',
       cardId: this._id,
+      swimlaneId: this.swimlaneId,
+      listId: this.listId,
     });
   },
 


### PR DESCRIPTION
## Summary

Fixes an issue where clicking a linked card (or subtask) navigates to the
swimlane overview instead of directly opening the card detail view on boards
with swimlanes.

## Root Cause

`FlowRouter.go/url/path('card', {...})` was called without `swimlaneId` and
`listId` in several places. Without these params, the router could not match
the card detail route on swimlane boards and fell back to the swimlane overview.


## After Fix

Clicking a linked card, subtask, or any generated card link opens the card
detail view directly, regardless of whether the board uses swimlanes.

## Related

Fixes #6176
