### PR TITLE
helm: add single-node ReplicaSet support with auto MONGO_OPLOG_URL

### DIFF
--- a/helm/wekan/templates/_helpers.tpl
+++ b/helm/wekan/templates/_helpers.tpl
@@ -74,6 +74,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{/*
 Create the MongoDB URL. If MongoDB is installed as part of this chart, use k8s service discovery,
 else use user-provided URL.
+Supports single-node ReplicaSet via mongodb.replicaSet.name (e.g. for oplog tailing).
 */}}
 {{- define "mongodb.url" -}}
 {{- if (index .Values "mongodb" "enabled") -}}
@@ -83,10 +84,32 @@ else use user-provided URL.
   {{- if gt $count 1 -}}
     {{- $replicaSetName := (index .Values "mongodb" "replicaSetName") -}}
     mongodb://{{- range $v := until $count }}{{ $release }}-mongodb-{{ $v }}.{{ $mongodbSvcName }}:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}/{{ .Values.dbname }}?replicaSet={{ $replicaSetName }}
+  {{- else if (index .Values "mongodb" "replicaSet" "name") -}}
+    {{- $replicaSetName := (index .Values "mongodb" "replicaSet" "name") -}}
+    mongodb://{{ $mongodbSvcName }}:27017/{{ .Values.dbname }}?replicaSet={{ $replicaSetName }}
   {{- else -}}
-    mongodb://{{ $release }}-mongodb-0.{{ $mongodbSvcName }}:27017/{{ .Values.dbname }}
+    mongodb://{{ $mongodbSvcName }}:27017/{{ .Values.dbname }}
   {{- end -}}
 {{- else -}}
   {{- index .Values "mongodb" "url" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the MongoDB Oplog URL for change stream support (requires ReplicaSet).
+Only rendered when mongodb.replicaSet.name is set or replicaCount > 1.
+*/}}
+{{- define "mongodb.oplog.url" -}}
+{{- if (index .Values "mongodb" "enabled") -}}
+  {{- $count := (int (index .Values "mongodb" "replicaCount")) -}}
+  {{- $release := .Release.Name -}}
+  {{- $mongodbSvcName := include "wekan.mongodb.svcname" . -}}
+  {{- if gt $count 1 -}}
+    {{- $replicaSetName := (index .Values "mongodb" "replicaSetName") -}}
+    mongodb://{{- range $v := until $count }}{{ $release }}-mongodb-{{ $v }}.{{ $mongodbSvcName }}:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}/local?replicaSet={{ $replicaSetName }}
+  {{- else if (index .Values "mongodb" "replicaSet" "name") -}}
+    {{- $replicaSetName := (index .Values "mongodb" "replicaSet" "name") -}}
+    mongodb://{{ $mongodbSvcName }}:27017/local?replicaSet={{ $replicaSetName }}
+  {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/wekan/templates/deployment.yaml
+++ b/helm/wekan/templates/deployment.yaml
@@ -73,6 +73,11 @@ spec:
             - name: MONGO_URL
               value: "{{ template "mongodb.url" . }}"
           {{- end }}
+          {{- $oplogUrl := include "mongodb.oplog.url" . -}}
+          {{- if $oplogUrl }}
+            - name: MONGO_OPLOG_URL
+              value: {{ $oplogUrl | quote }}
+          {{- end }}
           {{- range $key := .Values.env }}
           {{- if .value }}
             - name: {{ .name }}

--- a/helm/wekan/values.yaml
+++ b/helm/wekan/values.yaml
@@ -237,3 +237,16 @@ mongodb:
     requestedSize: 2Gi
     # Optional specify an existing PVC. If you do, unset the `requestedSize`.
     # persistentVolumeClaimName:
+
+  # Single-node ReplicaSet support for oplog tailing (METEOR_REACTIVITY_ORDER=oplog).
+  # When set, MONGO_URL gets ?replicaSet=<name> appended and MONGO_OPLOG_URL is
+  # injected automatically. You must start mongod with --replSet <name> and run
+  # rs.initiate() once (e.g. via an extraContainer sidecar).
+  # Example:
+  #   replicaSet:
+  #     name: rs0
+  #   args:
+  #     - "--replSet rs0"
+  #     - "--oplogSize 128"
+  replicaSet:
+    name: ""


### PR DESCRIPTION
- mongodb.url template now appends ?replicaSet=<name> for single-replica setups when mongodb.replicaSet.name is set, eliminating the need for a secretEnv workaround
- New mongodb.oplog.url helper generates MONGO_OPLOG_URL automatically when a ReplicaSet is configured (single-node or multi-node)
- deployment.yaml injects MONGO_OPLOG_URL env var when the oplog URL helper produces a non-empty value
- values.yaml documents the replicaSet.name option with example config