### PR TITLE
fix search: guard async methods in ReactiveCache and search publications

### DIFF
--- a/imports/reactiveCache.js
+++ b/imports/reactiveCache.js
@@ -75,57 +75,57 @@ const Users = lazyCollectionProxy(() => require('/models/users').default);
 // All methods are async for Meteor 3.0 compatibility.
 const ReactiveCacheServer = {
   async getBoard(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Boards.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Boards.findOneAsync === 'function' ? await Boards.findOneAsync(idOrFirstObjectSelector, options) : Boards.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getBoards(selector = {}, options = {}, getQuery = false) {
     let ret = Boards.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getList(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Lists.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Lists.findOneAsync === 'function' ? await Lists.findOneAsync(idOrFirstObjectSelector, options) : Lists.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getLists(selector = {}, options = {}, getQuery = false) {
     let ret = Lists.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getSwimlane(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Swimlanes.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Swimlanes.findOneAsync === 'function' ? await Swimlanes.findOneAsync(idOrFirstObjectSelector, options) : Swimlanes.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getSwimlanes(selector = {}, options = {}, getQuery = false) {
     let ret = Swimlanes.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getChecklist(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Checklists.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Checklists.findOneAsync === 'function' ? await Checklists.findOneAsync(idOrFirstObjectSelector, options) : Checklists.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getChecklists(selector = {}, options = {}, getQuery = false) {
     let ret = Checklists.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getChecklistItem(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await ChecklistItems.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof ChecklistItems.findOneAsync === 'function' ? await ChecklistItems.findOneAsync(idOrFirstObjectSelector, options) : ChecklistItems.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getChecklistItems(selector = {}, options = {}, getQuery = false) {
     let ret = ChecklistItems.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
@@ -137,46 +137,46 @@ const ReactiveCacheServer = {
     ) {
       return null;
     }
-    const ret = await Cards.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Cards.findOneAsync === 'function' ? await Cards.findOneAsync(idOrFirstObjectSelector, options) : Cards.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getCards(selector = {}, options = {}, getQuery = false) {
     let ret = Cards.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getCardComment(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await CardComments.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof CardComments.findOneAsync === 'function' ? await CardComments.findOneAsync(idOrFirstObjectSelector, options) : CardComments.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getCardComments(selector = {}, options = {}, getQuery = false) {
     let ret = CardComments.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getCardCommentReaction(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await CardCommentReactions.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof CardCommentReactions.findOneAsync === 'function' ? await CardCommentReactions.findOneAsync(idOrFirstObjectSelector, options) : CardCommentReactions.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getCardCommentReactions(selector = {}, options = {}, getQuery = false) {
     let ret = CardCommentReactions.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getCustomField(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await CustomFields.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof CustomFields.findOneAsync === 'function' ? await CustomFields.findOneAsync(idOrFirstObjectSelector, options) : CustomFields.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getCustomFields(selector = {}, options = {}, getQuery = false) {
     let ret = CustomFields.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
@@ -205,153 +205,153 @@ const ReactiveCacheServer = {
     return ret;
   },
   async getAvatar(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Avatars.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Avatars.findOneAsync === 'function' ? await Avatars.findOneAsync(idOrFirstObjectSelector, options) : Avatars.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getAvatars(selector = {}, options = {}, getQuery = false) {
     let ret = Avatars.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getUser(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Users.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Users.findOneAsync === 'function' ? await Users.findOneAsync(idOrFirstObjectSelector, options) : Users.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getUsers(selector = {}, options = {}, getQuery = false) {
     let ret = Users.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getOrg(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Org.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Org.findOneAsync === 'function' ? await Org.findOneAsync(idOrFirstObjectSelector, options) : Org.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getOrgs(selector = {}, options = {}, getQuery = false) {
     let ret = Org.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getTeam(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Team.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Team.findOneAsync === 'function' ? await Team.findOneAsync(idOrFirstObjectSelector, options) : Team.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getTeams(selector = {}, options = {}, getQuery = false) {
     let ret = Team.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getActivity(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Activities.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Activities.findOneAsync === 'function' ? await Activities.findOneAsync(idOrFirstObjectSelector, options) : Activities.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getActivities(selector = {}, options = {}, getQuery = false) {
     let ret = Activities.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getRule(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Rules.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Rules.findOneAsync === 'function' ? await Rules.findOneAsync(idOrFirstObjectSelector, options) : Rules.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getRules(selector = {}, options = {}, getQuery = false) {
     let ret = Rules.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getAction(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Actions.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Actions.findOneAsync === 'function' ? await Actions.findOneAsync(idOrFirstObjectSelector, options) : Actions.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getActions(selector = {}, options = {}, getQuery = false) {
     let ret = Actions.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getTrigger(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Triggers.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Triggers.findOneAsync === 'function' ? await Triggers.findOneAsync(idOrFirstObjectSelector, options) : Triggers.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getTriggers(selector = {}, options = {}, getQuery = false) {
     let ret = Triggers.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getImpersonatedUser(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await ImpersonatedUsers.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof ImpersonatedUsers.findOneAsync === 'function' ? await ImpersonatedUsers.findOneAsync(idOrFirstObjectSelector, options) : ImpersonatedUsers.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getImpersonatedUsers(selector = {}, options = {}, getQuery = false) {
     let ret = ImpersonatedUsers.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getIntegration(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Integrations.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Integrations.findOneAsync === 'function' ? await Integrations.findOneAsync(idOrFirstObjectSelector, options) : Integrations.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getIntegrations(selector = {}, options = {}, getQuery = false) {
     let ret = Integrations.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getSessionData(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await SessionData.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof SessionData.findOneAsync === 'function' ? await SessionData.findOneAsync(idOrFirstObjectSelector, options) : SessionData.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getSessionDatas(selector = {}, options = {}, getQuery = false) {
     let ret = SessionData.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getInvitationCode(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await InvitationCodes.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof InvitationCodes.findOneAsync === 'function' ? await InvitationCodes.findOneAsync(idOrFirstObjectSelector, options) : InvitationCodes.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getInvitationCodes(selector = {}, options = {}, getQuery = false) {
     let ret = InvitationCodes.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },
   async getCurrentSetting() {
-    const ret = await Settings.findOneAsync();
+    const ret = typeof Settings.findOneAsync === 'function' ? await Settings.findOneAsync() : Settings.findOne();
     return ret;
   },
   async getCurrentUser() {
-    const ret = await Meteor.userAsync();
+    const ret = typeof Meteor.userAsync === 'function' ? await Meteor.userAsync() : Meteor.user();
     return ret;
   },
   async getTranslation(idOrFirstObjectSelector = {}, options = {}) {
-    const ret = await Translation.findOneAsync(idOrFirstObjectSelector, options);
+    const ret = typeof Translation.findOneAsync === 'function' ? await Translation.findOneAsync(idOrFirstObjectSelector, options) : Translation.findOne(idOrFirstObjectSelector, options);
     return ret;
   },
   async getTranslations(selector = {}, options = {}, getQuery = false) {
     let ret = Translation.find(selector, options);
     if (getQuery !== true) {
-      ret = await ret.fetchAsync();
+      ret = typeof ret.fetchAsync === 'function' ? await ret.fetchAsync() : ret.fetch();
     }
     return ret;
   },

--- a/models/lib/attachmentBackwardCompatibility.js
+++ b/models/lib/attachmentBackwardCompatibility.js
@@ -21,7 +21,8 @@ const OldAttachmentsFileRecord = new Mongo.Collection('cfs.attachments.filerecor
 export async function isNewAttachmentStructure(attachmentId) {
   if (Meteor.isServer) {
     if (Attachments && Attachments.collection) {
-      return !!(await Attachments.collection.findOneAsync({ _id: attachmentId }));
+      const cursor = Attachments.collection;
+      return !!(typeof cursor.findOneAsync === 'function' ? await cursor.findOneAsync({ _id: attachmentId }) : cursor.findOne({ _id: attachmentId }));
     }
   }
   return false;
@@ -36,13 +37,13 @@ export async function getOldAttachmentData(attachmentId) {
   if (Meteor.isServer) {
     try {
       // First try to get from old filerecord collection
-      const fileRecord = await OldAttachmentsFileRecord.findOneAsync({ _id: attachmentId });
+      const fileRecord = typeof OldAttachmentsFileRecord.findOneAsync === 'function' ? await OldAttachmentsFileRecord.findOneAsync({ _id: attachmentId }) : OldAttachmentsFileRecord.findOne({ _id: attachmentId });
       if (!fileRecord) {
         return null;
       }
 
       // Get file data from old files collection
-      const fileData = await OldAttachmentsFiles.findOneAsync({ _id: attachmentId });
+      const fileData = typeof OldAttachmentsFiles.findOneAsync === 'function' ? await OldAttachmentsFiles.findOneAsync({ _id: attachmentId }) : OldAttachmentsFiles.findOne({ _id: attachmentId });
       if (!fileData) {
         return null;
       }
@@ -181,7 +182,8 @@ export async function getAttachmentWithBackwardCompatibility(attachmentId) {
   // First try new structure
   if (Meteor.isServer) {
     if (Attachments && Attachments.collection) {
-      const newAttachment = await Attachments.collection.findOneAsync({ _id: attachmentId });
+      const cursor = Attachments.collection;
+      const newAttachment = typeof cursor.findOneAsync === 'function' ? await cursor.findOneAsync({ _id: attachmentId }) : cursor.findOne({ _id: attachmentId });
       if (newAttachment) {
         return newAttachment;
       }
@@ -204,7 +206,8 @@ export async function getAttachmentsWithBackwardCompatibility(query) {
   // Get new attachments
   if (Meteor.isServer) {
     if (Attachments && Attachments.collection) {
-      newAttachments = await Attachments.collection.find(query).fetchAsync();
+      const cursor = Attachments.collection.find(query);
+      newAttachments = typeof cursor.fetchAsync === 'function' ? await cursor.fetchAsync() : cursor.fetch();
     }
   }
 
@@ -215,7 +218,8 @@ export async function getAttachmentsWithBackwardCompatibility(query) {
       // Query old structure for the same card
       const cardId = query['meta.cardId'];
       if (cardId) {
-        const oldFileRecords = await OldAttachmentsFileRecord.find({ cardId }).fetchAsync();
+        const cursor = OldAttachmentsFileRecord.find({ cardId });
+        const oldFileRecords = typeof cursor.fetchAsync === 'function' ? await cursor.fetchAsync() : cursor.fetch();
         for (const fileRecord of oldFileRecords) {
           const oldAttachment = await getOldAttachmentData(fileRecord._id);
           if (oldAttachment) {

--- a/server/models/org.js
+++ b/server/models/org.js
@@ -181,7 +181,8 @@ Meteor.methods({
       throw new Meteor.Error('not-authorized');
     }
     check(query, Match.OneOf(Object, null, undefined));
-    return await (await ReactiveCache.getOrgs(query, {}, true)).countAsync();
+    const cursor = await ReactiveCache.getOrgs(query || {}, {}, true);
+    return typeof cursor.countAsync === 'function' ? await cursor.countAsync() : cursor.count();
   },
 });
 

--- a/server/models/team.js
+++ b/server/models/team.js
@@ -159,7 +159,8 @@ Meteor.methods({
       throw new Meteor.Error('not-authorized');
     }
     check(query, Match.OneOf(Object, null, undefined));
-    return await (await ReactiveCache.getTeams(query, {}, true)).countAsync();
+    const cursor = await ReactiveCache.getTeams(query || {}, {}, true);
+    return typeof cursor.countAsync === 'function' ? await cursor.countAsync() : cursor.count();
   },
 });
 

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -762,7 +762,8 @@ Meteor.methods({
 });
 
 Accounts.onCreateUser(async (options, user) => {
-  const userCount = await (await ReactiveCache.getUsers({}, {}, true)).countAsync();
+  const usersCursor = await ReactiveCache.getUsers({}, {}, true);
+  const userCount = typeof usersCursor.countAsync === 'function' ? await usersCursor.countAsync() : usersCursor.count();
   user.isAdmin = userCount === 0;
 
   if (user.services.oidc) {
@@ -1097,9 +1098,8 @@ WebApp.handlers.get('/api/user', async function(req, res) {
 WebApp.handlers.get('/api/users', async function(req, res) {
   try {
     Authentication.checkUserId(req.userId);
-    const users = await Meteor.users
-      .find({}, { fields: { _id: 1, username: 1 } })
-      .fetchAsync();
+    const usersCursor = Meteor.users.find({}, { fields: { _id: 1, username: 1 } });
+    const users = typeof usersCursor.fetchAsync === 'function' ? await usersCursor.fetchAsync() : usersCursor.fetch();
     sendJsonResult(res, {
       code: 200,
       data: users.map(doc => ({ _id: doc._id, username: doc.username })),
@@ -1414,7 +1414,8 @@ Meteor.methods({
       throw new Meteor.Error('not-authorized', 'Admin access required');
     }
 
-    return await (await ReactiveCache.getUsers(query || {}, {}, true)).countAsync();
+    const cursor = await ReactiveCache.getUsers(query || {}, {}, true);
+    return typeof cursor.countAsync === 'function' ? await cursor.countAsync() : cursor.count();
   },
 
   async searchUsers(query, boardId) {

--- a/server/publications/cards.js
+++ b/server/publications/cards.js
@@ -270,11 +270,12 @@ Meteor.publish('dueCards', async function(allUsers = false) {
     console.log('dueCards userBoards count:', userBoards.length);
 
     // Also check if there are any cards with due dates in the system at all
-    const allCardsWithDueDates = await Cards.find({
+    const cursor = Cards.find({
       type: 'cardType-card',
       archived: false,
       dueAt: { $exists: true, $nin: [null, ''] }
-    }).countAsync();
+    });
+    const allCardsWithDueDates = typeof cursor.countAsync === 'function' ? await cursor.countAsync() : cursor.count();
     console.log('dueCards: total cards with due dates in system:', allCardsWithDueDates);
   }
 
@@ -327,10 +328,10 @@ Meteor.publish('dueCards', async function(allUsers = false) {
   const result = Cards.find(selector, options);
 
   if (process.env.DEBUG === 'true') {
-    const count = await result.countAsync();
+    const count = typeof result.countAsync === 'function' ? await result.countAsync() : result.count();
     console.log('dueCards publication: returning', count, 'cards');
     if (count > 0) {
-      const sampleCards = (await result.fetchAsync()).slice(0, 3);
+      const sampleCards = (typeof result.fetchAsync === 'function' ? await result.fetchAsync() : result.fetch()).slice(0, 3);
       console.log('dueCards publication: sample cards:', sampleCards.map(c => ({
         id: c._id,
         title: c.title,
@@ -367,8 +368,9 @@ Meteor.publish('sessionData', function(sessionId) {
   }
 
   const cursor = SessionData.find({ userId, sessionId });
+  const countPromise = typeof cursor.countAsync === 'function' ? cursor.countAsync() : Promise.resolve(cursor.count());
   if (process.env.DEBUG === 'true') {
-    cursor.countAsync().then(count => {
+    countPromise.then(count => {
       console.log('sessionData publication returning cursor with count:', count);
     });
   }
@@ -557,13 +559,11 @@ async function buildSelector(queryParams) {
     }
 
     if (queryParams.hasOperator(OPERATOR_COMMENT)) {
-      const cardIds = CardComments.textSearch(
+      const commentsFound = typeof CardComments.textSearch === 'function' ? await CardComments.textSearch(
         userId,
         queryParams.getPredicates(OPERATOR_COMMENT),
-        com => {
-          return com.cardId;
-        },
-      );
+      ) : [];
+      const cardIds = commentsFound.map(com => com.cardId);
       if (cardIds.length) {
         selector._id = { $in: cardIds };
       } else {
@@ -988,11 +988,11 @@ async function findCards(sessionId, query) {
   }
 
   let cards = await ReactiveCache.getCards(query.selector, dbProjection, true);
-  let totalCardsCount = cards ? await cards.countAsync() : 0;
+  let totalCardsCount = cards ? (typeof cards.countAsync === 'function' ? await cards.countAsync() : cards.count()) : 0;
   let orderedIds = [];
 
   if (isTextSearch && totalCardsCount > 0) {
-    let fetched = await cards.fetchAsync();
+    let fetched = typeof cards.fetchAsync === 'function' ? await cards.fetchAsync() : cards.fetch();
     const regex = new RegExp(escapeForRegex(textMatches), 'i');
     fetched.forEach(c => {
       c._score = 0;
@@ -1059,21 +1059,26 @@ async function findCards(sessionId, query) {
   }
 
   // Check if the session data was actually stored
-  const storedSessionData = await SessionData.findOneAsync({ userId, sessionId });
+  const storedSessionData = typeof SessionData.findOneAsync === 'function' ? await SessionData.findOneAsync({ userId, sessionId }) : SessionData.findOne({ userId, sessionId });
   if (process.env.DEBUG === 'true') {
     console.log('findCards - stored session data:', storedSessionData);
     console.log('findCards - stored session data count:', storedSessionData ? 1 : 0);
   }
 
   // remove old session data
-  await SessionData.removeAsync({
+  const removeSelector = {
     userId,
     modifiedAt: {
       $lt: new Date(
         subtract(now(), 1, 'day').toISOString(),
       ),
     },
-  });
+  };
+  if (typeof SessionData.removeAsync === 'function') {
+    await SessionData.removeAsync(removeSelector);
+  } else {
+    SessionData.remove(removeSelector);
+  }
 
   if (cards) {
     const boards = [];
@@ -1119,7 +1124,8 @@ async function findCards(sessionId, query) {
     const sessionDataCursor = SessionData.find({ userId, sessionId });
     if (process.env.DEBUG === 'true') {
       console.log('findCards - publishing session data cursor (after delay):', sessionDataCursor);
-      sessionDataCursor.countAsync().then(count => {
+      const countPromise = typeof sessionDataCursor.countAsync === 'function' ? sessionDataCursor.countAsync() : Promise.resolve(sessionDataCursor.count());
+      countPromise.then(count => {
         console.log('findCards - session data count (after delay):', count);
       });
     }
@@ -1128,7 +1134,8 @@ async function findCards(sessionId, query) {
   const sessionDataCursor = SessionData.find({ userId, sessionId });
   if (process.env.DEBUG === 'true') {
     console.log('findCards - publishing session data cursor:', sessionDataCursor);
-    sessionDataCursor.countAsync().then(count => {
+    const countPromise = typeof sessionDataCursor.countAsync === 'function' ? sessionDataCursor.countAsync() : Promise.resolve(sessionDataCursor.count());
+    countPromise.then(count => {
       console.log('findCards - session data count:', count);
     });
   }
@@ -1159,7 +1166,8 @@ async function findCards(sessionId, query) {
   const sessionDataCursor = SessionData.find({ userId, sessionId });
   if (process.env.DEBUG === 'true') {
     console.log('findCards - publishing session data cursor (no cards):', sessionDataCursor);
-    sessionDataCursor.countAsync().then(count => {
+    const countPromise = typeof sessionDataCursor.countAsync === 'function' ? sessionDataCursor.countAsync() : Promise.resolve(sessionDataCursor.count());
+    countPromise.then(count => {
       console.log('findCards - session data count (no cards):', count);
     });
   }


### PR DESCRIPTION


### Description

This bug was caused by inconsistencies in the availability of Meteor 3.x's new asynchronous MongoDB cursor methods (like `fetchAsync`, `findOneAsync`, and `countAsync`) in certain environments—specifically those reported in Kubernetes. To ensure maximum stability during this transition period, I have implemented a comprehensive "guard" pattern throughout the core data access layer.

### Key Changes
*   **Infrastructure Improvements**: implemented a safety pattern in `imports/reactiveCache.js` that checks for the existence of async methods before calling them, falling back to synchronous equivalents if necessary.
*   **Global Search Robustness**: Update the `globalSearch` and `findCards` publications in `server/publications/cards.js` to use these guards for all cursor counting and fetching operations.
*   **Bug Fix in Comment Search**: While Investigating, I found and fixed a bug in the `CardComments.textSearch` call which was missing an `await` and had mismatched arguments, previously causing comment-based searches to fail quietly.
*   **Legacy Content Support**: Added similar guards to `attachmentBackwardCompatibility.js` and other organizational server models to ensure the entire search predicate pipeline is stable.

**Fixes #6166** 

