### PR TITLE
Fix #5804: REST API returns HTTP 400/404 instead of 500 for invalid requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,22 @@ Versions:
 - WeKan 8.00-8.06 had wrong raw database directory setting /var/snap/wekan/common/wekan and some cards were not visible,
   it was fixed at WeKan 8.07 where database directory is back to /var/snap/wekan/common and all cards are visible.
 
+# Upcoming WeKan ® release
+
+This release fixes the following bugs:
+
+- [Fixed REST API returning HTTP 500 with a stack trace for an invalid request](https://github.com/wekan/wekan/issues/5804),
+  [#5804](https://github.com/wekan/wekan/issues/5804): posting a comment without the required `comment` parameter (or
+  to a board that does not exist) returned an HTTP 500 error page. The schema-validation error thrown on insert is a
+  circular object (`SimpleSchemaValidationContext` → `SimpleSchema` → …), and serializing it crashed the response
+  writer (`Converting circular structure to JSON`). Now: the `comment` parameter is validated and a missing/empty one
+  returns **HTTP 400**; an unknown board returns **HTTP 404** (the board-access checks no longer dereference
+  `board.members` of a non-existent board); the JSON response writer is crash-proof (falls back to a safe
+  `{ "error": … }` payload instead of throwing); and REST comment errors now use their real status code instead of
+  `200`. New unit tests in `server/lib/tests/apiResponseHelpers.tests.js`.
+
+Thanks to GitHub user Atry for reporting.
+
 # v9.65 2026-06-20 WeKan ® release
 
 This release adds the following updates:

--- a/server/apiMiddleware.js
+++ b/server/apiMiddleware.js
@@ -6,6 +6,7 @@ const { Meteor } = require('meteor/meteor');
 const { Accounts } = require('meteor/accounts-base');
 const { WebApp } = require('meteor/webapp');
 const bodyParser = require('body-parser');
+const { safeJsonStringify } = require('/server/lib/apiResponseHelpers');
 
 // ---------------------------------------------------------------------------
 // 1. Body parsing (previously registered by json-routes)
@@ -92,7 +93,10 @@ function sendJsonResult(res, options) {
     const shouldPrettyPrint = process.env.NODE_ENV === 'development';
     const spacer = shouldPrettyPrint ? 2 : null;
     res.setHeader('Content-Type', 'application/json');
-    res.write(JSON.stringify(options.data, null, spacer));
+    // Use a crash-proof serializer: some error payloads (e.g. a circular
+    // SimpleSchema validation error) would otherwise throw inside
+    // JSON.stringify and surface as a generic HTTP 500. See #5804.
+    res.write(safeJsonStringify(options.data, spacer));
   }
 
   res.end();

--- a/server/authentication.js
+++ b/server/authentication.js
@@ -43,6 +43,7 @@ export const Authentication = {
   async checkBoardAccess(userId, boardId) {
     Authentication.checkLoggedIn(userId);
     const board = await ReactiveCache.getBoard(boardId);
+    Authentication.checkBoardExists(board);
     const normalAccess = board.members.some(e => e.userId === userId && e.isActive && !e.isNoComments && !e.isCommentOnly && !e.isWorker);
     await Authentication.checkAdminOrCondition(userId, normalAccess);
   },
@@ -51,6 +52,7 @@ export const Authentication = {
   async checkBoardWriteAccess(userId, boardId) {
     Authentication.checkLoggedIn(userId);
     const board = await ReactiveCache.getBoard(boardId);
+    Authentication.checkBoardExists(board);
     const writeAccess = board.members.some(e => e.userId === userId && e.isActive && !e.isNoComments && !e.isCommentOnly && !e.isWorker && !e.isReadOnly && !e.isReadAssignedOnly);
     await Authentication.checkAdminOrCondition(userId, writeAccess);
   },
@@ -59,8 +61,20 @@ export const Authentication = {
   async checkBoardAdmin(userId, boardId) {
     Authentication.checkLoggedIn(userId);
     const board = await ReactiveCache.getBoard(boardId);
+    Authentication.checkBoardExists(board);
     const adminAccess = board.members.some(e => e.userId === userId && e.isActive && e.isAdmin);
     await Authentication.checkAdminOrCondition(userId, adminAccess);
+  },
+
+  // Helper function. Throws a 404 error when the board does not exist, so REST
+  // handlers return HTTP 404 instead of crashing on `board.members` of an
+  // undefined board (which surfaced as a generic HTTP 500). See #5804.
+  checkBoardExists(board) {
+    if (!board) {
+      const error = new Meteor.Error('NotFound', 'Board not found');
+      error.statusCode = 404;
+      throw error;
+    }
   },
 };
 

--- a/server/lib/apiResponseHelpers.js
+++ b/server/lib/apiResponseHelpers.js
@@ -1,0 +1,108 @@
+// Pure, Meteor-free helpers behind the REST API response/error handling fixes.
+// Kept dependency-free so they can be unit-tested standalone (mocha + chai)
+// without booting Meteor.
+//
+//   #5804 The REST API returned an HTTP 500 with a raw stack trace when a
+//         request was invalid (e.g. POST .../comments without a `comment`
+//         parameter, or against a board that does not exist):
+//
+//           - The schema validation error thrown on insert is a circular
+//             object (SimpleSchemaValidationContext -> SimpleSchema -> ...).
+//             Passing it to JSON.stringify threw "Converting circular
+//             structure to JSON" *inside* the response writer, which bubbled
+//             up as a generic HTTP 500 page.
+//           - Missing required parameters should be reported as HTTP 400, and
+//             auth/lookup failures with their own status code, not 500.
+//
+// These helpers make response serialization crash-proof and map errors to a
+// sensible HTTP status code.
+
+/**
+ * Extract a short, human-readable message from an arbitrary value (typically an
+ * Error / Meteor.Error / SimpleSchema validation error). Never throws and
+ * always returns a string, even for circular or exotic objects.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+export function extractErrorMessage(value) {
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  // Meteor.Error uses `reason`; native errors use `message`; some carry `error`.
+  const message = value.reason || value.message || value.error;
+  if (typeof message === 'string' && message.length > 0) {
+    return message;
+  }
+  try {
+    return String(value);
+  } catch (e) {
+    return 'Unknown error';
+  }
+}
+
+/**
+ * Serialize `data` to a JSON string that is safe to send as a response body.
+ * Falls back to a minimal `{ "error": <message> }` payload when the value
+ * cannot be serialized (for example a circular SimpleSchema validation error),
+ * so the response never crashes the request handler with an HTTP 500.
+ *
+ * @param {*} data
+ * @param {(number|null)} [spacer] indentation passed through to JSON.stringify
+ * @returns {string}
+ */
+export function safeJsonStringify(data, spacer) {
+  const space = spacer === undefined ? null : spacer;
+  try {
+    return JSON.stringify(data, null, space);
+  } catch (err) {
+    return JSON.stringify({ error: extractErrorMessage(data) }, null, space);
+  }
+}
+
+/**
+ * Map an error thrown inside a REST handler to an HTTP status code. Honours an
+ * explicit numeric `statusCode` (set by the Authentication helpers: 401/403),
+ * recognises a few well-known Meteor.Error names, and otherwise defaults to
+ * 500 (a genuine server error).
+ *
+ * @param {*} error
+ * @returns {number}
+ */
+export function httpStatusForError(error) {
+  if (error && typeof error.statusCode === 'number') {
+    return error.statusCode;
+  }
+  const name = error && (error.error || error.errorType || error.name);
+  switch (name) {
+    case 'Unauthorized':
+      return 401;
+    case 'Forbidden':
+      return 403;
+    case 'NotFound':
+      return 404;
+    default:
+      return 500;
+  }
+}
+
+/**
+ * Validate the body of a "create comment" REST request. The CardComments schema
+ * requires `text` to be a non-empty String; without this guard a missing
+ * `comment` parameter reaches the insert and throws a circular validation error
+ * that previously surfaced as an HTTP 500 (#5804).
+ *
+ * @param {object} body the request body
+ * @returns {{ valid: boolean, comment?: string, error?: string }}
+ */
+export function validateCommentBody(body) {
+  const comment =
+    body && typeof body.comment === 'string' ? body.comment.trim() : '';
+  if (comment === '') {
+    return { valid: false, error: 'Missing required parameter: comment' };
+  }
+  return { valid: true, comment };
+}

--- a/server/lib/tests/apiResponseHelpers.tests.js
+++ b/server/lib/tests/apiResponseHelpers.tests.js
@@ -1,0 +1,129 @@
+/* eslint-env mocha */
+import { expect } from 'chai';
+import {
+  extractErrorMessage,
+  safeJsonStringify,
+  httpStatusForError,
+  validateCommentBody,
+} from '../apiResponseHelpers';
+
+/**
+ * Unit tests for the pure helpers behind the REST API error-handling fix:
+ *
+ *   #5804 HTTP 500 error when sending an invalid `application/json` request,
+ *         should instead return HTTP 400.
+ *
+ * The helpers are Meteor-free so these tests run standalone (mocha + chai).
+ */
+describe('REST API response helpers (#5804)', function() {
+  // A SimpleSchema validation error is circular: a validation context points
+  // back to its schema, which points back to its contexts. This is the exact
+  // shape that previously crashed JSON.stringify and surfaced as HTTP 500.
+  function makeCircularValidationError() {
+    const schema = { name: 'SimpleSchema' };
+    const context = { name: 'SimpleSchemaValidationContext', _simpleSchema: schema };
+    schema._validationContexts = { default: context };
+    const error = new Error('failed validation');
+    error.reason = 'Text is required';
+    error._validationContexts = { default: context };
+    return error;
+  }
+
+  describe('extractErrorMessage', function() {
+    it('returns a Meteor.Error reason', function() {
+      expect(extractErrorMessage({ reason: 'Unauthorized' })).to.equal('Unauthorized');
+    });
+
+    it('returns a native Error message', function() {
+      expect(extractErrorMessage(new Error('boom'))).to.equal('boom');
+    });
+
+    it('prefers reason over message', function() {
+      const e = new Error('low level');
+      e.reason = 'friendly';
+      expect(extractErrorMessage(e)).to.equal('friendly');
+    });
+
+    it('passes a plain string through', function() {
+      expect(extractErrorMessage('just text')).to.equal('just text');
+    });
+
+    it('is null / undefined safe', function() {
+      expect(extractErrorMessage(null)).to.equal('null');
+      expect(extractErrorMessage(undefined)).to.equal('undefined');
+    });
+
+    it('never throws on a circular validation error', function() {
+      expect(() => extractErrorMessage(makeCircularValidationError())).to.not.throw();
+      expect(extractErrorMessage(makeCircularValidationError())).to.equal('Text is required');
+    });
+  });
+
+  describe('safeJsonStringify', function() {
+    it('serializes ordinary data like JSON.stringify', function() {
+      expect(safeJsonStringify({ _id: 'abc' })).to.equal('{"_id":"abc"}');
+    });
+
+    it('honours the spacer argument', function() {
+      expect(safeJsonStringify({ a: 1 }, 2)).to.equal('{\n  "a": 1\n}');
+    });
+
+    it('does NOT throw on a circular structure (regression for the HTTP 500)', function() {
+      const circular = {};
+      circular.self = circular;
+      expect(() => safeJsonStringify(circular)).to.not.throw();
+    });
+
+    it('falls back to an { error } payload for a circular validation error', function() {
+      const json = safeJsonStringify(makeCircularValidationError());
+      expect(JSON.parse(json)).to.deep.equal({ error: 'Text is required' });
+    });
+  });
+
+  describe('httpStatusForError', function() {
+    it('uses an explicit numeric statusCode', function() {
+      expect(httpStatusForError({ statusCode: 401 })).to.equal(401);
+      expect(httpStatusForError({ statusCode: 403 })).to.equal(403);
+      expect(httpStatusForError({ statusCode: 404 })).to.equal(404);
+    });
+
+    it('maps well-known Meteor.Error names', function() {
+      expect(httpStatusForError({ error: 'Unauthorized' })).to.equal(401);
+      expect(httpStatusForError({ error: 'Forbidden' })).to.equal(403);
+      expect(httpStatusForError({ error: 'NotFound' })).to.equal(404);
+    });
+
+    it('defaults to 500 for an unknown error', function() {
+      expect(httpStatusForError(new Error('boom'))).to.equal(500);
+      expect(httpStatusForError(null)).to.equal(500);
+      expect(httpStatusForError(undefined)).to.equal(500);
+    });
+  });
+
+  describe('validateCommentBody', function() {
+    it('accepts a non-empty comment and trims it', function() {
+      const r = validateCommentBody({ comment: '  hello  ' });
+      expect(r.valid).to.equal(true);
+      expect(r.comment).to.equal('hello');
+    });
+
+    it('rejects a missing comment (the #5804 repro: no body sent)', function() {
+      const r = validateCommentBody(undefined);
+      expect(r.valid).to.equal(false);
+      expect(r.error).to.match(/comment/i);
+    });
+
+    it('rejects an empty body object', function() {
+      expect(validateCommentBody({}).valid).to.equal(false);
+    });
+
+    it('rejects a whitespace-only comment', function() {
+      expect(validateCommentBody({ comment: '   ' }).valid).to.equal(false);
+    });
+
+    it('rejects a non-string comment', function() {
+      expect(validateCommentBody({ comment: 42 }).valid).to.equal(false);
+      expect(validateCommentBody({ comment: null }).valid).to.equal(false);
+    });
+  });
+});

--- a/server/lib/tests/index.js
+++ b/server/lib/tests/index.js
@@ -40,3 +40,4 @@ import './subtaskSettings.tests';
 import './subtaskCreation.tests';
 import './deleteWebhookActivity.tests';
 import './webhookNonBlocking.tests';
+import './apiResponseHelpers.tests';

--- a/server/models/cardComments.js
+++ b/server/models/cardComments.js
@@ -2,6 +2,11 @@ import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
 import { Authentication } from '/server/authentication';
 import { sendJsonResult } from '/server/apiMiddleware';
+import {
+  validateCommentBody,
+  httpStatusForError,
+  extractErrorMessage,
+} from '/server/lib/apiResponseHelpers';
 import { ReactiveCache } from '/imports/reactiveCache';
 import Activities from '/models/activities';
 import CardComments from '/models/cardComments';
@@ -93,8 +98,8 @@ WebApp.handlers.get('/api/boards/:boardId/cards/:cardId/comments', async functio
     });
   } catch (error) {
     sendJsonResult(res, {
-      code: 200,
-      data: error,
+      code: httpStatusForError(error),
+      data: { error: extractErrorMessage(error) },
     });
   }
 });
@@ -117,8 +122,8 @@ WebApp.handlers.get(
       });
     } catch (error) {
       sendJsonResult(res, {
-        code: 200,
-        data: error,
+        code: httpStatusForError(error),
+        data: { error: extractErrorMessage(error) },
       });
     }
   },
@@ -129,9 +134,22 @@ WebApp.handlers.post('/api/boards/:boardId/cards/:cardId/comments', async functi
     const paramBoardId = req.params.boardId;
     const paramCardId = req.params.cardId;
     await Authentication.checkBoardAccess(req.userId, paramBoardId);
+
+    // Validate the required `comment` parameter before inserting. Without this
+    // an empty/missing comment reaches the schema-validated insert and throws a
+    // circular validation error that previously surfaced as HTTP 500. See #5804.
+    const validation = validateCommentBody(req.body);
+    if (!validation.valid) {
+      sendJsonResult(res, {
+        code: 400,
+        data: { error: validation.error },
+      });
+      return;
+    }
+
     const id = await CardComments.direct.insertAsync({
       userId: req.userId,
-      text: req.body.comment,
+      text: validation.comment,
       cardId: paramCardId,
       boardId: paramBoardId,
     });
@@ -151,8 +169,8 @@ WebApp.handlers.post('/api/boards/:boardId/cards/:cardId/comments', async functi
     await commentCreation(req.userId, cardComment);
   } catch (error) {
     sendJsonResult(res, {
-      code: 200,
-      data: error,
+      code: httpStatusForError(error),
+      data: { error: extractErrorMessage(error) },
     });
   }
 });
@@ -178,8 +196,8 @@ WebApp.handlers.delete(
       });
     } catch (error) {
       sendJsonResult(res, {
-        code: 200,
-        data: error,
+        code: httpStatusForError(error),
+        data: { error: extractErrorMessage(error) },
       });
     }
   },


### PR DESCRIPTION
## Problem (#5804)

Posting a comment without the required `comment` parameter (or to a board that does not exist) returned an **HTTP 500** error page:

```
TypeError: Converting circular structure to JSON
--> starting at object with constructor 'SimpleSchemaValidationContext'
```

Root causes:
- The schema-validation error thrown on insert is a **circular** object; serializing it crashed the JSON response writer into a generic 500.
- A non-existent board caused a `TypeError` on `board.members` inside the board-access checks (also a 500).
- The REST comment handler had no validation for the required `comment` parameter, and its `catch` blocks returned `code: 200` with the raw error.

## Fix

- New Meteor-free helpers (`server/lib/apiResponseHelpers.js`):
  - `safeJsonStringify` — crash-proof; falls back to a `{ "error": … }` payload on circular/unserializable data.
  - `httpStatusForError` — maps an error to 401/403/404/500 (honours `error.statusCode`).
  - `validateCommentBody` — **HTTP 400** when `comment` is missing/empty.
  - `extractErrorMessage` — safe message extraction.
- `sendJsonResult` now serializes via `safeJsonStringify`.
- `checkBoardAccess` / `checkBoardWriteAccess` / `checkBoardAdmin` throw **HTTP 404** instead of a `TypeError` when the board does not exist.
- POST comment validates input; REST comment `catch` blocks return the real status code.

## Tests

18 new standalone unit tests in `server/lib/tests/apiResponseHelpers.tests.js` (mocha + chai), registered in the server test index. All passing.

Fixes #5804

🤖 Generated with [Claude Code](https://claude.com/claude-code)