### PR TITLE
Fix CleanDark theme: transparent list header, white popup text, no co…

### DIFF
--- a/client/components/boards/boardColors.css
+++ b/client/components/boards/boardColors.css
@@ -3370,18 +3370,19 @@ THEME - Clean Light
 
 .board-color-cleanlight .list,
 .board-color-cleandark .list {
-  background: none;
-  border-left: none;
+  background: none !important;
+  border-left: none !important;
 }
 
 .board-color-cleanlight .list .list-header,
 .board-color-cleandark .list .list-header {
-  border-bottom: none;
-  display: flex;
+  border-bottom: none !important;
+  display: flex !important;
   justify-content: space-between;
   align-items: center;
   font-size: 16px;
-  background: none;
+  background: none !important;
+  background-color: transparent !important;
 }
 
 .board-color-cleanlight .list .list-header div:has(.list-header-name),
@@ -4277,6 +4278,14 @@ THEME - Clean Light
 .board-color-cleanlight .pop-over-list li > a,
 .board-color-cleandark .pop-over-list li > a {
   font-weight: 500;
+}
+
+.board-color-cleandark .pop-over-list li > a {
+  color: rgba(255, 255, 255, 1) !important;
+}
+
+.board-color-cleanlight .pop-over-list li > a {
+  color: rgba(10, 10, 20, 0.85) !important;
 }
 
 .board-color-cleanlight .pop-over-list li > a i,


### PR DESCRIPTION
Fixes #6168 

Three regressions in the CleanDark (and CleanLight) theme:

  1. **List header not transparent** – `list.css` uses `!important` on `background-color: #e4e4e4` and `border-bottom`, which overrode the CleanDark `background: none` rule. Fixed by adding `!important` to the theme overrides.

  2. **Popup menu text color black instead of white** – `popup.css` has a global `.pop-over-list li > a { color: #000 !important }` (introduced with the popup overflow fixes for #6221). Fixed by adding more specific color overrides for CleanDark (white) and CleanLight (dark).                                                                                                                

  3. **Slight border between columns** – `list.css` default `.list { background: #dedede; border-left: 1px solid #ccc }` was not fully overridden. Fixed by adding `!important` to the theme's `background: none` and `border-left: none` rules.

All fixes are in `client/components/boards/boardColors.css` only.
