### PR TITLE
Fix attachment cursor handling and await board access check

### DIFF
--- a/server/models/boards.js
+++ b/server/models/boards.js
@@ -733,15 +733,13 @@ WebApp.handlers.post('/api/boards/:boardId/members/:memberId', async function(re
 
 WebApp.handlers.get('/api/boards/:boardId/attachments', async function(req, res) {
   const paramBoardId = req.params.boardId;
-  Authentication.checkBoardAccess(req.userId, paramBoardId);
+  await Authentication.checkBoardAccess(req.userId, paramBoardId);
   const attachments = await ReactiveCache.getAttachments(
     { 'meta.boardId': paramBoardId },
-    {},
-    true,
   );
   sendJsonResult(res, {
     code: 200,
-    data: attachments.each().map(attachment => ({
+    data: attachments.map(attachment => ({
       attachmentId: attachment._id,
       attachmentName: attachment.name,
       attachmentType: attachment.type,


### PR DESCRIPTION

**Description**
This PR fixes attachment listing by fetching the FilesCollection cursor as an array before mapping over it.

It also awaits `checkBoardAccess`, which is async. Previously the auth check was not awaited, so authorization could be silently bypassed and the route could crash before attachment mapping.

**Changes**
- Replace invalid `.each()` usage on FilesCollection cursors with `.fetch()`
- Await `checkBoardAccess` before continuing
- Preserve the existing attachment response mapping

**Closes**  #6326