### PR TITLE
Fix card actions popup overflow

### DIFF
--- a/client/components/main/popup.css
+++ b/client/components/main/popup.css
@@ -316,6 +316,26 @@
   overflow: visible !important; /* Overflow handled by parent */
 }
 
+/* Card Details Actions popup: ensure menu doesn't overflow viewport */
+.pop-over[data-popup="cardDetailsActionsPopup"] {
+  max-height: 80vh !important;
+  width: min(380px, 85vw) !important;
+}
+
+.pop-over[data-popup="cardDetailsActionsPopup"] .content-wrapper {
+  max-height: calc(80vh - 70px) !important; /* Subtract header height */
+  overflow-y: auto !important;
+}
+
+.pop-over[data-popup="cardDetailsActionsPopup"] .content-container {
+  max-height: calc(80vh - 70px) !important;
+}
+
+.pop-over[data-popup="cardDetailsActionsPopup"] .content {
+  max-height: none !important; /* Allow content to scroll within container */
+  overflow: visible !important; /* Overflow handled by parent */
+}
+
 .pop-over[data-popup="editCardReceivedDatePopup"] .datepicker-container,
 .pop-over[data-popup="editCardStartDatePopup"] .datepicker-container,
 .pop-over[data-popup="editCardDueDatePopup"] .datepicker-container,


### PR DESCRIPTION
## Problem
The card actions pop-up menu content overflows outside the visible viewport, 
making it difficult to access all menu options.

## Solution
- Added max-height constraint to card details actions popup
- Ensured popup fits within viewport on all screen sizes  
- Implemented scrollable content when menu exceeds viewport
- Used min(380px, 85vw) for responsive width sizing

## Changes
- Modified: client/components/main/popup.css

## Testing
1. Open any card
2. Click the card actions menu (⋮ icon)
3. Verify all menu items are visible
4. Verify menu fits within viewport
5. Verify scrolling works if content exceeds display height