### PR TITLE
Update DDP transport and reactivity order for multi-tenant deployment

### DIFF
--- a/docker-compose-multitenancy.yml
+++ b/docker-compose-multitenancy.yml
@@ -1,0 +1,164 @@
+# WeKan multi-tenant deployment on one Linux host
+#
+# Use this compose file when you want to run several WeKan instances
+# (one per customer / domain) on the SAME Linux host, all sharing the
+# host's kernel network namespace (network_mode: "host") and one
+# MongoDB replica set, with separate logical databases per tenant.
+#
+# This file shows the minimal extra configuration needed for the
+# `uws` DDP transport plus `changeStreams` reactivity to work
+# correctly in this topology, namely:
+#
+#   - DDP_TRANSPORT=uws on every service
+#   - METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling on every service
+#   - METEOR_SETTINGS with a DISTINCT uws.port per service (5001, 5002, …)
+#
+# Why the distinct uws.port: the uws DDP transport runs an internal
+# WebSocket proxy server on its own TCP port (default 127.0.0.1:5001)
+# and forwards WS upgrades from the public PORT into it. When two
+# services share a kernel netns and both default to 127.0.0.1:5001,
+# the second one to start fails to bind because the listen socket is
+# opened exclusively. Give each service its own internal port via
+# METEOR_SETTINGS and they coexist cleanly.
+#
+# Reference: see docs/Platforms/FOSS/Docker/Meteor3/multitenancy.md
+# and https://docs.meteor.com/performance/ddp-transport#multitenancy
+#
+# Setup:
+#   docker compose -f docker-compose-multitenancy.yml up -d
+#
+# Tear down:
+#   docker compose -f docker-compose-multitenancy.yml down -v
+#
+# Adding more tenants:
+#   Copy a tenant block, change the service name, PORT, ROOT_URL,
+#   MONGO_URL database name, and the uws.port inside METEOR_SETTINGS
+#   to a fresh value (5003, 5004, …). The MongoDB service and the
+#   reverse proxy in front of WeKan don't need any change.
+
+version: '3.8'
+
+services:
+
+  # ---------------------------------------------------------------------
+  # Shared MongoDB 7 with replica set (required for changeStreams).
+  # All tenants connect to this instance using DIFFERENT logical
+  # databases (?authSource if you enable auth).
+  # ---------------------------------------------------------------------
+  wekandb:
+    image: mongo:7
+    container_name: wekan-db
+    restart: always
+    network_mode: "host"
+    command: >
+      sh -c '
+        mongod --storageEngine wiredTiger --wiredTigerCacheSizeGB 1
+               --timeZoneInfo /usr/share/zoneinfo
+               --oplogSize 2048 --replSet rs0
+               --bind_ip 127.0.0.1 --port 27017 --quiet &
+        until mongosh --host 127.0.0.1 --port 27017 --quiet --eval "
+          try {
+            const status = rs.status();
+            quit(status.ok === 1 ? 0 : 1);
+          } catch (e) {
+            if (
+              e.codeName === \"NotYetInitialized\" ||
+              e.message.includes(\"no replset config has been received\") ||
+              e.message.includes(\"not yet initialized\")
+            ) {
+              rs.initiate({
+                _id: \"rs0\",
+                members: [{ _id: 0, host: \"127.0.0.1:27017\" }]
+              });
+              quit(1);
+            }
+            quit(1);
+          }
+        " >/dev/null 2>&1; do
+          sleep 2
+        done
+        wait
+      '
+    volumes:
+      - wekan-db:/data/db
+      - wekan-db-dump:/dump
+
+  # ---------------------------------------------------------------------
+  # Tenant 1
+  #
+  # Each tenant needs three things distinct from every other tenant:
+  #   1. PORT                     — public HTTP port (here 8081)
+  #   2. MONGO_URL database name  — here `wekan_tenant1`
+  #   3. uws.port in METEOR_SETTINGS — here 5001
+  # ---------------------------------------------------------------------
+  wekan-tenant1:
+    image: ghcr.io/wekan/wekan:latest
+    container_name: wekan-tenant1
+    restart: always
+    network_mode: "host"
+    depends_on:
+      - wekandb
+    environment:
+      - PORT=8081
+      - ROOT_URL=https://tenant1.example.com
+      - MONGO_URL=mongodb://127.0.0.1:27017/wekan_tenant1?replicaSet=rs0
+      - MONGO_OPLOG_URL=mongodb://127.0.0.1:27017/local?replicaSet=rs0
+      - DDP_TRANSPORT=uws
+      - METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
+      # Internal uws proxy port — MUST be distinct per service.
+      - METEOR_SETTINGS={"packages":{"ddp-server":{"uws":{"port":5001,"host":"127.0.0.1"}}}}
+      - WRITABLE_PATH=/data
+      - WITH_API=true
+    volumes:
+      - wekan-tenant1-data:/data
+
+  # ---------------------------------------------------------------------
+  # Tenant 2 — same template, distinct PORT / database / uws.port
+  # ---------------------------------------------------------------------
+  wekan-tenant2:
+    image: ghcr.io/wekan/wekan:latest
+    container_name: wekan-tenant2
+    restart: always
+    network_mode: "host"
+    depends_on:
+      - wekandb
+    environment:
+      - PORT=8082
+      - ROOT_URL=https://tenant2.example.com
+      - MONGO_URL=mongodb://127.0.0.1:27017/wekan_tenant2?replicaSet=rs0
+      - MONGO_OPLOG_URL=mongodb://127.0.0.1:27017/local?replicaSet=rs0
+      - DDP_TRANSPORT=uws
+      - METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
+      - METEOR_SETTINGS={"packages":{"ddp-server":{"uws":{"port":5002,"host":"127.0.0.1"}}}}
+      - WRITABLE_PATH=/data
+      - WITH_API=true
+    volumes:
+      - wekan-tenant2-data:/data
+
+  # ---------------------------------------------------------------------
+  # Add more tenants by copying a block above and bumping:
+  #   PORT       (e.g. 8083, 8084, …)
+  #   ROOT_URL   (the tenant's public domain)
+  #   MONGO_URL  (a new database name)
+  #   uws.port   (5003, 5004, …)
+  # ---------------------------------------------------------------------
+
+volumes:
+  wekan-db:
+  wekan-db-dump:
+  wekan-tenant1-data:
+  wekan-tenant2-data:
+
+# ---------------------------------------------------------------------
+# Verifying the uws internal listen sockets are isolated.
+#
+# From the host (or any container sharing the netns):
+#
+#   cat /proc/net/tcp | awk '$4 == "0A" {print $2}' | sort | uniq -c
+#
+# You want to see ONE listener per uws port — the hex addresses
+# `0100007F:1389` (5001) and `0100007F:138A` (5002) should each
+# appear with count 1, no duplicates. If you see `2 0100007F:1389`,
+# two services are trying to share the default port; reconfigure
+# their METEOR_SETTINGS.uws.port to distinct values and restart.
+# ---------------------------------------------------------------------

--- a/docker-compose-multitenancy.yml
+++ b/docker-compose-multitenancy.yml
@@ -50,35 +50,14 @@ services:
     container_name: wekan-db
     restart: always
     network_mode: "host"
-    command: >
-      sh -c '
-        mongod --storageEngine wiredTiger --wiredTigerCacheSizeGB 1
-               --timeZoneInfo /usr/share/zoneinfo
-               --oplogSize 2048 --replSet rs0
-               --bind_ip 127.0.0.1 --port 27017 --quiet &
-        until mongosh --host 127.0.0.1 --port 27017 --quiet --eval "
-          try {
-            const status = rs.status();
-            quit(status.ok === 1 ? 0 : 1);
-          } catch (e) {
-            if (
-              e.codeName === \"NotYetInitialized\" ||
-              e.message.includes(\"no replset config has been received\") ||
-              e.message.includes(\"not yet initialized\")
-            ) {
-              rs.initiate({
-                _id: \"rs0\",
-                members: [{ _id: 0, host: \"127.0.0.1:27017\" }]
-              });
-              quit(1);
-            }
-            quit(1);
-          }
-        " >/dev/null 2>&1; do
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        mongod --storageEngine wiredTiger --wiredTigerCacheSizeGB 1 --timeZoneInfo /usr/share/zoneinfo --oplogSize 2048 --replSet rs0 --bind_ip 127.0.0.1 --port 27017 --quiet &
+        until mongosh --host 127.0.0.1 --port 27017 --quiet --eval 'try { const s = rs.status(); quit(s.ok === 1 ? 0 : 1); } catch (e) { if (e.codeName === "NotYetInitialized" || /no replset config has been received|not yet initialized/.test(e.message)) { rs.initiate({_id:"rs0", members:[{_id:0, host:"127.0.0.1:27017"}]}); quit(1); } quit(1); }' >/dev/null 2>&1; do
           sleep 2
         done
         wait
-      '
     volumes:
       - wekan-db:/data/db
       - wekan-db-dump:/dump

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -315,9 +315,9 @@ services:
       # https://github.com/meteor/meteor/blob/release-3.5/v3-docs/docs/performance/change-streams-observer-driver.md#choosing-the-reactivity-driver-order
       # Use oplog,polling to fix performance until changeStreams is fixed at next release of Meteor 3.5 Beta:
       # https://github.com/wekan/wekan/issues/6307#issuecomment-4299349231
-      - METEOR_REACTIVITY_ORDER=oplog,polling
-      - DDP_TRANSPORT=sockjs
-      #- DDP_TRANSPORT=uws
+      - METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
+      - DDP_TRANSPORT=uws
+      #- DDP_TRANSPORT=sockjs
       #-----------------------------------------------------------------
       # ==== WRITEABLE PATH FOR FILE UPLOADS ====
       - WRITABLE_PATH=/data

--- a/docs/Platforms/FOSS/Docker/Meteor3/multitenancy.md
+++ b/docs/Platforms/FOSS/Docker/Meteor3/multitenancy.md
@@ -1,102 +1,96 @@
 # Multitenancy
 
-TLDR a) and b)
+Run several WeKan instances (one per customer / domain) on the same
+Linux host. Two supported topologies, pick whichever fits your
+deployment.
 
-## a) Oplog sockjs
+## a) Recommended — one host, many WeKan domains, `uws` + `changeStreams`
 
-- One server/Many WeKan domains/One IPv4
-- Multitenancy works
+Highest DDP throughput and lowest reactive latency.
 
-docker-compose.yml:
+Configure each instance with:
+
+- `DDP_TRANSPORT=uws`
+- `METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling`
+- A **distinct** `Meteor.settings.packages['ddp-server'].uws.port`
+  per instance (`5001`, `5002`, `5003`, … in the example below)
+- `network_mode: "host"` (or any setup that shares one kernel
+  network namespace)
+- The same MongoDB replica set (separate logical databases per
+  tenant)
+
+Why the distinct `uws.port`: the `uws` DDP transport runs its own
+internal WebSocket proxy server on a dedicated TCP port (default
+`127.0.0.1:5001`) and forwards public WebSocket upgrades into it.
+The internal listen socket is opened exclusively, so each instance
+in the same kernel netns must declare its own internal port.
+
+Working example: see [`docker-compose-multitenancy.yml`](../../../../../docker-compose-multitenancy.yml)
+in the repository root.
+
+Sketch of the per-tenant environment block:
+
+```yaml
+environment:
+  - PORT=8081                                                # public HTTP port
+  - ROOT_URL=https://tenant1.example.com
+  - MONGO_URL=mongodb://127.0.0.1:27017/wekan_tenant1?replicaSet=rs0
+  - DDP_TRANSPORT=uws
+  - METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
+  - METEOR_SETTINGS={"packages":{"ddp-server":{"uws":{"port":5001,"host":"127.0.0.1"}}}}
 ```
+
+For tenant 2, bump `PORT`, `ROOT_URL`, the MongoDB database name, and
+the `uws.port` (e.g. `5002`). The reverse proxy in front of WeKan
+keeps routing customer domains to each tenant's public `PORT`
+exactly as before — the internal `uws.port` is never exposed.
+
+### Verifying the configuration
+
+From the host (or from inside any container sharing the netns):
+
+```sh
+cat /proc/net/tcp | awk '$4 == "0A" {print $2}' | sort | uniq -c
+```
+
+Each `uws.port` should appear exactly once. `0x1389` is `5001`,
+`0x138A` is `5002`, etc. If you see `2 0100007F:1389`, two tenants
+are trying to share the default port; reconfigure their
+`METEOR_SETTINGS.uws.port` to distinct values and restart.
+
+### If you forget to set a distinct `uws.port`
+
+The second tenant to start refuses the bind and Meteor throws at
+startup with an actionable error:
+
+```text
+Error: uWebSockets.js: failed to listen on 127.0.0.1:5001 (address already in use).
+  Another Meteor instance in this network namespace is already bound to this port.
+  Set a distinct Meteor.settings.packages["ddp-server"].uws.port (or .host) for each instance.
+```
+
+Add a `METEOR_SETTINGS` line with a free port to the failing
+service, restart.
+
+## b) Alternative — `sockjs` + `oplog` (maximum proxy compatibility)
+
+Use this if your reverse proxy / load balancer cannot guarantee
+WebSocket upgrade pass-through, or if some clients sit on networks
+that block raw WebSocket. SockJS will fall back to HTTP long-polling
+on those clients.
+
+```yaml
+- DDP_TRANSPORT=sockjs
 - METEOR_REACTIVITY_ORDER=oplog,polling
-- DDP_TRANSPORT=uws
 ```
 
-## b) changeStreams uws
+No per-tenant `uws.port` configuration is needed because `sockjs`
+does not run a separate internal listen socket. The trade-off is
+lower DDP throughput compared to `uws`.
 
-- One server/One WeKan domain/One IPv4
+## Reference
 
-Multitenancy does not work, causes bug: round robin changing
-WeKan website at every webpage reload at same address.
-
-For example:
-
-1) At https://boards.wekan.team shows https://wekan.customer2.com
-2) Reload webpage. https://boards.wekan.team shows https://wekan.customer3.com
-3) Reload webpage. https://boards.wekan.team shows https://wekan.customer4.com
-    - 4) Reload webpage. https://boards.wekan.team shows https://customer4.wekan.team
-    - etc.
-
-## Details
-
-When multiple Meteor 3 applications are running on the same server using
-`network_mode: "host"` and are shared across the same MongoDB server,
-the combination `DDP_TRANSPORT=uws` and `METEOR_REACTIVITY_ORDER=changeStreams`
-is subject to a very rare but critical **Context/Descriptor Confusion**.
-
-Here is a detailed technical explanation of what is happening behind the scenes and why it breaks a multi-tenant environment:
-
-### 1. µWebSockets (`uws`) and shared host networking
-
-`uws` is an extremely high-performance WebSocket engine written in C++.
-It bypasses many of the traditional networking layers of Node.js and
-handles network sockets and their file handles (File Descriptors)
-directly at a low level in its own Event Loop.
-
-When containers are set to `network_mode: "host"`, they are not
-network-level isolated. They share the same Linux kernel
-network stack and memory space for network traffic.
-When your browser does a WebSocket handshake (`Upgrade: websocket`)
-after an HTTP request, `uws` allocates a memory address for the socket.
-
-The bug occurs when multiple containers do this at the same time
-in the same host network environment,
-**the low-level C++ code in the `uws` engine can cross-identify socket identifiers from different processes**
-if the framework (in this case, an early beta integration of Meteor 3)
-is unable to keep connection ownership (v8 isolation) completely separate.
-
-### 2. `changeStreams` and data misrouting
-
-MongoDB's `changeStreams` relies on the application opening a long-lived,
-real-time listening pipe to the database. It is heavier and more complex
-than the old `oplog` table because it creates constantly changing,
-stateful cursors between the application and the database.
-
-When this is combined with `uws` WebSocket:
-
-1. User A opens the `boards.wekan.team` page.
-
-2. The browser requests a WebSocket connection, and Meteor creates a
-   `changeStream` listener on the database for User A's container.
-
-3. At the same time, User B loads the `kanban.buetzow.de` page.
-
-4. Since both containers talk locally to the same MongoDB process
-   and share the same host interface, the application layer's
-   reactivity engine (multiplexer) confuses which `changeStream`
-   data input belongs to which active `uws` socket address.
-
-**Result:** A reactive data packet from the database (e.g. different customer 1 boards)
-is pushed into the `uws` pipe that was locally open to the `boards.wekan.team` browser.
-The browser gets a perfectly valid HTML body, but the Javascript layer draws the data
-it received from the WebSocket.
-
-### Why did good old `sockjs` and `oplog` fix the situation?
-
-* **`sockjs`** is written in pure JavaScript (Node.js' native network stack).
-  It strictly follows Node.js' own process boundaries, and does not perform
-  direct C++-level optimizations beyond the kernel. Even though containers
-  share the host network, Node.js makes sure that each process's sockets
-  remain strictly within its own application window.
-
-* **`oplog`** is a more passive way to read the database. The application
-  reads the raw log file (`local.oplog.rs`) and filters its own data from
-  there, instead of MongoDB's active `changeStream` engine trying to route
-  and load balance cursors between different processes on the fly.
-
-Simply put: `uws` and `changeStreams` are great tools when you are running
-**only one large application** on a single server for which you want
-maximum performance. In a multi-tenant environment
-(many different clients on the same machine), they are too aggressive
-and break the invisible boundaries between containers.
+- Meteor 3.5 DDP transport docs, including the multi-tenant section:
+  <https://docs.meteor.com/performance/ddp-transport#multitenancy>
+- Meteor changeStreams reactivity driver:
+  <https://docs.meteor.com/performance/change-streams-observer-driver>

--- a/snap-src/bin/config
+++ b/snap-src/bin/config
@@ -8,15 +8,15 @@ keys="DEBUG DDP_TRANSPORT METEOR_REACTIVITY_ORDER MONGO_LOG_DESTINATION MONGO_UR
 #-------------------- CHANGE STREAMS --------------------
 # https://forums.meteor.com/t/meteor-3-5-beta-change-streams-performance-improvements/64461#change-streams-setup-3
 # https://github.com/meteor/meteor/blob/release-3.5/v3-docs/docs/performance/change-streams-observer-driver.md#choosing-the-reactivity-driver-order
-# Use oplog,polling to fix performance until changeStreams is fixed at next release of Meteor 3.5 Beta:
-# https://github.com/wekan/wekan/issues/6307#issuecomment-4299349231
-# Later change to: METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
-DESCRIPTION_METEOR_REACTIVITY_ORDER="METEOR_REACTIVITY_ORDER. Default for multitenancy: 'oplog,polling'. Alternative for one domain only: 'changeStreams,oplog,polling'"
-DEFAULT_METEOR_REACTIVITY_ORDER="oplog,polling"
+DESCRIPTION_METEOR_REACTIVITY_ORDER="METEOR_REACTIVITY_ORDER. Default: 'changeStreams,oplog,polling'. Fallback for environments without a replica set: 'oplog,polling'"
+DEFAULT_METEOR_REACTIVITY_ORDER="changeStreams,oplog,polling"
 KEY_METEOR_REACTIVITY_ORDER='meteor-reactivity-order'
 
-DESCRIPTION_DDP_TRANSPORT="DDP_TRANSPORT. Default for multitenancy: 'sockjs'. Alternative for one domain only: 'uws'"
-DEFAULT_DDP_TRANSPORT="sockjs"
+# For multi-process / multi-tenant deployments on one host with network_mode: host,
+# also set a distinct Meteor.settings.packages['ddp-server'].uws.port per process.
+# See docs/Platforms/FOSS/Docker/Meteor3/multitenancy.md
+DESCRIPTION_DDP_TRANSPORT="DDP_TRANSPORT. Default: 'uws'. Alternative for maximum proxy compatibility: 'sockjs'"
+DEFAULT_DDP_TRANSPORT="uws"
 KEY_DDP_TRANSPORT='ddp-transport'
 #-----------------------------------------------------------------
 # ==== AWS S3 FOR FILES ====

--- a/start-wekan.bat
+++ b/start-wekan.bat
@@ -66,12 +66,12 @@ REM # https://github.com/meteor/meteor/blob/release-3.5/v3-docs/docs/performance
 REM # https://github.com/wekan/wekan/issues/6307#issuecomment-4299349231
 REM # SET METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
 IF /I "%USE_CHANGE_STREAMS%"=="true" (
-   SET METEOR_REACTIVITY_ORDER=oplog,polling
+   SET METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
 ) ELSE (
    SET METEOR_REACTIVITY_ORDER=polling
 )
-SET DDP_TRANSPORT=sockjs
-REM #   REM # SET DDP_TRANSPORT=uws
+SET DDP_TRANSPORT=uws
+REM #   REM # SET DDP_TRANSPORT=sockjs
 
 REM # Writable path required to exist and be writable for attachments to migrate and work correctly
 SET WRITABLE_PATH=..

--- a/start-wekan.sh
+++ b/start-wekan.sh
@@ -40,9 +40,9 @@
       # https://github.com/wekan/wekan/issues/6307#issuecomment-4299349231
       # Later change to: METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
       if [ "$USE_CHANGE_STREAMS" = "true" ]; then
-          export METEOR_REACTIVITY_ORDER=oplog,polling
-          export DDP_TRANSPORT=sockjs
-          #export DDP_TRANSPORT=uws
+          export METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling
+          export DDP_TRANSPORT=uws
+          #export DDP_TRANSPORT=sockjs
       else
           export METEOR_REACTIVITY_ORDER=polling
       fi


### PR DESCRIPTION
## Summary

Meteor 3.5-beta.12 ships the fix for the multi-process `uws` transport
bug Wekan worked around in `7b88f4c21` ([meteor/meteor#14425][m-pr]).
With that fix in place, `DDP_TRANSPORT=uws` +
`METEOR_REACTIVITY_ORDER=changeStreams,oplog,polling` is once again
the recommended default for performance.

This PR:

1. Restores `uws` + `changeStreams,oplog,polling` as the active env
   defaults in the four files `7b88f4c21` touched.
2. Adds `docker-compose-multitenancy.yml`, a self-documenting example
   for operators who want to run several Wekan tenants on one host
   with `uws` + `changeStreams`.
3. Rewrites `docs/Platforms/FOSS/Docker/Meteor3/multitenancy.md` as
   feature docs (two supported topologies, how to configure each),
   replacing the previous bug-narrative content.

Single-domain / single-process Wekan deployments need no change to
their existing setup — the new defaults are faster, but functionally
compatible with the previous ones. Multi-tenant deployments running
on one host with `network_mode: "host"` (or any setup that shares
one kernel netns) now need one extra line per tenant — see the
Migration notes below.

## What's changed

### Env defaults restored to `uws` + `changeStreams,oplog,polling`

| File | Change |
|------|--------|
| `docker-compose.yml` | `DDP_TRANSPORT=sockjs` → `uws`, `METEOR_REACTIVITY_ORDER=oplog,polling` → `changeStreams,oplog,polling` (commented alternative swapped) |
| `start-wekan.sh` | Same flip inside the `USE_CHANGE_STREAMS=true` branch |
| `start-wekan.bat` | Same flip in the Windows branch |
| `snap-src/bin/config` | `DEFAULT_DDP_TRANSPORT="uws"`, `DEFAULT_METEOR_REACTIVITY_ORDER="changeStreams,oplog,polling"`; descriptions updated to point at `multitenancy.md` when per-process `uws.port` is needed |

### New example: `docker-compose-multitenancy.yml`

Follows the same naming/format pattern as `docker-compose-ferretdb.yml`.
Boots:

- A shared `mongo:7` replica set on `127.0.0.1:27017` (initialised
  automatically by the entrypoint).
- Two `wekan-tenant{1,2}` services with `network_mode: "host"`,
  distinct public `PORT` (8081 / 8082), distinct MongoDB database
  (`wekan_tenant1` / `wekan_tenant2`), and **distinct internal
  `uws.port`** declared via `METEOR_SETTINGS` (5001 / 5002).
- Header comment explaining the why and how to add more tenants.
- Footer comment with the `/proc/net/tcp` verification command.

cc: @xet7 @harryadel 
