### PR TITLE
Add modern:true to benefit from meteor 3.3 optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "mainModule": {
       "client": "client/main.js",
       "server": "server/main.js"
-    }
+    },
+    "modern": true
   }
 }


### PR DESCRIPTION
While I was checking this app that migrated to Meteor 3.4 I found a missing piece to get extra speed gains.

This PR applies `"modern": true` in `package.json` to enable the [Meteor bundler optimizations](https://docs.meteor.com/about/modern-build-stack/meteor-bundler-optimizations.html#meteor-bundler-optimizations) introduced in Meteor 3.3, including full use of SWC for Atmosphere package transpilation and minification, a better watcher for package files, and others.

Congrats @harryadel for all efforts and success to transit to Meteor 3.x!

