### PR TITLE
Draft: Use upsertAsync() instead of non-existing upsert()

### DIFF
--- a/server/authentication.js
+++ b/server/authentication.js
@@ -64,7 +64,7 @@ export const Authentication = {
   },
 };
 
-Meteor.startup(() => {
+Meteor.startup(async () => {
   Accounts.validateLoginAttempt(function(options) {
     const user = options.user || {};
     return !user.loginDisabled;
@@ -75,7 +75,7 @@ Meteor.startup(() => {
       process.env.ORACLE_OIM_ENABLED === 'true' ||
       process.env.ORACLE_OIM_ENABLED === true
     ) {
-      ServiceConfiguration.configurations.upsert(
+      await ServiceConfiguration.configurations.upsertAsync(
         // eslint-disable-line no-undef
         { service: 'oidc' },
         {
@@ -97,7 +97,7 @@ Meteor.startup(() => {
       process.env.OAUTH2_ENABLED === 'true' ||
       process.env.OAUTH2_ENABLED === true
     ) {
-      ServiceConfiguration.configurations.upsert(
+      await ServiceConfiguration.configurations.upsertAsync(
         // eslint-disable-line no-undef
         { service: 'oidc' },
         {
@@ -121,7 +121,7 @@ Meteor.startup(() => {
       process.env.CAS_ENABLED === 'true' ||
       process.env.CAS_ENABLED === true
     ) {
-      ServiceConfiguration.configurations.upsert(
+      await erviceConfiguration.configurations.upsertAsync(
         // eslint-disable-line no-undef
         { service: 'cas' },
         {
@@ -145,7 +145,7 @@ Meteor.startup(() => {
       process.env.SAML_ENABLED === 'true' ||
       process.env.SAML_ENABLED === true
     ) {
-      ServiceConfiguration.configurations.upsert(
+      await ServiceConfiguration.configurations.upsertAsync(
         // eslint-disable-line no-undef
         { service: 'saml' },
         {


### PR DESCRIPTION
This came up with latest release 8.43 where it seems the meteor update requires the use of upsertAsync() now. However I wasn't able to produce a release build tarball for other unrelated reasons. So this is so far untested, still I though maybe good to raise that, though maybe it is the utterly wrong fix to the error:
```
error on boot.js Error: update is not available on the server. Please use updateAsync() instead.
    at Object.ret.<computed> [as update] (packages/mongo/remote_collection_driver.ts:92:15)
    at Collection.update (packages/mongo/collection/methods_sync.js:254:31)
    at Collection.Mongo.Collection.<computed> [as update] (packages/aldeed:collection2/main.js:245:24)
    at Collection.upsert (packages/mongo/collection/methods_sync.js:309:17)
    at webpack:/wekan/server/authentication.js:100:43
    at Function.time (/app/code/bundle/programs/server/tools/tool-env/profile.ts:646:30)
    at /tools/static-assets/server/boot.js:453:19
    at processTicksAndRejections (node:internal/process/task_queues:103:5)
    at /tools/static-assets/server/boot.js:503:5
    at startServerProcess (/tools/static-assets/server/boot.js:501:3)
```