### PR TITLE
ui: enable the horizontal scroll in the quick access menu boards list

### DIFF
--- a/client/components/main/header.css
+++ b/client/components/main/header.css
@@ -177,7 +177,6 @@
 }
 #header-quick-access ul.header-quick-access-list {
   transition: opacity 0.2s;
-  overflow: hidden;
   white-space: nowrap;
   padding: 10px;
   margin: -10px;
@@ -185,16 +184,18 @@
   min-width: 0; /* Allow shrinking below content size */
   display: flex; /* Use flexbox for better control */
   align-items: center;
+  overflow-x: auto;
+  scrollbar-color: white #2573a7;
 }
 
 /* Hide scrollbar completely */
 #header-quick-access ul.header-quick-access-list::-webkit-scrollbar {
-  display: none;
+  display: flex;
 }
 
 #header-quick-access ul.header-quick-access-list {
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: thin; /* IE and Edge */
+  scrollbar-width: thin; /* Firefox */
 }
 #header-quick-access ul.header-quick-access-list li {
   display: inline-block; /* Keep inline-block for proper spacing */

--- a/client/components/main/header.jade
+++ b/client/components/main/header.jade
@@ -70,10 +70,6 @@ template(name="header")
           else
             li.current.empty(title="{{_ 'quick-access-description'}}")
             | {{_ 'quick-access-description'}}
-        #header-new-board-icon
-      // Next line is used only for spacing at header,
-      // there is no visible clickable icon.
-      #header-new-board-icon
       //
         Hide duplicate create board button,
       //


### PR DESCRIPTION
### Issue

- The space dedicated to starred boards in the quick access menu doesn't show correctly.
- Using a wide top-left logo makes the space for starred boards too tiny.
- There is no horizontal scroll in case too many boards are starred.

Before:
<img width="1154" height="345" alt="image" src="https://github.com/user-attachments/assets/a37bb20e-5edd-4835-9d4c-66902ee49ef7" />

### Fix

- Adjusting the CSS styles makes it more usable.
- The div is horizontally scrollable.
- The #header-new-board-icon sections have been removed, I didn't get why they were there (...)

Result:
<img width="1156" height="350" alt="image" src="https://github.com/user-attachments/assets/79f413c0-1e2a-4691-afc5-63a7ce832f52" />