### PR TITLE
Fix: include historical comments and activities in board exports

### DIFF
--- a/models/exporter.js
+++ b/models/exporter.js
@@ -124,8 +124,17 @@ export class Exporter {
       { boardIds: this._boardId },
       { fields: { boardIds: 0 } },
     );
-    result.comments = await ReactiveCache.getCardComments(byBoard, noBoardId);
-    result.activities = await ReactiveCache.getActivities(byBoard, noBoardId);
+    const cardIds = result.cards.map(card => card._id);
+    result.comments = await ReactiveCache.getCardComments(
+      { cardId: { $in: cardIds } },
+      noBoardId,
+    );
+    result.activities = await ReactiveCache.getActivities(
+      {
+        $or: [{ boardId: this._boardId }, { cardId: { $in: cardIds } }],
+      },
+      noBoardId,
+    );
     result.rules = await ReactiveCache.getRules(byBoard, noBoardId);
     result.checklists = [];
     result.checklistItems = [];

--- a/models/server/ExporterExcel.js
+++ b/models/server/ExporterExcel.js
@@ -68,7 +68,7 @@ class ExporterExcel {
     result.customFields = await ReactiveCache.getCustomFields(
       {
         boardIds: {
-          $in: [this.boardId],
+          $in: [this._boardId],
         },
       },
       {
@@ -77,8 +77,17 @@ class ExporterExcel {
         },
       },
     );
-    result.comments = await ReactiveCache.getCardComments(byBoard, noBoardId);
-    result.activities = await ReactiveCache.getActivities(byBoard, noBoardId);
+    const cardIds = result.cards.map(card => card._id);
+    result.comments = await ReactiveCache.getCardComments(
+      { cardId: { $in: cardIds } },
+      noBoardId,
+    );
+    result.activities = await ReactiveCache.getActivities(
+      {
+        $or: [{ boardId: this._boardId }, { cardId: { $in: cardIds } }],
+      },
+      noBoardId,
+    );
     result.rules = await ReactiveCache.getRules(byBoard, noBoardId);
     result.checklists = [];
     result.checklistItems = [];
@@ -873,7 +882,7 @@ class ExporterExcel {
         commentcnt.toString(),
         jcomment.text,
         jcomment.cardTitle,
-        jmeml[jcomment.userId],
+        jmeml[jcomment.userId] || jcomment.userId || '',
         addTZhours(jcomment.createdAt),
         addTZhours(jcomment.modifiedAt),
       ];


### PR DESCRIPTION
### Description: This PR fixes a bug where board exports (JSON and Excel) incorrectly excluded comments and activities from previous years.

### Reason: 
Older records in the card_comments and activities collections often lack the boardId field. Since the exporters were filtering strictly by boardId, these records were being skipped.


### Changes:

Exporter Logic: Modified both JSON and Excel exporters to retrieve comments and activities based on the cardId of all cards on the board, ensuring historical data is captured.
Bug Fix: Fixed an undefined variable in ExporterExcel.js that was preventing Custom Fields from being exported.
Robustness: Added username fallbacks in the Excel export for deleted users.

Related Issue: Fixes #6274