### PR TITLE
Fix: prevent cards from disappearing after dragging in List view

### DIFF
--- a/client/components/lists/list.js
+++ b/client/components/lists/list.js
@@ -75,7 +75,8 @@ Template.list.onRendered(function () {
       const nextCardDom = ui.item.next('.js-minicard').get(0);
       const nCards = MultiSelection.isActive() ? MultiSelection.count() : 1;
       const sortIndex = calculateIndex(prevCardDom, nextCardDom, nCards);
-      const listId = Blaze.getData(ui.item.parents('.list').get(0))._id;
+      const listData = Blaze.getData(ui.item.parents('.list').get(0));
+      const listId = listData._id;
       const currentBoard = Utils.getCurrentBoard();
       const defaultSwimlaneId = currentBoard.getDefaultSwimline()._id;
       let targetSwimlaneId = null;
@@ -84,9 +85,12 @@ Template.list.onRendered(function () {
       if (
         Utils.boardView() === 'board-view-swimlanes' ||
         currentBoard.isTemplatesBoard()
-      )
+      ) {
         targetSwimlaneId = Blaze.getData(ui.item.parents('.swimlane').get(0))
           ._id;
+      } else if (listData.swimlaneId) {
+        targetSwimlaneId = listData.swimlaneId;
+      }
 
       // Normally the jquery-ui sortable library moves the dragged DOM element
       // to its new position, which disrupts Blaze reactive updates mechanism

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -126,8 +126,9 @@ Template.listBody.onCreated(function () {
         Utils.boardView() === 'board-view-lists' ||
         Utils.boardView() === 'board-view-cal' ||
         !Utils.boardView()
-      )
-      swimlaneId = board.getDefaultSwimline()._id;
+      ) {
+        swimlaneId = data.swimlaneId || board.getDefaultSwimline()._id;
+      }
 
       const nextCardNumber = await board.getNextCardNumber();
 
@@ -557,7 +558,8 @@ Template.linkCardPopup.onCreated(function () {
   this.board = ReactiveCache.getBoard(this.boardId);
   // List where to insert card
   this.list = $(Popup._getTopStack().openerElement).closest('.js-list');
-  this.listId = Blaze.getData(this.list[0])._id;
+  const listData = Blaze.getData(this.list[0]);
+  this.listId = listData._id;
   // Swimlane where to insert card
   const swimlane = $(Popup._getTopStack().openerElement).closest(
     '.js-swimlane',
@@ -566,7 +568,7 @@ Template.linkCardPopup.onCreated(function () {
   if (Utils.boardView() === 'board-view-swimlanes')
     this.swimlaneId = Blaze.getData(swimlane[0])._id;
   else if (Utils.boardView() === 'board-view-lists' || !Utils.boardView)
-    this.swimlaneId = ReactiveCache.getSwimlane({ boardId: this.boardId })._id;
+    this.swimlaneId = listData.swimlaneId || ReactiveCache.getSwimlane({ boardId: this.boardId })._id;
 
   this.getSortIndex = () => {
     const position = Template.currentData().position;
@@ -787,17 +789,18 @@ Template.searchElementPopup.onCreated(function () {
   this.selectedBoardId = new ReactiveVar(this.boardId);
   this.list = $(Popup._getTopStack().openerElement).closest('.js-list');
 
-  if (!this.isBoardTemplateSearch) {
-    this.swimlaneId = '';
-    // Swimlane where to insert card
-    const swimlane = $(Popup._getTopStack().openerElement).parents(
-      '.js-swimlane',
-    );
-    if (Utils.boardView() === 'board-view-swimlanes')
-      this.swimlaneId = Blaze.getData(swimlane[0])._id;
-    else this.swimlaneId = ReactiveCache.getSwimlane({ boardId: this.boardId })._id;
-    // List where to insert card
-    this.listId = Blaze.getData(this.list[0])._id;
+    if (!this.isBoardTemplateSearch) {
+      this.swimlaneId = '';
+      // Swimlane where to insert card
+      const swimlane = $(Popup._getTopStack().openerElement).parents(
+        '.js-swimlane',
+      );
+      const listData = Blaze.getData(this.list[0]);
+      if (Utils.boardView() === 'board-view-swimlanes')
+        this.swimlaneId = Blaze.getData(swimlane[0])._id;
+      else this.swimlaneId = listData.swimlaneId || ReactiveCache.getSwimlane({ boardId: this.boardId })._id;
+      // List where to insert card
+      this.listId = listData._id;
   }
   this.term = new ReactiveVar('');
 

--- a/client/components/swimlanes/swimlanes.js
+++ b/client/components/swimlanes/swimlanes.js
@@ -39,14 +39,8 @@ function saveSorting(ui) {
     }
   } else {
     // List was dropped in lists view (not swimlanes view)
-    // In this case, assign to the default swimlane
-    const currentBoard = ReactiveCache.getBoard(Session.get('currentBoard'));
-    if (currentBoard) {
-      const defaultSwimlane = currentBoard.getDefaultSwimline();
-      if (defaultSwimlane) {
-        targetSwimlaneId = defaultSwimlane._id;
-      }
-    }
+    // In this case, keep the original swimlane
+    targetSwimlaneId = list.getEffectiveSwimlaneId ? list.getEffectiveSwimlaneId() : (list.swimlaneId || null);
   }
 
   // Get the original swimlane ID of the list (handle backward compatibility)


### PR DESCRIPTION

### Description
This PR resolves a longstanding issue where cards (and sometimes entire lists) would "disappear" from their swimlanes after being moved or interacted with while in **List View** or **Calendar View**. 

Because WeKan now uses "Per-Swimlane Lists" (where each list resides strictly within its own swimlane), manipulating items in List View caused them to either lose their `swimlaneId` or fall back to the board's default swimlane (since the `.swimlane` UI DOM wrappers couldn't be evaluated from the List View). This meant the cards technically reached their target list, but became invisible or orphaned once the user switched back to **Swimlane View**.


### How to Test
1. Switch your board to **List View**.
2. Find two lists that belong to different swimlanes. 
3. Move a card from one list to the other, or type to create a new card in the target list. 
4. Switch back to **Swimlane View**. The card should correctly appear in its new swimlane and no longer be hidden.

**Fixes issue:** #6137