### PR TITLE
Repair broken swimlane list rendering and add board integrity repair flow

### DIFF
--- a/client/components/boards/boardBody.css
+++ b/client/components/boards/boardBody.css
@@ -10,6 +10,103 @@
   min-width: 100%;
 }
 
+.board-wrapper.has-integrity-banner .board-canvas {
+  top: 76px;
+}
+
+.board-integrity-banner {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  right: 12px;
+  z-index: 7;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  border-radius: 6px;
+  background: rgba(255, 245, 204, 0.98);
+  color: #2c2411;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.board-integrity-banner.is-repairing {
+  background: rgba(217, 238, 255, 0.98);
+  color: #14304f;
+}
+
+.board-integrity-banner.is-error {
+  background: rgba(255, 224, 224, 0.98);
+  color: #4a1919;
+}
+
+.board-integrity-copy {
+  min-width: 0;
+}
+
+.board-integrity-title {
+  font-weight: 700;
+  margin-bottom: 2px;
+}
+
+.board-integrity-text {
+  font-size: 13px;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.board-integrity-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.board-integrity-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.78);
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.board-integrity-action.primary {
+  background: #1b6ac9;
+  border-color: #15569f;
+  color: #fff;
+}
+
+.board-integrity-note {
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+@media (max-width: 900px) {
+  .board-wrapper.has-integrity-banner .board-canvas {
+    top: 108px;
+  }
+
+  .board-integrity-banner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .board-integrity-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+}
+
 /* When zoom is 50% or lower, ensure full width like content */
 .board-wrapper[style*="transform: scale(0.5)"] {
   width: 100% !important;

--- a/client/components/boards/boardBody.jade
+++ b/client/components/boards/boardBody.jade
@@ -23,7 +23,23 @@ template(name="boardBody")
     if debugBoardState
       .debug-info(style="position: fixed; top: 0; left: 0; background: rgba(0,0,0,0.8); color: white; padding: 10px; z-index: 9999; font-size: 12px;")
         | {{_ 'board'}}: {{currentBoard.title}} | {{_ 'view'}}: {{boardView}} | {{_ 'has-swimlanes'}}: {{hasSwimlanes}} | {{_ 'swimlanes'}}: {{currentBoard.swimlanes.length}}
-    .board-wrapper(class=currentBoard.colorClass class="{{#if isMiniScreen}}mobile-view{{/if}}")
+    .board-wrapper(class=currentBoard.colorClass class="{{#if isMiniScreen}}mobile-view{{/if}}" class="{{#if showBoardIntegrityBanner}}has-integrity-banner{{/if}}")
+      if showBoardIntegrityBanner
+        .board-integrity-banner(class="{{boardIntegrityBannerClass}}")
+          .board-integrity-copy
+            .board-integrity-title {{boardIntegrityTitle}}
+            .board-integrity-text {{boardIntegritySummary}}
+          .board-integrity-actions
+            if canRunBoardIntegrityRepair
+              a.board-integrity-action.primary.js-run-board-integrity-repair
+                if $eq boardIntegrityStatus "repairing"
+                  | {{_ 'migration-running'}}
+                else
+                  | {{_ 'run-migration'}}
+            else
+              span.board-integrity-note {{_ 'migrations-admin-only'}}
+            if isViewSwimlanes
+              a.board-integrity-action.js-switch-integrity-to-lists-view {{_ 'board-view-lists'}}
       .board-canvas.js-swimlanes(
         class="{{#if hasSwimlanes}}dragscroll{{/if}}"
         class="{{#if Sidebar.isOpen}}is-sibling-sidebar-open{{/if}}"

--- a/client/components/boards/boardBody.js
+++ b/client/components/boards/boardBody.js
@@ -144,7 +144,13 @@ Template.boardBody.onCreated(function () {
   Meteor.subscribe('tableVisibilityModeSettings');
   this.showOverlay = new ReactiveVar(false);
   this.draggingActive = new ReactiveVar(false);
+  this.boardIntegrity = new ReactiveVar({
+    status: 'idle',
+    issues: [],
+    error: '',
+  });
   this._isDragging = false;
+  this._boardIntegrityRequestId = 0;
   // Used to set the overlay
   this.mouseHasEnterCardDetails = false;
   this._sortFieldsFixed = new Set(); // Track which boards have had sort fields fixed
@@ -155,6 +161,41 @@ Template.boardBody.onCreated(function () {
   // Methods on the template instance for programmatic access
   this.setIsDragging = (bool) => {
     this.draggingActive.set(bool);
+  };
+
+  this.refreshBoardIntegrityState = async boardId => {
+    const requestId = ++this._boardIntegrityRequestId;
+    this.boardIntegrity.set({
+      status: 'checking',
+      issues: [],
+      error: '',
+    });
+
+    try {
+      const result = await Meteor.callAsync(
+        'comprehensiveBoardMigration.check',
+        boardId,
+      );
+      if (this.view.isDestroyed || requestId !== this._boardIntegrityRequestId) {
+        return;
+      }
+
+      this.boardIntegrity.set({
+        status: result?.status || 'not_needed',
+        issues: Array.isArray(result?.issues) ? result.issues : [],
+        error: result?.error || '',
+      });
+    } catch (error) {
+      if (this.view.isDestroyed || requestId !== this._boardIntegrityRequestId) {
+        return;
+      }
+
+      this.boardIntegrity.set({
+        status: 'error',
+        issues: [],
+        error: error?.reason || error?.message || TAPi18n.__('migration-failed'),
+      });
+    }
   };
 
   this.scrollLeft = (position = 0) => {
@@ -248,6 +289,22 @@ Template.boardBody.onCreated(function () {
       this._sortFieldsFixed.add(`lists-${boardId}`);
     }
   }
+
+  this.autorun(() => {
+    const boardId = Session.get('currentBoard');
+    const userId = Meteor.userId();
+
+    if (!boardId || !userId) {
+      this.boardIntegrity.set({
+        status: 'idle',
+        issues: [],
+        error: '',
+      });
+      return;
+    }
+
+    this.refreshBoardIntegrityState(boardId);
+  });
 });
 
 Template.boardBody.onRendered(function () {
@@ -606,6 +663,65 @@ Template.boardBody.onDestroyed(function () {
 });
 
 Template.boardBody.helpers({
+  boardIntegrity() {
+    return Template.instance().boardIntegrity.get();
+  },
+  showBoardIntegrityBanner() {
+    const { status } = Template.instance().boardIntegrity.get();
+    return ['needed', 'repairing', 'error'].includes(status);
+  },
+  boardIntegrityTitle() {
+    const { status } = Template.instance().boardIntegrity.get();
+    if (status === 'repairing') {
+      return TAPi18n.__('migration-running');
+    }
+    if (status === 'error') {
+      return TAPi18n.__('migration-failed');
+    }
+    return TAPi18n.__('migration-needed');
+  },
+  boardIntegrityStatus() {
+    return Template.instance().boardIntegrity.get().status;
+  },
+  boardIntegritySummary() {
+    const { status, issues, error } = Template.instance().boardIntegrity.get();
+    if (status === 'repairing') {
+      return TAPi18n.__('migration-warning-text');
+    }
+    if (status === 'error') {
+      return error || TAPi18n.__('migration-failed');
+    }
+    if (!issues.length) {
+      return TAPi18n.__('comprehensive-board-migration-description');
+    }
+
+    const descriptions = issues
+      .slice(0, 2)
+      .map(issue => issue.description)
+      .filter(Boolean);
+    const remaining = issues.length - descriptions.length;
+    if (remaining > 0) {
+      descriptions.push(`+${remaining}`);
+    }
+    return descriptions.join(' | ');
+  },
+  canRunBoardIntegrityRepair() {
+    const user = ReactiveCache.getCurrentUser();
+    if (!user) {
+      return false;
+    }
+    return user.isAdmin() || user.isBoardAdmin();
+  },
+  boardIntegrityBannerClass() {
+    const { status } = Template.instance().boardIntegrity.get();
+    if (status === 'repairing') {
+      return 'is-repairing';
+    }
+    if (status === 'error') {
+      return 'is-error';
+    }
+    return 'is-needed';
+  },
   draggingActive() {
     return Template.instance().draggingActive.get();
   },
@@ -757,6 +873,43 @@ Template.boardBody.helpers({
 });
 
 Template.boardBody.events({
+  async 'click .js-run-board-integrity-repair'(event, tpl) {
+    event.preventDefault();
+    const boardId = Session.get('currentBoard');
+    if (!boardId) {
+      return;
+    }
+
+    const integrity = tpl.boardIntegrity.get();
+    if (integrity.status === 'repairing') {
+      return;
+    }
+
+    if (!confirm(TAPi18n.__('run-comprehensive-migration-confirm'))) {
+      return;
+    }
+
+    tpl.boardIntegrity.set({
+      status: 'repairing',
+      issues: integrity.issues || [],
+      error: '',
+    });
+
+    try {
+      await Meteor.callAsync('comprehensiveBoardMigration.execute', boardId);
+      await tpl.refreshBoardIntegrityState(boardId);
+    } catch (error) {
+      tpl.boardIntegrity.set({
+        status: 'error',
+        issues: integrity.issues || [],
+        error: error?.reason || error?.message || TAPi18n.__('migration-failed'),
+      });
+    }
+  },
+  'click .js-switch-integrity-to-lists-view'(event) {
+    event.preventDefault();
+    Utils.setBoardView('board-view-lists');
+  },
   // XXX The board-overlay div should probably be moved to the parent
   // component.
   mouseup(event, tpl) {

--- a/client/components/lists/listBody.js
+++ b/client/components/lists/listBody.js
@@ -309,15 +309,7 @@ Template.listBody.helpers({
       listId: Template.currentData()._id,
       archived: false,
     };
-    if (swimlaneId) {
-      // Fallback: also show cards with no swimlaneId (null/empty) so that
-      // pre-migration / orphaned cards are always visible without a DB migration.
-      selector.$or = [
-        { swimlaneId },
-        { swimlaneId: null },  // null covers null AND missing field
-        { swimlaneId: '' },    // empty string from shared-lists era
-      ];
-    }
+    if (swimlaneId) selector.swimlaneId = swimlaneId;
     const ret = ReactiveCache.getCards(Filter.mongoSelector(selector), {
       // sort: ['sort'],
       sort: sortBy,

--- a/client/components/swimlanes/swimlanes.js
+++ b/client/components/swimlanes/swimlanes.js
@@ -142,23 +142,7 @@ function saveSorting(ui) {
 
 function currentListIsInThisSwimlane(swimlaneId) {
   const currentList = Utils.getCurrentList();
-  if (!currentList) return false;
-  // Match the list's own swimlane, or shared/orphaned lists (empty/null
-  // swimlaneId are visible in every swimlane as a fallback).
-  if (currentList.swimlaneId === swimlaneId || !currentList.swimlaneId) {
-    return true;
-  }
-  // Also match when the list has an orphaned swimlaneId (references a deleted
-  // swimlane) and THIS is the first swimlane — orphaned lists are shown there.
-  const currentBoard = Utils.getCurrentBoard();
-  if (!currentBoard) return false;
-  const allSwimlanes = ReactiveCache.getSwimlanes(
-    { boardId: currentBoard._id, archived: false },
-    { sort: ['sort'] },
-  );
-  if (!allSwimlanes.length || allSwimlanes[0]._id !== swimlaneId) return false;
-  const validIds = new Set(allSwimlanes.map(s => s._id));
-  return !validIds.has(currentList.swimlaneId);
+  return currentList && currentList.swimlaneId === swimlaneId;
 }
 
 function currentCardIsInThisList(listId, swimlaneId) {
@@ -172,10 +156,7 @@ function currentCardIsInThisList(listId, swimlaneId) {
     return (
       currentCard &&
       currentCard.listId === listId &&
-      // Match cards for this swimlane, AND orphaned/shared cards that have no
-      // swimlaneId assigned (null/empty) — they are shown in every swimlane as
-      // a fallback so no content is ever invisible.
-      (currentCard.swimlaneId === swimlaneId || !currentCard.swimlaneId)
+      currentCard.swimlaneId === swimlaneId
     );
   else if (
     //currentUser &&
@@ -598,38 +579,7 @@ Template.swimlane.helpers({
     return ReactiveCache.getCurrentUser().isBoardAdmin();
   },
   lists() {
-    const swimlane = this;
-    // myLists() already covers:
-    //   • lists owned by this swimlane (swimlaneId === this._id)
-    //   • shared / pre-migration lists (swimlaneId empty or null)
-    const regularLists = swimlane.myLists();
-
-    // Additionally, detect lists whose swimlaneId references a swimlane that
-    // no longer exists ("orphaned-swimlane" lists).  These would be invisible
-    // in every swimlane without this fallback.  Show them in the FIRST swimlane
-    // on the board so they are always accessible without a DB migration.
-    const allSwimlanes = ReactiveCache.getSwimlanes(
-      { boardId: swimlane.boardId, archived: false },
-      { sort: ['sort'] },
-    );
-    // Only the first swimlane picks up orphaned-swimlane lists.
-    if (!allSwimlanes.length || allSwimlanes[0]._id !== swimlane._id) {
-      return regularLists;
-    }
-    const validIds = allSwimlanes.map(s => s._id);
-    const orphaned = swimlane.orphanedSwimlaneLists(validIds);
-    if (!orphaned.length) return regularLists;
-
-    // Merge, deduplicating by _id (regularLists may already contain some).
-    const seen = new Set(regularLists.map(l => l._id));
-    const combined = [...regularLists];
-    for (const l of orphaned) {
-      if (!seen.has(l._id)) {
-        seen.add(l._id);
-        combined.push(l);
-      }
-    }
-    return combined;
+    return this.myLists();
   },
   collapseSwimlane() {
     return Utils.getSwimlaneCollapseState(this);

--- a/models/lists.js
+++ b/models/lists.js
@@ -250,16 +250,7 @@ Lists.helpers({
       listId: this._id,
       archived: false,
     };
-    if (swimlaneId) {
-      // Fallback: also surface cards with no swimlaneId (null/empty) so that
-      // pre-migration / orphaned cards are always visible in every swimlane
-      // without requiring a database migration.
-      selector.$or = [
-        { swimlaneId },
-        { swimlaneId: null },  // null covers null AND missing field
-        { swimlaneId: '' },    // empty string from shared-lists era
-      ];
-    }
+    if (swimlaneId) selector.swimlaneId = swimlaneId;
     const filterSelector =
       typeof Filter !== 'undefined' && typeof Filter.mongoSelector === 'function'
         ? Filter.mongoSelector(selector)
@@ -273,14 +264,7 @@ Lists.helpers({
       listId: this._id,
       archived: false,
     };
-    if (swimlaneId) {
-      // Same fallback as cards(): include orphaned cards with no swimlaneId.
-      selector.$or = [
-        { swimlaneId },
-        { swimlaneId: null },
-        { swimlaneId: '' },
-      ];
-    }
+    if (swimlaneId) selector.swimlaneId = swimlaneId;
     const ret = ReactiveCache.getCards(selector, { sort: ['sort'] });
     return ret;
   },

--- a/models/swimlanes.js
+++ b/models/swimlanes.js
@@ -351,19 +351,13 @@ Swimlanes.helpers({
   },
 
   myLists() {
-    // Return per-swimlane lists: this swimlane's own lists.
-    // Also include "shared" / pre-migration lists whose swimlaneId is empty or
-    // null — they existed before the per-swimlane model and should remain
-    // visible in EVERY swimlane as a fallback (matching old shared-list
-    // behaviour) without requiring a database migration.
+    // Only render lists that actually belong to this swimlane.
+    // Corrupted/shared list structures should be repaired through the board
+    // migration flow instead of being shown as normal swimlane data.
     return ReactiveCache.getLists(
       {
         boardId: this.boardId,
-        $or: [
-          { swimlaneId: this._id },
-          { swimlaneId: null },   // null covers null AND missing field
-          { swimlaneId: '' },     // empty string from old shared-lists era
-        ],
+        swimlaneId: this._id,
         archived: false,
       },
       { sort: ['sort'] },

--- a/server/migrations/comprehensiveBoardMigration.js
+++ b/server/migrations/comprehensiveBoardMigration.js
@@ -72,24 +72,30 @@ class ComprehensiveBoardMigration {
       const cards = await ReactiveCache.getCards({ boardId });
       const lists = await ReactiveCache.getLists({ boardId });
       const swimlanes = await ReactiveCache.getSwimlanes({ boardId });
+      const validSwimlaneIds = new Set(swimlanes.map(swimlane => swimlane._id));
+      const validListIds = new Set(lists.map(list => list._id));
 
-      // Issue 1: Cards with missing swimlaneId
-      const cardsWithoutSwimlane = cards.filter(card => !card.swimlaneId);
-      if (cardsWithoutSwimlane.length > 0) {
+      // Issue 1: Cards with missing or invalid swimlaneId
+      const cardsWithoutValidSwimlane = cards.filter(card =>
+        !card.swimlaneId || !validSwimlaneIds.has(card.swimlaneId)
+      );
+      if (cardsWithoutValidSwimlane.length > 0) {
         issues.push({
-          type: 'cards_without_swimlane',
-          count: cardsWithoutSwimlane.length,
-          description: `${cardsWithoutSwimlane.length} cards missing swimlaneId`
+          type: 'cards_without_valid_swimlane',
+          count: cardsWithoutValidSwimlane.length,
+          description: `${cardsWithoutValidSwimlane.length} cards missing or using an invalid swimlane`
         });
       }
 
-      // Issue 2: Cards with missing listId
-      const cardsWithoutList = cards.filter(card => !card.listId);
-      if (cardsWithoutList.length > 0) {
+      // Issue 2: Cards with missing or invalid listId
+      const cardsWithoutValidList = cards.filter(card =>
+        !card.listId || !validListIds.has(card.listId)
+      );
+      if (cardsWithoutValidList.length > 0) {
         issues.push({
-          type: 'cards_without_list',
-          count: cardsWithoutList.length,
-          description: `${cardsWithoutList.length} cards missing listId`
+          type: 'cards_without_valid_list',
+          count: cardsWithoutValidList.length,
+          description: `${cardsWithoutValidList.length} cards missing or using an invalid list`
         });
       }
 
@@ -103,7 +109,19 @@ class ComprehensiveBoardMigration {
         });
       }
 
-      // Issue 4: Cards with mismatched listId/swimlaneId
+      // Issue 4: Lists pointing to a swimlane that no longer exists
+      const listsWithInvalidSwimlane = lists.filter(list =>
+        !!list.swimlaneId && list.swimlaneId !== '' && !validSwimlaneIds.has(list.swimlaneId)
+      );
+      if (listsWithInvalidSwimlane.length > 0) {
+        issues.push({
+          type: 'lists_with_invalid_swimlane',
+          count: listsWithInvalidSwimlane.length,
+          description: `${listsWithInvalidSwimlane.length} lists linked to a missing swimlane`
+        });
+      }
+
+      // Issue 5: Cards with mismatched listId/swimlaneId
       const listSwimlaneMap = new Map();
       lists.forEach(list => {
         listSwimlaneMap.set(list._id, list.swimlaneId || '');
@@ -123,7 +141,7 @@ class ComprehensiveBoardMigration {
         });
       }
 
-      // Issue 5: Empty lists (lists with no cards)
+      // Issue 6: Empty lists (lists with no cards)
       const emptyLists = lists.filter(list => {
         const listCards = cards.filter(card => card.listId === list._id);
         return listCards.length === 0;
@@ -304,6 +322,8 @@ class ComprehensiveBoardMigration {
     const cards = await ReactiveCache.getCards({ boardId });
     const swimlanes = await ReactiveCache.getSwimlanes({ boardId });
     const lists = await ReactiveCache.getLists({ boardId });
+    const validSwimlaneIds = new Set(swimlanes.map(swimlane => swimlane._id));
+    const validListIds = new Set(lists.map(list => list._id));
 
     let cardsFixed = 0;
     const defaultSwimlane = swimlanes.find(s => s.title === 'Default') || swimlanes[0];
@@ -314,18 +334,21 @@ class ComprehensiveBoardMigration {
       let needsUpdate = false;
       const updates = {};
 
-      // Fix missing swimlaneId
-      if (!card.swimlaneId) {
+      // Fix missing or invalid swimlaneId
+      if (!card.swimlaneId || !validSwimlaneIds.has(card.swimlaneId)) {
         updates.swimlaneId = defaultSwimlane._id;
         needsUpdate = true;
       }
 
-      // Fix missing listId
-      if (!card.listId) {
+      // Fix missing or invalid listId
+      if (!card.listId || !validListIds.has(card.listId)) {
+        const targetSwimlaneId =
+          updates.swimlaneId ||
+          (validSwimlaneIds.has(card.swimlaneId) ? card.swimlaneId : defaultSwimlane._id);
+
         // Find or create a default list for this swimlane
-        const swimlaneId = updates.swimlaneId || card.swimlaneId;
         let defaultList = lists.find(list =>
-          list.swimlaneId === swimlaneId && list.title === 'Default'
+          list.swimlaneId === targetSwimlaneId && list.title === 'Default'
         );
 
         if (!defaultList) {
@@ -333,14 +356,20 @@ class ComprehensiveBoardMigration {
           const newListId = await Lists.insertAsync({
             title: 'Default',
             boardId: boardId,
-            swimlaneId: swimlaneId,
+            swimlaneId: targetSwimlaneId,
             sort: 0,
             archived: false,
             createdAt: new Date(),
             modifiedAt: new Date(),
             type: 'list'
           });
-          defaultList = { _id: newListId };
+          defaultList = {
+            _id: newListId,
+            swimlaneId: targetSwimlaneId,
+            title: 'Default',
+          };
+          lists.push(defaultList);
+          validListIds.add(newListId);
         }
 
         updates.listId = defaultList._id;
@@ -478,12 +507,13 @@ class ComprehensiveBoardMigration {
   async ensurePerSwimlaneLists(boardId) {
     const lists = await ReactiveCache.getLists({ boardId });
     const swimlanes = await ReactiveCache.getSwimlanes({ boardId });
+    const validSwimlaneIds = new Set(swimlanes.map(swimlane => swimlane._id));
     const defaultSwimlane = swimlanes.find(s => s.title === 'Default') || swimlanes[0];
 
     let listsProcessed = 0;
 
     for (const list of lists) {
-      if (!list.swimlaneId || list.swimlaneId === '') {
+      if (!list.swimlaneId || list.swimlaneId === '' || !validSwimlaneIds.has(list.swimlaneId)) {
         // Assign to default swimlane
         await Lists.updateAsync(list._id, {
           $set: {


### PR DESCRIPTION
## Summary

This PR stops swimlane view from silently rendering structurally invalid list data and adds a board-level repair flow for admins when integrity issues are detected.

## Root Cause

Some boards still contain pre-migration or inconsistent per-swimlane data, including shared lists, lists linked to deleted swimlanes, and cards whose list and swimlane references no longer agree.

Recent fallback rendering made those broken structures appear as normal swimlane data instead of surfacing them as board integrity problems. That could leave a list visible in swimlane view while its cards were filtered into a different swimlane context, which made the list look empty and caused moved cards to appear to disappear.

## What Changed

- made swimlane rendering strict again so a swimlane only shows lists and cards that actually belong to it
- removed the client-side fallback that displayed shared and orphaned swimlane data as if it were valid swimlane content
- added a board integrity banner in the board UI that checks for migration issues and lets board admins run a repair directly from the board
- wired the repair action to the existing comprehensive board migration flow
- expanded comprehensive migration detection and repair so it also handles invalid swimlane references, invalid list references, shared lists, and mismatched list/swimlane relationships

## User Impact

- broken boards are surfaced as integrity issues instead of showing ghost lists in swimlane view
- board admins get a direct repair path from the affected board
- after repair, the board returns to a consistent per-swimlane structure


Fixes #6266
