### PR TITLE
fix: missing module '@meteorjs/reify/lib/runtime'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,6 +204,7 @@ cd /home/wekan/app
 wget "https://github.com/wekan/wekan/releases/download/v${VERSION}/wekan-${VERSION}-${WEKAN_ARCH}.zip"
 unzip "wekan-${VERSION}-${WEKAN_ARCH}.zip"
 rm "wekan-${VERSION}-${WEKAN_ARCH}.zip"
+npm install --production --prefix ./bundle/programs/server
 mv /home/wekan/app/bundle /build
 
 # Restore original tar


### PR DESCRIPTION
Hi!

Could you please take a look at this?
It works for me now.

Resolves #6224 #6236

Many thanks to [@mzch](https://github.com/wekan/wekan/issues/6224#issuecomment-4150847727) for the fix!

