### PR TITLE
Fix: Clarify CSV export separator labels for i18n

### DIFF
--- a/client/components/sidebar/sidebar.jade
+++ b/client/components/sidebar/sidebar.jade
@@ -640,11 +640,11 @@ template(name="exportBoardPopup")
     li
       a(href="{{exportCsvUrl}}", download="{{exportCsvFilename}}")
         i.fa.fa-upload
-        | {{_ 'export-board-csv'}} ,
+        | {{_ 'export-board-csv-comma'}}
     li
       a(href="{{exportScsvUrl}}", download="{{exportCsvFilename}}")
         i.fa.fa-upload
-        | {{_ 'export-board-csv'}} ;
+        | {{_ 'export-board-csv-semicolon'}}
     li
       a(href="{{exportTsvUrl}}", download="{{exportTsvFilename}}")
         i.fa.fa-upload

--- a/imports/i18n/data/en.i18n.json
+++ b/imports/i18n/data/en.i18n.json
@@ -460,6 +460,8 @@
   "export-board": "Export board",
   "export-board-json": "Export board to JSON",
   "export-board-csv": "Export board to CSV",
+  "export-board-csv-comma": "Export to CSV (separator: ,)",
+  "export-board-csv-semicolon": "Export to CSV (separator: ;)",
   "export-board-tsv": "Export board to TSV",
   "export-board-excel": "Export board to Excel",
   "user-can-not-export-excel": "User can not export Excel",

--- a/imports/i18n/data/fr.i18n.json
+++ b/imports/i18n/data/fr.i18n.json
@@ -460,6 +460,8 @@
   "export-board": "Exporter le tableau",
   "export-board-json": "Exporter le tableau en JSON",
   "export-board-csv": "Exporter le tableau en CSV",
+  "export-board-csv-comma": "Exporter en CSV (séparateur : ,)",
+  "export-board-csv-semicolon": "Exporter en CSV (séparateur : ;)",
   "export-board-tsv": "Exporter le tableau en TSV",
   "export-board-excel": "Exporter le tableau vers Excel",
   "user-can-not-export-excel": "L'utilisateur ne peut pas exporter vers Excel",

--- a/imports/i18n/data/zh-TW.i18n.json
+++ b/imports/i18n/data/zh-TW.i18n.json
@@ -460,6 +460,8 @@
   "export-board": "匯出看板",
   "export-board-json": "匯出看板為 JSON 格式",
   "export-board-csv": "匯出看板為 CSV 格式",
+  "export-board-csv-comma": "匯出為 CSV (分隔欄位: ,)",
+  "export-board-csv-semicolon": "匯出為 CSV (分隔欄位: ;)",
   "export-board-tsv": "匯出看板為 TSV 格式",
   "export-board-excel": "匯出看板為 Excel",
   "user-can-not-export-excel": "使用者無法匯出至 Excel",


### PR DESCRIPTION

### **Description**

This PR fixes the issue where the CSV export options in the board sidebar were difficult to translate and prone to confusion. 

Previously, the labels used a single translation key, `"Export board to CSV"`, with raw commas (`,`) or semicolons (`;`) appended directly . This was problematic because:
1. It didn't fully explain to the user what the symbols meant (field separators).
2. It prevented translators from properly contextualizing the strings for their respective languages.

### Changes Made
- **Template Update**: Updated  sidebar.jadeto use two distinct, descriptive translation keys (`export-board-csv-comma` and `export-board-csv-semicolon`) instead of passing raw characters.
- **English Strings**: Added the new keys to [en.i18n.json] with the clearer text:
  - `Export to CSV (separator: ,)`
  - `Export to CSV (separator: ;)`
- **Translations included**:
  - Added translations for Traditional Chinese
  - Added translations for French 
- **Fallbacks**: All other locales will gracefully fall back to the English strings containing the universal `,` and `;` symbols until they are updated by translators.

Fixes #6206 
