### PR TITLE
Fix workspace settings modal overflow

### DIFF
--- a/client/components/main/popup.css
+++ b/client/components/main/popup.css
@@ -296,6 +296,26 @@
   margin-bottom: 0 !important;
 }
 
+/* Workspace Settings popup: ensure modal doesn't overflow viewport */
+.pop-over[data-popup="workspaceActionsPopup"] {
+  max-height: 80vh !important;
+  width: min(420px, 85vw) !important;
+}
+
+.pop-over[data-popup="workspaceActionsPopup"] .content-wrapper {
+  max-height: calc(80vh - 70px) !important; /* Subtract header height */
+  overflow-y: auto !important;
+}
+
+.pop-over[data-popup="workspaceActionsPopup"] .content-container {
+  max-height: calc(80vh - 70px) !important;
+}
+
+.pop-over[data-popup="workspaceActionsPopup"] .content {
+  max-height: none !important; /* Allow content to scroll within container */
+  overflow: visible !important; /* Overflow handled by parent */
+}
+
 .pop-over[data-popup="editCardReceivedDatePopup"] .datepicker-container,
 .pop-over[data-popup="editCardStartDatePopup"] .datepicker-container,
 .pop-over[data-popup="editCardDueDatePopup"] .datepicker-container,
@@ -350,7 +370,7 @@
 .pop-over .content-container .content {
   /* Match wider popover, leave padding */
   width: 100%;
-  padding: 0 1.3vw 1.3vh;
+  padding: 1.3vh 1.3vw 1.3vh;
   box-sizing: border-box;
   /* Ensure content is not shifted left */
   margin-left: 0 !important;


### PR DESCRIPTION
- Added top padding to popup content to prevent crowding
- Added max-height constraints for workspace actions popup
- Ensured modal fits within viewport on all screen sizes
- Implemented scrollable content when exceeding viewport
- Fixes issue with partially hidden controls in Workspace Settings modal

Closes #6200