### PR TITLE
Fix #5462: read-only members no longer trigger 403 Access denied when reordering lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This release fixes the following bugs:
   shim (`client/lib/bsonBrowserShim.js`, imported first in `client/main.js`) that gives the browser `process` a no-op
   `getBuiltinModule`, so bson takes its intended `?? {}` fallback. New unit tests
   (`client/lib/tests/bsonBrowserShim.tests.js`); also hardened the #5686 Playwright spec to run against a rendering
-  board.
+  board. ([PR #6410](https://github.com/wekan/wekan/pull/6410))
 
 - [Fixed REST API returning HTTP 500 with a stack trace for an invalid request](https://github.com/wekan/wekan/pull/6406),
   [#5804](https://github.com/wekan/wekan/issues/5804): posting a comment without the required `comment` parameter (or
@@ -67,7 +67,7 @@ This release fixes the following bugs:
   `Utils.canModifyBoard()`; it now is, consistent with the other two, plus a defense-in-depth guard so a logged-in
   user without write access can never persist a reorder (anonymous public-board reordering via localStorage is
   unaffected). The server already enforced this; the fix stops the unauthorized drag and the console error. New
-  Playwright regression test in `tests/playwright/specs/35-list-sort-permissions.e2e.js`.
+  Playwright regression test in `tests/playwright/specs/35-list-sort-permissions.e2e.js`. ([PR #6408](https://github.com/wekan/wekan/pull/6408))
 
 Thanks to GitHub users Atry, mueller-ma and liferadioat for reporting.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,16 @@ This release fixes the following bugs:
   `client/lib/cardCloseGuard.js`), so a deliberate click on empty board space still closes the card. New unit
   tests in `client/lib/tests/cardCloseGuard.tests.js` and a Playwright regression test in
   `tests/playwright/specs/34-checklist-text-selection.e2e.js`. ([PR #6407](https://github.com/wekan/wekan/pull/6407))
+- [Fixed list reordering throwing `403 Access denied` for read-only members](https://github.com/wekan/wekan/issues/5462),
+  [#5462](https://github.com/wekan/wekan/issues/5462): read-only / comment-only board members could still drag-reorder
+  lists, which fired a server write that allow/deny rejected with `403 Access denied` (the list then snapped back). Of
+  the three list jQuery-UI sortables in `client/components/swimlanes/swimlanes.js`, one was not gated on
+  `Utils.canModifyBoard()`; it now is, consistent with the other two, plus a defense-in-depth guard so a logged-in
+  user without write access can never persist a reorder (anonymous public-board reordering via localStorage is
+  unaffected). The server already enforced this; the fix stops the unauthorized drag and the console error. New
+  Playwright regression test in `tests/playwright/specs/35-list-sort-permissions.e2e.js`.
 
-Thanks to GitHub users Atry and mueller-ma for reporting.
+Thanks to GitHub users Atry, mueller-ma and liferadioat for reporting.
 
 # v9.65 2026-06-20 WeKan ® release
 

--- a/client/components/swimlanes/swimlanes.js
+++ b/client/components/swimlanes/swimlanes.js
@@ -10,6 +10,12 @@ import { defaultSwimlaneIdForBoard } from '/client/components/lists/listAddHelpe
 const { calculateIndex } = Utils;
 
 function saveSorting(ui) {
+  // #5462 (defense in depth): a logged-in user without write access must never
+  // persist a list reorder, even if a sortable was left enabled. Anonymous
+  // users on public boards fall through to the localStorage path below.
+  if (Meteor.userId() && !Utils.canModifyBoard()) {
+    return;
+  }
   // To attribute the new index number, we need to get the DOM element
   // of the previous and the following list -- if any.
   const prevListDom = ui.item.prev('.js-list').get(0);
@@ -322,6 +328,11 @@ function initSortable(boardComponent, $listsDom) {
       distance: 3,
       forcePlaceholderSize: true,
       cursor: 'move',
+      // #5462: only users with write access may reorder lists. Without this,
+      // read-only / comment-only members could drag lists, firing a server
+      // write that is denied with `403 Access denied` (and the list snaps
+      // back). The two other list sortables already gate on canModifyBoard().
+      disabled: !Utils.canModifyBoard(),
       start(evt, ui) {
         ui.helper.css('z-index', 1000);
         ui.placeholder.height(ui.helper.height());

--- a/tests/playwright/specs/35-list-sort-permissions.e2e.js
+++ b/tests/playwright/specs/35-list-sort-permissions.e2e.js
@@ -1,0 +1,127 @@
+'use strict';
+
+/**
+ * Spec 35 — List reorder permissions (#5462)
+ *
+ * "Sorting lists is not working" with `r {error: 403, reason: 'Access denied'}`
+ * in the browser console. Root cause: read-only / comment-only board members
+ * could still drag-reorder lists (one of the three jQuery-UI sortables in
+ * client/components/swimlanes/swimlanes.js was not gated on
+ * `Utils.canModifyBoard()`), which fires a server write that allow/deny then
+ * rejects with HTTP 403 "Access denied" — so the list snaps back and the
+ * console shows the error.
+ *
+ * The data-integrity boundary is enforced server-side and is exercised here
+ * directly over DDP (so it runs even when the board view is not rendering):
+ *   - a read-only member's list-reorder is rejected and the stored order is
+ *     unchanged, via BOTH the `updateListSort` method and a direct collection
+ *     write (the exact 403 the reporter saw);
+ *   - a write-access member CAN reorder and it persists (regression guard for
+ *     the related #5997 "order not persisted").
+ */
+
+const { test, expect } = require('../fixtures');
+const db = require('../helpers/db');
+const { loginWithToken } = require('../helpers/auth');
+
+// Run a Meteor method/DDP call in the page context and return {err, result}.
+async function ddp(page, name, args) {
+  return page.evaluate(
+    ({ name, args }) =>
+      new Promise(resolve => {
+        // eslint-disable-next-line no-undef
+        Meteor.apply(name, args, (err, result) =>
+          resolve({
+            err: err
+              ? { error: err.error, reason: err.reason, message: err.message }
+              : null,
+            result,
+          }),
+        );
+      }),
+    { name, args },
+  );
+}
+
+function addMember(boardId, userId, flags) {
+  db.updateOne(
+    'boards',
+    { _id: boardId },
+    {
+      $push: {
+        members: {
+          userId,
+          isAdmin: false,
+          isActive: true,
+          isNoComments: false,
+          isCommentOnly: false,
+          isWorker: false,
+          isReadOnly: false,
+          isReadAssignedOnly: false,
+          ...flags,
+        },
+      },
+    },
+  );
+}
+
+test.describe('List reorder permissions (#5462)', () => {
+  test('read-only member cannot reorder lists; write member can (#5462 / #5997)', async ({
+    browser,
+    user, // board owner (write access)
+    user2, // will be the read-only member
+    board,
+  }) => {
+    addMember(board.boardId, user2.id, { isReadOnly: true });
+
+    const targetList = board.listIds[2];
+    const originalSort = db.findOne('lists', { _id: targetList }, { sort: 1 }).sort;
+
+    // --- Read-only member: both write paths must be denied, order unchanged ---
+    const roCtx = await browser.newContext();
+    const roPage = await roCtx.newPage();
+    await loginWithToken(roPage, user2.id, user2.token);
+
+    const roMethod = await ddp(roPage, 'updateListSort', [
+      targetList,
+      board.boardId,
+      { sort: -999 },
+    ]);
+    expect(roMethod.err, 'read-only updateListSort must be rejected').not.toBeNull();
+    expect(roMethod.err.error).toBe('permission-denied');
+
+    const roDirect = await ddp(roPage, '/lists/update', [
+      { _id: targetList },
+      { $set: { sort: -999 } },
+    ]);
+    expect(roDirect.err, 'read-only direct list write must be rejected').not.toBeNull();
+    // This is the exact error from the #5462 report.
+    expect(roDirect.err.error).toBe(403);
+    expect(roDirect.err.reason).toBe('Access denied');
+
+    expect(
+      db.findOne('lists', { _id: targetList }, { sort: 1 }).sort,
+      'stored list order must be unchanged after denied attempts',
+    ).toBe(originalSort);
+
+    await roCtx.close();
+
+    // --- Write-access owner: reorder succeeds and persists (#5997) ---
+    const okCtx = await browser.newContext();
+    const okPage = await okCtx.newPage();
+    await loginWithToken(okPage, user.id, user.token);
+
+    const okMethod = await ddp(okPage, 'updateListSort', [
+      targetList,
+      board.boardId,
+      { sort: -3 },
+    ]);
+    expect(okMethod.err, 'owner updateListSort must succeed').toBeNull();
+    expect(
+      db.findOne('lists', { _id: targetList }, { sort: 1 }).sort,
+      'new list order must persist to the database',
+    ).toBe(-3);
+
+    await okCtx.close();
+  });
+});


### PR DESCRIPTION
## Problem (#5462)

> Sorting of lists is not working. Chrome console: `r {error: 403, reason: 'Access denied', ...}`

Reproduced live (over DDP): a **read-only** (or comment-only) board member attempting a list reorder triggers a direct collection write that allow/deny rejects with exactly `{error: 403, reason: 'Access denied'}` — the list snaps back and the console logs the error. A normal write-access member reorders fine.

## Root cause

`client/components/swimlanes/swimlanes.js` initialises **three** jQuery-UI list sortables. Two of them gate on `disabled: !Utils.canModifyBoard()` (lines ~435 and ~922), but the third (the main `initSortable`, ~line 335) did **not** — so users without write access could still start a list drag, firing the denied server write.

`Utils.canModifyBoard()` already returns false for read-only / comment-only / worker / read-assigned members, so the gate just needed to be applied consistently.

## Fix

- Add the missing `disabled: !Utils.canModifyBoard()` to the third sortable.
- Add a defense-in-depth guard at the top of `saveSorting()`: a **logged-in** user without write access can never persist a reorder. Anonymous public-board reordering (which uses the localStorage path) is unaffected.

The server already enforced the permission (this is not a security fix); the change stops the unauthorized drag and the resulting 403 noise / snap-back.

## Tests

New Playwright regression spec `tests/playwright/specs/35-list-sort-permissions.e2e.js`, run against a live instance over DDP (so it does not depend on board rendering). It asserts:
- read-only member → `updateListSort` rejected (`permission-denied`) **and** direct `/lists/update` rejected with the exact `403 / Access denied`; stored order unchanged;
- write-access member → reorder succeeds and **persists** to the DB (also a regression guard for #5997).

**Verified passing** against the running instance (`1 passed`).

Fixes #5462

🤖 Generated with [Claude Code](https://claude.com/claude-code)