### PR TITLE
Clarify board drag tooltip text in Remaining and Workspaces

### DIFF
--- a/client/components/boards/boardsList.jade
+++ b/client/components/boards/boardsList.jade
@@ -130,7 +130,7 @@ template(name="boardList")
                     if BoardMultiSelection.isActive
                       .materialCheckBox.multi-selection-checkbox.js-toggle-board-multi-selection(
                         class="{{#if BoardMultiSelection.isSelected _id}}is-checked{{/if}}")
-                    span.board-handle(title="{{_ 'drag-board'}}")
+                    span.board-handle(title="{{boardWorkspaceDragHint}}")
                       span.emoji-icon
                         i.fa.fa-arrows
 
@@ -158,13 +158,13 @@ template(name="boardList")
                     if BoardMultiSelection.isActive
                       .materialCheckBox.multi-selection-checkbox.js-toggle-board-multi-selection(
                         class="{{#if BoardMultiSelection.isSelected _id}}is-checked{{/if}}")
-                    span.board-handle(title="{{_ 'drag-board'}}")
+                    span.board-handle(title="{{boardWorkspaceDragHint}}")
                       span.emoji-icon
                         i.fa.fa-arrows
 
                     a.js-open-board(href="{{pathFor 'board' id=_id slug=slug}}")
                       span.details
-                        span.board-list-item-name(title="{{_ 'board-drag-drop-reorder-or-click-open'}}")
+                        span.board-list-item-name(title="{{boardOpenAndMoveHint}}")
                           +viewer
                             = title
                         unless currentSetting.hideBoardMemberList

--- a/client/components/boards/boardsList.js
+++ b/client/components/boards/boardsList.js
@@ -539,6 +539,26 @@ Template.boardList.helpers({
   hasBoardsSelected() {
     return BoardMultiSelection.count() > 0;
   },
+  boardWorkspaceDragHint() {
+    const drag = TAPi18n.__('drag-board') || 'Drag board';
+    const remaining = TAPi18n.__('allboards.remaining') || 'Remaining';
+    const workspaces = TAPi18n.__('allboards.workspaces') || 'Workspaces';
+    return `${drag}: ${remaining} <-> ${workspaces}`;
+  },
+  boardOpenAndMoveHint() {
+    const remaining = TAPi18n.__('allboards.remaining') || 'Remaining';
+    const workspaces = TAPi18n.__('allboards.workspaces') || 'Workspaces';
+    return (
+      TAPi18n.__(
+        'board-open-and-move-between-remaining-and-workspaces',
+        {
+          remaining,
+          workspaces,
+        },
+      ) ||
+      `Click board icon to open board. Drag board between ${remaining} and ${workspaces}.`
+    );
+  },
 });
 
 Template.workspaceTree.helpers({

--- a/imports/i18n/data/en.i18n.json
+++ b/imports/i18n/data/en.i18n.json
@@ -189,6 +189,7 @@
   "board-private-info": "This board will be <strong>private</strong>.",
   "board-public-info": "This board will be <strong>public</strong>.",
   "board-drag-drop-reorder-or-click-open": "Drag and drop to reorder board icons. Click board icon to open board.",
+  "board-open-and-move-between-remaining-and-workspaces": "Click board icon to open board. Drag board between __remaining__ and __workspaces__.",
   "boardChangeColorPopup-title": "Change Board Background",
   "boardChangeBackgroundImagePopup-title": "Change Background Image",
   "allBoardsChangeColorPopup-title": "Change color",


### PR DESCRIPTION
## Summary

This PR clarifies the board drag tooltip text in All Boards so it matches the current behavior more accurately.

It does not change drag/drop behavior. The goal is only to reduce confusion around the drag handle by making it clear that boards are moved between Remaining and Workspaces.

## Changes

- Updated board drag handle tooltip text in All Boards
- Updated the board title tooltip to explain open vs move behavior more clearly
- Added one new English source i18n key only, following the translation contribution workflow

## Notes

- No drag/drop logic was changed
- No reorder behavior was re-enabled
- Non-English translations should be handled through Transifex, per project workflow
- The new English source string was added to `imports/i18n/data/en.i18n.json` only

## Why

The current UI suggests board reordering is supported, but the actual behavior is board assignment between Remaining and per-user Workspaces. This PR makes the wording match the current intent and avoids misleading users.