### PR TITLE
Refactor upsert calls to use async method

### DIFF
--- a/server/authentication.js
+++ b/server/authentication.js
@@ -75,7 +75,7 @@ Meteor.startup(() => {
       process.env.ORACLE_OIM_ENABLED === 'true' ||
       process.env.ORACLE_OIM_ENABLED === true
     ) {
-      ServiceConfiguration.configurations.upsert(
+      await ServiceConfiguration.configurations.upsertAsync(
         // eslint-disable-line no-undef
         { service: 'oidc' },
         {
@@ -97,7 +97,7 @@ Meteor.startup(() => {
       process.env.OAUTH2_ENABLED === 'true' ||
       process.env.OAUTH2_ENABLED === true
     ) {
-      ServiceConfiguration.configurations.upsert(
+      await ServiceConfiguration.configurations.upsertAsync(
         // eslint-disable-line no-undef
         { service: 'oidc' },
         {
@@ -121,7 +121,7 @@ Meteor.startup(() => {
       process.env.CAS_ENABLED === 'true' ||
       process.env.CAS_ENABLED === true
     ) {
-      ServiceConfiguration.configurations.upsert(
+      await ServiceConfiguration.configurations.upsertAsync(
         // eslint-disable-line no-undef
         { service: 'cas' },
         {
@@ -145,7 +145,7 @@ Meteor.startup(() => {
       process.env.SAML_ENABLED === 'true' ||
       process.env.SAML_ENABLED === true
     ) {
-      ServiceConfiguration.configurations.upsert(
+      await ServiceConfiguration.configurations.upsertAsync(
         // eslint-disable-line no-undef
         { service: 'saml' },
         {


### PR DESCRIPTION
This PR is not tested yet for an attempt to fix this error in k8s pod of Wekan 8.52:

```
error on boot.js Error: update is not available on the server. Please use updateAsync() instead.
    at Object.ret.<computed> [as update] (packages/mongo/remote_collection_driver.ts:92:15)
    at Collection.update (packages/mongo/collection/methods_sync.js:254:31)
    at Collection.Mongo.Collection.<computed> [as update] (packages/aldeed:collection2/main.js:245:24)
    at Collection.upsert (packages/mongo/collection/methods_sync.js:309:17)
    at webpack:/wekan/server/authentication.js:100:43
    at Function.time (/build/programs/server/tools/tool-env/profile.ts:646:30)
    at /tools/static-assets/server/boot.js:453:19
    at processTicksAndRejections (node:internal/process/task_queues:103:5)
    at /tools/static-assets/server/boot.js:503:5
    at startServerProcess (/tools/static-assets/server/boot.js:501:3)
Error: update is not available on the server. Please use updateAsync() instead.
    at Object.ret.<computed> [as update] (packages/mongo/remote_collection_driver.ts:92:15)
    at Collection.update (packages/mongo/collection/methods_sync.js:254:31)
    at Collection.Mongo.Collection.<computed> [as update] (packages/aldeed:collection2/main.js:245:24)
    at Collection.upsert (packages/mongo/collection/methods_sync.js:309:17)
    at webpack:/wekan/server/authentication.js:100:43
    at Function.time (/build/programs/server/tools/tool-env/profile.ts:646:30)
    at /tools/static-assets/server/boot.js:453:19
    at processTicksAndRejections (node:internal/process/task_queues:103:5)
    at /tools/static-assets/server/boot.js:503:5
    at startServerProcess (/tools/static-assets/server/boot.js:501:3)
```
