### PR TITLE
Fix LDAP group filters by removing redundant backslash escaping

### DIFF
--- a/packages/wekan-ldap/server/ldap.js
+++ b/packages/wekan-ldap/server/ldap.js
@@ -420,7 +420,7 @@ export default class LDAP {
     // Escape the username to prevent LDAP injection
     const escapedUsername = escapedToHex(username);
     const searchOptions = {
-      filter: filter.join('').replace(/#{username}/g, escapedUsername).replace(/\\/g, "\\\\"),
+      filter: filter.join('').replace(/#{username}/g, escapedUsername),
       scope : 'sub',
     };
 
@@ -470,7 +470,7 @@ export default class LDAP {
     // Escape the username to prevent LDAP injection
     const escapedUsername = escapedToHex(username);
     const searchOptions = {
-      filter: filter.join('').replace(/#{username}/g, escapedUsername).replace(/\\/g, "\\\\"),
+      filter: filter.join('').replace(/#{username}/g, escapedUsername),
       scope : 'sub',
     };
 


### PR DESCRIPTION
The LDAP filter string was being post-processed with an additional backslash replacement after username escaping was already applied.
That caused double-escaping in the final filter value and breaks expected LDAP matching.

Changes

- Removed the extra backslash replacement in LDAP filter construction at ldap.js
- Kept existing username escaping via escapedToHex(username).
- No behavior changes outside LDAP group filter generation.

Tested on Corporate prodcution LDAP

Related Issue:
Fixes #6460 