### PR TITLE
AI: Fix card attachment filename helper bootstrap (#6493)

### DIFF
--- a/client/features/main.js
+++ b/client/features/main.js
@@ -38,6 +38,7 @@ import '/client/components/main/layouts.js';
 import '/client/components/main/myCards.js';
 import '/client/components/main/popup.js';
 import '/client/components/main/recoveryMaintenance.js';
+import '/client/components/main/safeFilename.js';
 import '/client/components/main/spinner.js';
 import '/client/components/main/support.js';
 

--- a/tests/fileNameDisplay.test.cjs
+++ b/tests/fileNameDisplay.test.cjs
@@ -120,6 +120,9 @@ check('global filename helpers registered and used across the UI', () => {
   const js = read('client/components/main/safeFilename.js');
   assert.ok(/registerHelper\('cleanFilename'/.test(js) && /registerHelper\('downloadFilename'/.test(js),
     'cleanFilename + downloadFilename helpers registered');
+  const clientMain = read('client/features/main.js');
+  assert.ok(/import ['"]\/client\/components\/main\/safeFilename\.js['"]/.test(clientMain),
+    'filename helpers loaded by the explicit client bootstrap');
   const cards = read('client/components/cards/attachments.jade');
   assert.ok(/\{\{ cleanFilename name \}\}/.test(cards), 'card attachment name uses cleanFilename');
   assert.ok(/download="\{\{downloadFilename name\}\}"/.test(cards), 'download uses the clean name');


### PR DESCRIPTION
**Content warning:** This pull request is _mostly_ AI generated.  While I did test the code I am not capable of fully validate it.  
_Feel free to drop it if it's not salvageable._

Load safeFilename.js from the explicit client feature entry point so Blaze registers cleanFilename and downloadFilename before attachment galleries or the admin files report render. Without this import, opening any card with an attachment aborts with "No such function: cleanFilename".

Extend the filename display wiring test to verify that the helper module remains reachable from the client bootstrap, rather than only checking that its source and template references exist.

Fixes #6493.

Assisted-by: Codex:gpt-5.6  
Tested-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>  
Signed-off-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>