### PR TITLE
fix(exporter): attachments always empty in board JSON export

### DIFF
--- a/models/exporter.js
+++ b/models/exporter.js
@@ -39,7 +39,7 @@ export class Exporter {
     const os = Npm.require('os');
     const path = Npm.require('path');
 
-    const byBoard = { boardId: this._boardId };
+    const byBoard = { 'meta.boardId': this._boardId };
     const byBoardNoLinked = {
       boardId: this._boardId,
       linkedId: { $in: ['', null] },
@@ -75,7 +75,7 @@ export class Exporter {
         `tmpexport${process.pid}${Math.random()}`,
       );
       const tmpWriteable = fs.createWriteStream(tmpFile);
-      const readStream = doc.createReadStream();
+      const readStream = fs.createReadStream(doc.versions.original.path);
       readStream.on('data', function (chunk) {
         buffer = Buffer.concat([buffer, chunk]);
       });
@@ -97,7 +97,7 @@ export class Exporter {
       getBase64Data(doc, (err, res) => err ? reject(err) : resolve(res));
     });
     const byBoardAndAttachment = this._attachmentId
-      ? { boardId: this._boardId, _id: this._attachmentId }
+      ? { 'meta.boardId': this._boardId, _id: this._attachmentId }
       : byBoard;
     const attachmentDocs = await ReactiveCache.getAttachments(byBoardAndAttachment);
     result.attachments = [];


### PR DESCRIPTION
I'm trying to build an importer that uses the exported board json file, but noticed attachments were always empty in the json export. I had Claude code figure out why that was the case, and it figured out this as the root cause:

> The Meteor-Files migration left the attachment queries using the old field name:
> 
> **`models/exporter.js:42, 100`** — `byBoard` and `byBoardAndAttachment` queried `{ boardId: ... }` but the attachments collection stores the board ID at `meta.boardId`. The query matched nothing.
>
> **`models/exporter.js:78`** — `doc.createReadStream()` is a Meteor-Files instance method not available on plain objects returned by `ReactiveCache.getAttachments()`. Replaced with `fs.createReadStream(doc.versions.original.path)` using the `fs` already required in the same scope.

This fixes both the full board export and the single-attachment export endpoint (`GET /api/boards/:boardId/attachments/:attachmentId/export`).