### PR TITLE
Remove raix:handlebar-helpers, replace with native Blaze helpers

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -40,7 +40,6 @@ reactive-dict@1.3.1
 session@1.2.1
 tracker@1.3.3
 audit-argument-checks@1.0.7
-raix:handlebar-helpers
 http@2.0.0! # force new http package
 
 # Datepicker (disabled - using native HTML inputs)

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -91,7 +91,6 @@ ostrio:i18n@3.2.1
 promise@0.12.2
 quave:synced-cron@2.2.1
 raix:eventemitter@0.1.3
-raix:handlebar-helpers@0.2.5
 random@1.2.1
 rate-limit@1.1.1
 react-fast-refresh@0.2.8
@@ -120,7 +119,6 @@ templating-runtime@1.5.0
 templating-tools@1.2.2
 tracker@1.3.3
 typescript@4.9.5
-ui@1.0.13
 underscore@1.6.1
 url@1.3.2
 useraccounts:core@1.16.2

--- a/client/config/blazeHelpers.js
+++ b/client/config/blazeHelpers.js
@@ -6,6 +6,7 @@ import {
   DEFAULT_SITE_MANIFEST,
 } from '/imports/lib/customHeadDefaults';
 import { Blaze } from 'meteor/blaze';
+import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
 import {
   formatDateTime,
@@ -116,3 +117,25 @@ Blaze.registerHelper('canModifyBoard', () => Utils.canModifyBoard());
 Blaze.registerHelper('add', (a, b) => a + b);
 
 Blaze.registerHelper('increment', (n) => (n || 0) + 1);
+
+// Operator helpers (replacement for raix:handlebar-helpers)
+Blaze.registerHelper('$eq', (a, b) => a === b);
+Blaze.registerHelper('$neq', (a, b) => a !== b);
+Blaze.registerHelper('$gt', (a, b) => a > b);
+Blaze.registerHelper('$lt', (a, b) => a < b);
+Blaze.registerHelper('$gte', (a, b) => a >= b);
+Blaze.registerHelper('$lte', (a, b) => a <= b);
+Blaze.registerHelper('$and', (a, b) => a && b);
+Blaze.registerHelper('$or', (a, b) => a || b);
+Blaze.registerHelper('$not', (a) => !a);
+Blaze.registerHelper('$in', (...args) => {
+  args.pop(); // Blaze hash argument
+  const value = args.shift();
+  return args.some((arg) => value === arg);
+});
+Blaze.registerHelper('$nin', (...args) => {
+  args.pop(); // Blaze hash argument
+  const value = args.shift();
+  return args.every((arg) => value !== arg);
+});
+Blaze.registerHelper('$', () => ({ Session, Meteor }));


### PR DESCRIPTION
## Summary
- Removed the `raix:handlebar-helpers` package dependency
- Added equivalent operator helpers (`$eq`, `$neq`, `$gt`, `$lt`, `$gte`, `$lte`, `$and`, `$or`, `$not`, `$in`, `$nin`, `$`) as native Blaze helper registrations in `blazeHelpers.js`
- Removed unused `ui@1.0.13` package pin from `.meteor/versions`

I've considered using https://github.com/veliovgroup/Meteor-Template-helpers but then thought best code is no code, and cutting down on number of used packages is in Wekan's interest even post 3.0 migration 