### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/docs/Platforms/FOSS/Platforms.md
+++ b/docs/Platforms/FOSS/Platforms.md
@@ -44,6 +44,7 @@ Only newest Wekan is supported. Please check you are running newest Wekan, becau
 ## Production: SaaS, Wekan ready paid services, just start using.
 
 * [Wekan Team](https://wekan.fi/commercial-support/) - Snap Gantt Gpl Automatic Updates. Supports Wekan maintenance and development.
+* [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/wekan) - One-click managed Wekan: storage, backups, email and a free subdomain included. A share of every subscription goes back to Wekan.
 * [Cloudron](../Propietary/Cloud/Cloudron/Cloudron.md) - Standalone Wekan
 * [PikaPods](../Propietary/Cloud/PikaPods/PikaPods.md) - Standalone Wekan with managed updates and backups.
 * [Scalingo](../Propietary/Cloud/Scalingo.md) - Standalone Wekan


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added
Wekan to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the "Production:
SaaS, Wekan ready paid services" list in docs/Platforms/FOSS/Platforms.md (links to
https://zenith.hosting/host/wekan).

one line added, docs only, nothing else touched. no tests or build affected.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting
