### PR TITLE
feat: add missing board‑attachments API endpoint (fix #6319)

### DIFF
--- a/server/routes/attachmentApi.js
+++ b/server/routes/attachmentApi.js
@@ -335,6 +335,41 @@ WebApp.handlers.use('/api/attachment/upload', async (req, res, next) => {
       sendErrorResponse(res, 401, error.message);
     }
   });
+// Board attachments endpoint (legacy)
+WebApp.handlers.use('/api/boards/:boardId/attachments', async (req, res, next) => {
+  if (req.method !== 'GET') {
+    return next();
+  }
+  try {
+    const userId = await authenticateApiRequest(req);
+    const boardId = req.params.boardId;
+    const board = await ReactiveCache.getBoard(boardId);
+    if (!board || !board.isBoardMember(userId)) {
+      return sendErrorResponse(res, 403, 'You do not have permission to access this board');
+    }
+    const query = { 'meta.boardId': boardId };
+    const attachments = await ReactiveCache.getAttachments(query);
+    const attachmentList = attachments.map(attachment => {
+      const strategy = fileStoreStrategyFactory.getFileStrategy(attachment, 'original');
+      return {
+        attachmentId: attachment._id,
+        fileName: attachment.name,
+        fileSize: attachment.size,
+        fileType: attachment.type,
+        storageBackend: strategy.getStorageName(),
+        boardId: attachment.meta.boardId,
+        swimlaneId: attachment.meta.swimlaneId,
+        listId: attachment.meta.listId,
+        cardId: attachment.meta.cardId,
+        createdAt: attachment.uploadedAt,
+        isImage: attachment.isImage
+      };
+    });
+    sendJsonResponse(res, 200, { success: true, attachments: attachmentList, count: attachmentList.length });
+  } catch (error) {
+    sendErrorResponse(res, 401, error.message);
+  }
+});
 
   // Copy attachment endpoint
   WebApp.handlers.use('/api/attachment/copy', async (req, res, next) => {


### PR DESCRIPTION
#### **Problem**  
Calling  

```
GET /api/boards/<boardId>/attachments
```  

on Wekan 8.74.0 returns **500 Internal Server Error**.  
All other attachment routes (`/api/attachment/...`) work, and the front‑end can fetch the same files via the legacy CFS route. The error was caused by the **absence of a handler** for the board‑level attachments endpoint, so the request fell through to the generic error handler.

#### **Solution**  
*Added a new GET handler* in `server/routes/attachmentApi.js` that:

1. Authenticates the request using the existing `authenticateApiRequest` helper (X‑User‑Id / X‑Auth‑Token).  
2. Verifies that the caller is a member of the requested board.  
3. Queries `ReactiveCache` for all attachments whose `meta.boardId` matches the board.  
4. Maps each attachment to the same JSON shape used by the other attachment APIs (`attachmentId`, `fileName`, `fileSize`, `fileType`, `storageBackend`, `boardId`, `swimlaneId`, `listId`, `cardId`, `createdAt`, `isImage`).  
5. Returns a success payload `{ success:true, attachments: [...], count: N }`.  
6. Handles errors uniformly with `sendErrorResponse`.

#### **Related issues**  
- Fixes **#6319** – “Accessing attachments api endpoint fails”.  