### PR TITLE
docs: update README with first-time setup guide and correct Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ By working directly with WeKan ® you get the benefit of active maintenance and 
 
 ## Getting Started with Development
 
-The default branch uses [Meteor 2 with Node.js 14](https://wekan.fi/install/).
+The default branch uses Meteor 3 with Node.js 22.22.
+See [CHANGELOG.md](https://github.com/wekan/wekan/blob/main/CHANGELOG.md) for the latest runtime updates.
 
 To contribute, [create a fork](https://github.com/wekan/wekan/blob/main/docs/DeveloperDocs/Build-and-Create-Pull-Request.md#2-create-fork-of-httpsgithubcomwekanwekan-at-github-web-page) and run `./rebuild-wekan.sh` (or `./rebuild-wekan.bat` on Windows) as detailed [here](https://github.com/wekan/wekan/blob/main/docs/DeveloperDocs/Build-and-Create-Pull-Request.md#3-select-option-1-to-install-dependencies-and-then-enter). Once you're ready, please test your code and [submit a pull request (PR)](https://github.com/wekan/wekan/blob/main/docs/DeveloperDocs/Build-and-Create-Pull-Request.md#7-test).
 
@@ -116,17 +117,17 @@ Please refer to the [developer documentation](https://github.com/wekan/wekan/blo
 Before building WeKan from source, ensure you have:
 
 - **Git** - for cloning the repository
-- **Node.js 14.x** - WeKan requires Node.js 14 (not newer versions)
+- **Node.js 22.22** - WeKan requires Node.js 22.22
 - **Meteor** - the JavaScript framework WeKan is built with
 
-### Installing Node.js 14
+### Installing Node.js 22.22
 
 ```bash
 # Using nvm (recommended)
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 source ~/.zshrc  # or ~/.bashrc
-nvm install 14
-nvm use 14
+nvm install 22.22.0
+nvm use 22.22.0
 ```
 
 ### Installing Meteor
@@ -176,7 +177,12 @@ softwareupdate --install-rosetta
 arch -x86_64 ./rebuild-wekan.sh
 ```
 
+### WSL Users
+
+WSL users can use Snap Candidate. See [install docs](https://wekan.fi/install/).
+
 The development server will start at http://localhost:4000. Any changes you make to the source code will automatically trigger a rebuild and refresh your browser.
+
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ See bottom of https://github.com/wekan/wekan/issues/3874
 ## FAQ
 
 **NOTE**:
+
 - Please read the [FAQ](https://github.com/wekan/wekan/blob/main/docs/FAQ/FAQ.md) first
 - Please don't feed the [trolls](https://github.com/wekan/wekan/blob/main/docs/FAQ/FAQ.md#why-am-i-called-a-troll) and [spammers](https://github.com/wekan/wekan/blob/main/docs/FAQ/FAQ.md#why-am-i-called-a-spammer) that are mentioned in the FAQ :)
 
 ## About WeKan ®
 
-WeKan ® is an completely [Open Source][open_source] and [Free software][free_software]
+WeKan ® is a completely [Open Source][open_source] and [Free software][free_software]
 collaborative kanban board application with MIT license.
 
 Whether you’re maintaining a personal todo list, planning your holidays with some friends,
@@ -76,15 +77,15 @@ that by providing one-click installation on various platforms.
 - 1 GB RAM minimum free for WeKan ®. Production server should have minimum total 4 GB RAM.
   For thousands of users, for example with [Docker](https://github.com/wekan/wekan/blob/main/docker-compose.yml): 3 frontend servers,
   each having 2 CPU and 2 wekan-app containers. One backend wekan-db server with many CPUs.
-- Enough disk space and alerts about low disk space. If you run out disk space, MongoDB database gets corrupted.
+- Enough disk space and alerts about low disk space. If you run out of disk space, MongoDB database gets corrupted.
 - SECURITY: Updating to newest WeKan ® version very often. Please check you do not have automatic updates of Sandstorm or Snap turned off.
   Old versions have security issues because of old versions Node.js etc. Only newest WeKan ® is supported.
   WeKan ® on Sandstorm is not usually affected by any Standalone WeKan ® (Snap/Docker/Source) security issues.
 - [Reporting all new bugs immediately](https://github.com/wekan/wekan/issues).
   New features and fixes are added to WeKan ® [many times a day](https://github.com/wekan/wekan/blob/main/CHANGELOG.md).
-- [Backups](https://github.com/wekan/wekan/blob/main/docs/Backup/Backup.md) of WeKan ® database once a day miminum.
+- [Backups](https://github.com/wekan/wekan/blob/main/docs/Backup/Backup.md) of WeKan ® database once a day minimum.
   Bugs, updates, users deleting list or card, harddrive full, harddrive crash etc can eat your data. There is no undo yet.
-  Some bug can cause WeKan ® board to not load at all, requiring manual fixing of database content.
+  Some bugs can cause WeKan ® board to not load at all, requiring manual fixing of database content.
 
 ## Roadmap and Demo
 
@@ -92,7 +93,7 @@ that by providing one-click installation on various platforms.
 
 [Developer Documentation][dev_docs]
 
-- There is many companies and individuals contributing code to WeKan ®, to add features and bugfixes
+- There are many companies and individuals contributing code to WeKan ®, to add features and bugfixes
   [many times a day](https://github.com/wekan/wekan/blob/main/CHANGELOG.md).
 - [Please add Add new Feature Requests and Bug Reports immediately](https://github.com/wekan/wekan/issues).
 - [Commercial Support](https://wekan.fi/commercial-support/).
@@ -107,6 +108,75 @@ The default branch uses [Meteor 2 with Node.js 14](https://wekan.fi/install/).
 To contribute, [create a fork](https://github.com/wekan/wekan/blob/main/docs/DeveloperDocs/Build-and-Create-Pull-Request.md#2-create-fork-of-httpsgithubcomwekanwekan-at-github-web-page) and run `./rebuild-wekan.sh` (or `./rebuild-wekan.bat` on Windows) as detailed [here](https://github.com/wekan/wekan/blob/main/docs/DeveloperDocs/Build-and-Create-Pull-Request.md#3-select-option-1-to-install-dependencies-and-then-enter). Once you're ready, please test your code and [submit a pull request (PR)](https://github.com/wekan/wekan/blob/main/docs/DeveloperDocs/Build-and-Create-Pull-Request.md#7-test).
 
 Please refer to the [developer documentation](https://github.com/wekan/wekan/blob/main/docs/DeveloperDocs/Developer-Documentation.md) for more information.
+
+## First-Time Setup for Development
+
+### Prerequisites
+
+Before building WeKan from source, ensure you have:
+
+- **Git** - for cloning the repository
+- **Node.js 14.x** - WeKan requires Node.js 14 (not newer versions)
+- **Meteor** - the JavaScript framework WeKan is built with
+
+### Installing Node.js 14
+
+```bash
+# Using nvm (recommended)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+source ~/.zshrc  # or ~/.bashrc
+nvm install 14
+nvm use 14
+```
+
+### Installing Meteor
+
+```bash
+curl https://install.meteor.com/ | sh
+```
+
+### Building WeKan
+
+The `rebuild-wekan.sh` script guides you through a three-stage process:
+
+1. **Install dependencies (Option 1)** - Downloads all required Meteor packages and npm modules
+2. **Build WeKan (Option 2)** - Compiles the application
+3. **Run WeKan (Option 3)** - Starts the development server at http://localhost:4000
+
+```bash
+# Clone your fork
+git clone git@github.com:YOUR_USERNAME/wekan.git
+cd wekan
+
+# Make the script executable
+chmod +x rebuild-wekan.sh
+
+# Step 1: Install dependencies
+./rebuild-wekan.sh
+# Press 1 and Enter
+
+# Step 2: Build WeKan (after dependencies complete)
+./rebuild-wekan.sh
+# Press 2 and Enter
+
+# Step 3: Run WeKan in development mode
+./rebuild-wekan.sh
+# Press 3 and Enter
+```
+
+### Apple Silicon (M1/M2/M3) Users
+
+If you're using a Mac with Apple Silicon, run Meteor under Rosetta 2:
+
+```bash
+# Install Rosetta 2 (if not already)
+softwareupdate --install-rosetta
+
+# Run the rebuild script under Rosetta
+arch -x86_64 ./rebuild-wekan.sh
+```
+
+The development server will start at http://localhost:4000. Any changes you make to the source code will automatically trigger a rebuild and refresh your browser.
 
 ## Screenshot
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-## About money
+## About Money
 
 See [CONTRIBUTING](CONTRIBUTING.md)
 
@@ -8,13 +8,13 @@ See [CONTRIBUTING](CONTRIBUTING.md)
 2. Send info about security issue ONLY to security@wekan.fi . NOT TO ANYWHERE ELSE. NO CC, NO BCC.
 3. Wait for new WeKan release that fixes security issue to appear to top of
    https://github.com/wekan/wekan/blob/main/CHANGELOG.md
-4. We will thank you by adding you to Hall of Fame: https://wekan.fi/hall-of-fame/
+4. We will thank you by adding you to Hall the of Fame: https://wekan.fi/hall-of-fame/
 5. All vulnerability details will be private to security@wekan.fi ,
    unless you help all WeKan platforms to have a way to upgrade, like sending
    database migrations code to security@wekan.fi or PRs to https://github.com/wekan/wekan/pulls .
-   There is no benefit to Wordwide Security Community to have more details about vulnerabilities,
+   There is no benefit to the Wordwide Security Community to have more details about vulnerabilities,
    if Worldwide Security Community does not help to make upgrades possible.
-6. If there some day becomes available a way to upgrade all WeKan platforms,
+6. If some day a way becomes available to upgrade all WeKan platforms,
    this page will be updated to add permission for security researchers
    to request new GHSA or CVE ID and publish your vulnerability details at your blog, talks, etc,
    and send that info also to security@wekan.fi to be added to
@@ -32,7 +32,7 @@ See [CONTRIBUTING](CONTRIBUTING.md)
 - If you forget to include vulnerability details.
 - If you send info about security issue to somewhere else than security@wekan.fi
 
-## How should reports be formatted?
+## How Should Reports Be Formatted?
 
 ```
 Name: %name
@@ -57,13 +57,13 @@ added to the WeKan Hall of Fame https://wekan.fi/hall-of-fame/
 No public domains, because all those are donated to Wekan Open Source project,
 and we don't have any permissions to do security scans on those donated servers.
 
-Please don't perform research that could impact other users. Secondly, please keep
-the reports short and succinct. If we fail to understand the logics of your bug, we will tell you.
+Please don't perform research that could impact other users. Second, please keep
+the reports short and succinct. If we fail to understand the logic of your bug, we will tell you.
 
-You can [Install Wekan](https://github.com/wekan/wekan/releases) to your own computer
+You can [Install Wekan](https://github.com/wekan/wekan/releases) on your own computer
 and scan it's vulnerabilities there.
 
-## About Wekan versions
+## About Wekan Versions
 
 There are only 2 versions of Wekan: Standalone Wekan, and Sandstorm Wekan.
 
@@ -74,8 +74,8 @@ like Snap and Docker have their own specific sandboxing etc features.
 
 Standalone Wekan by default does not load any files from Internet, like fonts, CSS, etc.
 This also means all Standalone Wekan functionality works in offline local networks.
-WeKan is used at most countries of the world https://snapcraft.io/wekan
-and by by companies that have 30k users.
+WeKan is used in most countries of the world https://snapcraft.io/wekan
+and by companies that have 30k users.
 
 - Wekan private board attachments are not accessible without logging in.
 - There is feature to set board public, so that board is visible without logging in in readonly mode, with realtime updates.
@@ -90,19 +90,19 @@ and by by companies that have 30k users.
 
 ## XSS
 
-- Dompurify https://www.npmjs.com/package/dompurify
-  - WeKan uses dompurify npm package to filter for XSS at fields like cards, as you can see from
+- DOMpurify https://www.npmjs.com/package/dompurify
+  - WeKan uses DOMpurify npm package to filter for XSS at fields like cards, as you can see from
     [package.json](https://github.com/wekan/wekan/blob/main/package.json). Other used versions can be seen from
     [Meteor versions file](https://github.com/wekan/wekan/blob/main/.meteor/versions).
   - Forms can include markdown links, html, image tags etc like you see at https://wekan.github.io .
   - It's possible to add attachments to cards, and markdown/html links to files.
-  - Dompurify cleans up viewed code, so Javascript in input fields does not execute
+  - Dompurify cleans up viewed code, so JavaScript in input fields does not execute
     - https://wekan.github.io/hall-of-fame/fieldbleed/
 - Reaction in comment is now checked, that it does not have extra added code
   - https://wekan.github.io/hall-of-fame/reactionbleed/
 - https://github.com/wekan/wekan/blob/main/packages/markdown/src/template-integration.js#L76
 
-## QA about PubSub
+## QA About PubSub
 
 Q:
 
@@ -115,32 +115,32 @@ A:
 
 ## PubSub
 
-- It is not security issue to show some text or image, that user has permission to see. It is a security issue, if browserside is some text or image that user should not see.
-- Meteor has browserside minimongo database, made with Javascript, updated with Publish/Subscribe, PubSub.
+- It is not a security issue to show text or images that the user has permission to see. It is a security issue, if browserside is some text or image that user should not see.
+- Meteor has browserside minimongo database, made with JavaScript, updated with Publish/Subscribe, PubSub.
 - Publish/Subscribe means, that realtime web framework reads database changes stream, and then immediately updates webpage,
-  like like dashboards, chat, kanban. That is the point in any realtime web framework in any programming language.
+  like like dashboards, chat, kanban. That is the point of any realtime web framework in any programming language.
 - Yes, you should check with Meteor DevTools Evolved Chromium/Firefox extension that at minimongo is only text that user has permission to see.
-- Do checking as logged in user, and logged out user.
+- Check as a logged-in user and as a logged-out user.
 - Check permissions and sanitize before allowing some change, because someone could modify content of input field,
   PubSub/websocket data (for example with Burp Suite Community Edition), etc.
-- If you have REST API, also check that only those that have login token, and have permission, can view or edit text
+- If you have a REST API, also check that only those who have a login token and permission can view or edit text.
 - You should not include any data user is not allowed to see. Not to webpage text, not to websockets/PubSub, etc.
 - Minimongo should not have password hashes PubSub https://wekan.github.io/hall-of-fame/userbleed/
-- PubSub uses Websockets, so you need those to be enabled at webserver like Caddy/Nginx/Apache etc, examples of settings
+- PubSub uses WebSockets, so you need those to be enabled on the webserver like Caddy/Nginx/Apache etc, examples of settings
   at right menu of https://github.com/wekan/wekan/wiki
-- Clientside https://github.com/wekan/wekan/tree/main/client/components subscribes to 
+- Clientside https://github.com/wekan/wekan/tree/main/client/components subscribes to
   PubSub https://github.com/wekan/wekan/tree/main/server/publications or calls meteor methods at https://github.com/wekan/wekan/tree/main/models
 - For Admin:
   - You can have input field for password https://github.com/wekan/wekan/blob/main/client/components/cards/attachments.js#L303-L312
   - You can save password to database https://github.com/wekan/wekan/blob/main/client/components/cards/attachments.js#L303-L312
   - Check that only current user or Admin can change password https://github.com/wekan/wekan/blob/main/client/components/cards/attachments.js#L303-L312
     - Note that currentUser uses code like Meteor.user() in .js file
-  - Do not have password hashes in PubSub https://github.com/wekan/wekan/blob/main/server/publications/users.js
+  - Do not include password hashes in PubSub https://github.com/wekan/wekan/blob/main/server/publications/users.js
   - Only show Admin Panel to Admin https://github.com/wekan/wekan/blob/main/client/components/settings/settingBody.jade#L3
-- If there is a lot of data, use pagination https://github.com/wekan/wekan/blob/main/client/components/settings/peopleBody.js
-- Only have limited amount of data published in PubSub. Limit in MongoDB query in publications how much is published. Too much could make browser too slow.
-- Use Environment variables for any email etc passwords.
-- But what if you would like to remove minimongo? And only use Meteor methods for saving? In that case, you don't have realtime updates,
+- If there is a large amount of data, use pagination https://github.com/wekan/wekan/blob/main/client/components/settings/peopleBody.js
+- Only publish a limited amount of data in PubSub. Limit in MongoDB query in publications how much is published. Too much could make browser too slow.
+- Environment variables for email and other passwords.
+- But what if you would like to remove Minimongo and only use Meteor methods for saving? In that case, you don't have realtime updates,
   and you need to write much more code to load and save data yourself, handle any multi user data saving conflicts yourself,
   and many Meteor Atmospherejs.com PubSub using packages would not work anymore https://github.com/wekan/we
 
@@ -152,10 +152,10 @@ A:
 
 ## Permissions and Roles
 
-- For any user permissions, it's best to use Meteor package package https://github.com/Meteor-Community-Packages/meteor-roles .
-- Currently WeKan has custom hardcoded permissions, WeKan does not yet use that meteor-roles package.
+- For any user permissions, it's best to use Meteor package https://github.com/Meteor-Community-Packages/meteor-roles .
+- Currently, WeKan has custom hardcoded permissions and does not yet use the meteor-roles package.
   - Using permissions at WeKan sidebar https://github.com/wekan/wekan/blob/main/client/components/sidebar/sidebar.js#L1854-L1875
-  - List of roles https://github.com/wekan/wekan/wiki/REST-API-Role . Change at board or Admin Panel. Also Organizations/Teams.
+  - List of roles: https://github.com/wekan/wekan/wiki/REST-API-Role . Change at board or Admin Panel. Also Organizations/Teams.
   - Worker role: https://github.com/wekan/wekan/issues/2788
   - Not implemented yet: Granular Roles https://github.com/wekan/wekan/issues/3022
 - Check is user logged in, with `if (Meteor.user()) {`
@@ -164,8 +164,8 @@ A:
 
 ## Environment variables
 
-- For any passwords, use environment variables, those are serverside
-- Do not copy environment variable to public variable that is visible browserside https://github.com/wekan/wekan/blob/main/server/max-size.js
+- For any passwords, use environment variables; those are serverside
+- Do not copy environment variables to public variables that are visible on the browserside https://github.com/wekan/wekan/blob/main/server/max-size.js
 
 ```
 Meteor.startup(() => {
@@ -176,13 +176,13 @@ Meteor.startup(() => {
 ```
 
 - For serverside, you can set Meteor.settings.variablename, without text public
-- For WeKan kanban, there is feature for setting board public, it can be viewed by anyone, there is realtime updates. But 
+- For WeKan kanban, there is a feature for setting a board to public; it can be viewed by anyone, with realtime updates. But
 - Some of those permissions are checked at users.js models at https://github.com/wekan/wekan/tree/main/models
 - Environment variables are used for email server passwords, etc, at all platforms https://github.com/wekan/wekan/commit/a781c0e7dcfdbe34c1483ee83cec12455b7026f7
 
 ## Escape HTML comment tags so that HTML comments are visible
 
-- Someone reported, that it is problem that content of HTML comments in edit mode, are not visible at at view mode, so this makes HTML comments visible.
+- Someone reported that it was a problem that the content of HTML comments in edit mode was not visible in view mode, so this change makes HTML comments visible.
 - https://github.com/wekan/wekan/commit/167863d95711249e69bb3511175d73b34acbbdb3
 - https://wekan.github.io/hall-of-fame/invisiblebleed/
 
@@ -249,18 +249,16 @@ Meteor.startup(() => {
 
 ### Sandstorm Wekan Security
 
-On Sandstorm platform using environment variable Standalone Wekan features like Admin Panel etc are
-turned off, because Sandstorm platform provides SSO for all apps running on Sandstorm. 
+On the Sandstorm platform, Standalone WeKan features like the Admin Panel are turned off using environment variables, because Sandstorm platform provides SSO for all apps running on Sandstorm.
 
-[Sandstorm](https://sandstorm.io) is separate Open Source platform that has been
+[Sandstorm](https://sandstorm.io) is a separate Open Source platform that has been
 [security audited](https://sandstorm.io/news/2017-03-02-security-review) and found bugs fixed.
-Sandstorm also has passwordless login, LDAP, SAML, Google etc auth options already.
-At Sandstorm code is read-only and signed by app maintainers, only grain content can be modified.
-Wekan at Sandstorm runs in sandboxed grain, it does not have access elsewhere without user-visible
-PowerBox request or opening randomly-generated API key URL.
+Sandstorm also has passwordless login, LDAP, SAML, Google, and other auth options already.
+On Sandstorm, code is read-only and signed by app maintainers; only grain content can be modified.
+WeKan on Sandstorm runs in a sandboxed grain; it does not have access elsewhere without a user-visible PowerBox request or opening a randomly-generated API key URL.
 Also read [Sandstorm Security Practices](https://docs.sandstorm.io/en/latest/using/security-practices/) and
 [Sandstorm Security non-events](https://docs.sandstorm.io/en/latest/using/security-non-events/).
-For Sandstorm specific security issues you can contact [kentonv](https://github.com/kentonv) by email. 
+For Sandstorm specific security issues you can contact [kentonv](https://github.com/kentonv) by email.
 
 ## What Wekan bugs are eligible?
 
@@ -276,14 +274,14 @@ a security issue, we'd like to know about it, and also how to fix it:
 
 ## What Wekan bugs are NOT eligible?
 
-Typical already known or "no impact" bugs such as:
+Typical already-known or 'no impact' bugs such as:
 
 - [Wekan API old tokens not replaced correctly](https://github.com/wekan/wekan/issues/1437)
 - Missing Cookie flags on non-session cookies or 3rd party cookies
 - Logout CSRF
 - Social engineering
 - Denial of service
-- SSL BEAST/CRIME/etc. Wekan does not have SSL built-in, it uses Caddy/Nginx/Apache etc at front.
+- SSL BEAST/CRIME/etc. WeKan does not have SSL built-in; it uses Caddy/Nginx/Apache, etc., on the front end.
   Integrated Caddy support is updated often.
 - Email spoofing, SPF, DMARC & DKIM. Wekan does not include email server.
 


### PR DESCRIPTION
## Summary
This PR updates the development setup documentation to align with current Node.js guidance from CHANGELOG and keeps the README improvements clear and focused.

## Changes Made

### New Content
Added a **First-Time Setup for Development** section with:

| Topic | Details |
|-------|---------|
| Prerequisites | Git, Node.js 22.22, Meteor |
| Node.js 22.22 Installation | Using nvm with step-by-step commands |
| Meteor Installation | One-line installation command |
| Build Process | Three-stage process explained (Options 1, 2, 3) |
| Apple Silicon Support | Rosetta 2 instructions for M1/M2/M3 Macs |
| WSL Support | WSL users can use Snap Candidate |

### Version Correction
Updated Node.js requirement references from **14.x** to **22.22**, based on CHANGELOG guidance.

### Typo Fixes

| Location | Before | After |
|----------|--------|-------|
| About WeKan section | an completely | a completely |
| Requirements section | out disk space | out of disk space |
| Requirements section | miminum | minimum |
| Requirements section | Some bug can cause | Some bugs can cause |
| Roadmap section | There is many companies | There are many companies |

### Grammar Improvements
- Fixed subject-verb agreement throughout
- Improved clarity in the requirements section
- Standardized formatting for consistency

## Notes
- Documentation-only change
- No code or runtime behavior changes