### PR TITLE
 Fix: Server crash during comment deletion

### DIFF
--- a/server/models/activities.js
+++ b/server/models/activities.js
@@ -148,7 +148,10 @@ Activities.after.insert(async (userId, doc) => {
 
   if (activity.commentId) {
     const comment = await activity.comment();
-    params.comment = normalizeActivityText(comment.text);
+    if (!comment) {
+      console.warn('[Activities.after.insert] Comment not found for commentId:', activity.commentId, '— skipping comment params.');
+    }
+    params.comment = normalizeActivityText(comment?.text);
     let hasMentions = false;
     if (board) {
       const knownUsers = [];
@@ -237,7 +240,9 @@ Activities.after.insert(async (userId, doc) => {
         }
       }
     }
-    params.commentId = comment._id;
+    if (comment) {
+      params.commentId = comment._id;
+    }
     params.hasMentions = hasMentions;
   }
 
@@ -328,8 +333,11 @@ Activities.after.insert(async (userId, doc) => {
     }
   });
 
+  const integrationBoardIds = board
+    ? [board._id, Integrations.Const.GLOBAL_WEBHOOK_ID]
+    : [Integrations.Const.GLOBAL_WEBHOOK_ID];
   const integrations = await ReactiveCache.getIntegrations({
-    boardId: { $in: [board._id, Integrations.Const.GLOBAL_WEBHOOK_ID] },
+    boardId: { $in: integrationBoardIds },
     enabled: true,
     activities: { $in: [description, 'all'] },
   });

--- a/server/models/cardComments.js
+++ b/server/models/cardComments.js
@@ -8,6 +8,10 @@ import CardComments from '/models/cardComments';
 
 async function commentCreation(userId, doc) {
   const card = await ReactiveCache.getCard(doc.cardId);
+  if (!card) {
+    console.warn('[commentCreation] Card not found for cardId:', doc.cardId, '— skipping activity insert.');
+    return;
+  }
   await Activities.insertAsync({
     userId,
     activityType: 'addComment',
@@ -30,6 +34,10 @@ CardComments.after.insert(async (userId, doc) => {
 
 CardComments.after.update(async (userId, doc) => {
   const card = await ReactiveCache.getCard(doc.cardId);
+  if (!card) {
+    console.warn('[CardComments.after.update] Card not found for cardId:', doc.cardId, '— skipping activity insert.');
+    return;
+  }
   await Activities.insertAsync({
     userId,
     activityType: 'editComment',
@@ -42,19 +50,27 @@ CardComments.after.update(async (userId, doc) => {
 });
 
 CardComments.before.remove(async (userId, doc) => {
-  const card = await ReactiveCache.getCard(doc.cardId);
-  await Activities.insertAsync({
-    userId,
-    activityType: 'deleteComment',
-    boardId: doc.boardId,
-    cardId: doc.cardId,
-    commentId: doc._id,
-    listId: card.listId,
-    swimlaneId: card.swimlaneId,
-  });
-  const activity = await ReactiveCache.getActivity({ commentId: doc._id });
-  if (activity) {
-    await Activities.removeAsync(activity._id);
+  try {
+    const card = await ReactiveCache.getCard(doc.cardId);
+    if (!card) {
+      console.warn('[CardComments.before.remove] Card not found for cardId:', doc.cardId, '— skipping deleteComment activity.');
+    } else {
+      await Activities.insertAsync({
+        userId,
+        activityType: 'deleteComment',
+        boardId: doc.boardId,
+        cardId: doc.cardId,
+        commentId: doc._id,
+        listId: card.listId,
+        swimlaneId: card.swimlaneId,
+      });
+    }
+    const activity = await ReactiveCache.getActivity({ commentId: doc._id });
+    if (activity) {
+      await Activities.removeAsync(activity._id);
+    }
+  } catch (e) {
+    console.error('[CardComments.before.remove] Error while processing comment deletion for doc._id:', doc._id, e);
   }
 });
 


### PR DESCRIPTION
**Description**
This PR resolves the instantaneous server crash reported in #6216. The crash was caused by unhandled null-reference exceptions in asynchronous Meteor hooks for the CardComments and Activities models.

When a comment (or its parent card) is deleted, asynchronous hooks can fire after the document has already been removed from the database or cache. Accessing properties like .listId or .text on these null objects caused unhandled exceptions that terminated the server process.

**How to Test**
Start Wekan in development mode.
Open any card and add a comment.
Delete the comment immediately.
Result: The server process should remain running and stable, and the comment should be successfully removed.   

Closes: #6216