### PR TITLE
Remove unused meteorhacks:aggregate for Meteor 3.0 migration

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -55,7 +55,6 @@ dynamic-import@0.7.3
 msavin:usercache
 # Keep stylus in 1.1.0, because building v2 takes extra 52 minutes.
 meteorhacks:subs-manager
-meteorhacks:aggregate@1.3.0
 wekan-markdown
 quave:synced-cron
 ostrio:cookies

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -56,8 +56,6 @@ mdg:validation-error@0.5.1
 meteor@1.11.5
 meteor-autosize@5.0.1
 meteor-base@1.5.1
-meteorhacks:aggregate@1.3.0
-meteorhacks:collection-utils@1.2.0
 meteorhacks:picker@1.0.3
 meteorhacks:subs-manager@1.6.4
 meteortesting:browser-tests@1.4.2
@@ -74,7 +72,6 @@ mongo@1.16.10
 mongo-decimal@0.1.3
 mongo-dev-server@1.1.0
 mongo-id@1.0.8
-mongo-livedata@1.0.12
 mquandalle:jade@0.4.9
 mquandalle:jade-compiler@0.4.5
 msavin:usercache@1.8.0

--- a/models/server/metrics.js
+++ b/models/server/metrics.js
@@ -34,27 +34,27 @@ function accessToken(req) {
   );
 }
 
-const getBoardTitleWithMostActivities = (dateWithXdaysAgo, nbLimit) => {
-  return Promise.await(
-    Activities.rawCollection()
-      .aggregate([
+const getBoardTitleWithMostActivities = async (dateWithXdaysAgo, nbLimit) => {
+  return await Activities.rawCollection()
+    .aggregate([
       {
-          $match: { modifiedAt: { $gte: dateWithXdaysAgo }}
+        $match: { modifiedAt: { $gte: dateWithXdaysAgo } },
       },
       {
-       $group: { _id: '$boardId', count: { $sum: 1 } }
+        $group: { _id: '$boardId', count: { $sum: 1 } },
       },
       {
-       $sort: { count: -1 }
+        $sort: { count: -1 },
       },
       {
-       $lookup: { from: 'boards', localField: '_id', foreignField: '_id', as: 'lookup'}
+        $lookup: { from: 'boards', localField: '_id', foreignField: '_id', as: 'lookup' },
       },
       {
-       $project: { "lookup.title":1, "count":1}
-      }])
-      .limit(nbLimit).toArray()
-      );
+        $project: { 'lookup.title': 1, count: 1 },
+      },
+    ])
+    .limit(nbLimit)
+    .toArray();
 };
 
 const getBoards = async (boardIds) => {
@@ -196,7 +196,7 @@ Meteor.startup(() => {
         metricsRes +=
           '# Top 10 boards with most activities dated 30 days ago\n';
         //Get top 10 table with most activities in current month
-        const boardTitleWithMostActivities = getBoardTitleWithMostActivities(
+        const boardTitleWithMostActivities = await getBoardTitleWithMostActivities(
           dateWithXdaysAgo,
           xdays,
         );


### PR DESCRIPTION
## Summary
- Remove `meteorhacks:aggregate@1.3.0` — it was unused since the only aggregation call already uses `rawCollection().aggregate()` (native MongoDB driver)
- Convert `getBoardTitleWithMostActivities` from `Promise.await` to `async/await` for Meteor 3.0 Fibers removal compatibility
- Also removes transitive dependencies `meteorhacks:collection-utils` and `mongo-livedata` from `.meteor/versions`
