### PR TITLE
Add Apple Glass Pastel board theme

### DIFF
--- a/client/components/boards/boardColors.css
+++ b/client/components/boards/boardColors.css
@@ -1458,6 +1458,312 @@ THEME - Corteza
 /* === END Corteza THEME === */
 
 /* ===============
+THEME - Apple Glass Pastel
+=================*/
+
+.board-color-appleglasspastel {
+  background:
+    radial-gradient(60% 50% at 85% 5%, rgba(255, 200, 220, 0.55), transparent 60%),
+    radial-gradient(55% 50% at 5% 25%, rgba(180, 215, 255, 0.55), transparent 65%),
+    radial-gradient(55% 50% at 95% 95%, rgba(200, 230, 255, 0.5), transparent 60%),
+    radial-gradient(70% 60% at 0% 100%, rgba(230, 215, 255, 0.5), transparent 65%),
+    linear-gradient(180deg, #f6f7fb 0%, #eef0f7 100%);
+  color: #111827;
+}
+
+.board-color-appleglasspastel#header,
+.board-color-appleglasspastel#header-quick-access,
+.board-color-appleglasspastel.sk-spinner div,
+.board-color-appleglasspastel .setting-content .content-body .side-menu ul li.active,
+.board-color-appleglasspastel .setting-content .content-body .side-menu ul li.active:hover {
+  background: #2563eb;
+  color: #fff;
+}
+
+.board-backgrounds-list .board-color-appleglasspastel.background-box,
+.public-board-row.board-color-appleglasspastel,
+.board-list .board-color-appleglasspastel a {
+  background:
+    radial-gradient(80% 70% at 80% 0%, rgba(255, 200, 220, 0.7), transparent 62%),
+    radial-gradient(70% 80% at 0% 15%, rgba(180, 215, 255, 0.75), transparent 66%),
+    radial-gradient(75% 70% at 100% 100%, rgba(230, 215, 255, 0.7), transparent 62%),
+    linear-gradient(180deg, #f6f7fb 0%, #eef0f7 100%);
+  color: #111827 !important;
+}
+
+.board-color-appleglasspastel#header-quick-access {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.board-color-appleglasspastel#header #header-main-bar,
+.board-color-appleglasspastel#header-quick-access,
+.board-color-appleglasspastel .boards-left-menu .menu-item.active a,
+.board-color-appleglasspastel .boards-left-menu .menu-item.active a:hover {
+  background: #2563eb;
+}
+
+.board-color-appleglasspastel#header ul li.current,
+.board-color-appleglasspastel#header-quick-access ul li.current {
+  border-bottom: 4px solid #dbeafe;
+}
+
+.board-color-appleglasspastel#header-quick-access #header-new-board-icon,
+.board-color-appleglasspastel#header-quick-access #header-user-bar,
+.board-color-appleglasspastel#header-quick-access ul li,
+.board-color-appleglasspastel#header-quick-access a,
+.board-color-appleglasspastel#header .board-header-btn,
+.board-color-appleglasspastel#header .board-header-btn i {
+  color: #fff;
+}
+
+.board-color-appleglasspastel#header ul li:hover,
+.board-color-appleglasspastel#header-quick-access ul li:hover,
+.board-color-appleglasspastel .board-header-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+}
+
+.board-color-appleglasspastel#header #header-main-bar .board-header-btn.emphasis {
+  background: #1e3a8a;
+  box-shadow: 0 4px 16px rgba(37, 99, 235, 0.12), 0 1px 2px rgba(0,0,0,0.04);
+}
+
+.board-color-appleglasspastel#header #header-main-bar .board-header-btn.emphasis:hover,
+.board-color-appleglasspastel#header #header-main-bar .board-header-btn.emphasis .board-header-btn-close {
+  background: #1d4ed8;
+}
+
+.board-color-appleglasspastel#header #header-main-bar .board-header-btn.emphasis:hover .board-header-btn-close {
+  background: #1e3a8a;
+}
+
+.board-color-appleglasspastel.board-wrapper {
+  background:
+    radial-gradient(60% 50% at 85% 5%, rgba(255, 200, 220, 0.55), transparent 60%),
+    radial-gradient(55% 50% at 5% 25%, rgba(180, 215, 255, 0.55), transparent 65%),
+    radial-gradient(55% 50% at 95% 95%, rgba(200, 230, 255, 0.5), transparent 60%),
+    radial-gradient(70% 60% at 0% 100%, rgba(230, 215, 255, 0.5), transparent 65%),
+    linear-gradient(180deg, #f6f7fb 0%, #eef0f7 100%);
+}
+
+.board-color-appleglasspastel .board-canvas {
+  scrollbar-color: rgba(37, 99, 235, 0.35) rgba(255, 255, 255, 0);
+  scrollbar-width: thin;
+}
+
+.board-color-appleglasspastel .swimlane {
+  background: transparent;
+}
+
+.board-color-appleglasspastel .swimlane .swimlane-header-wrap {
+  background: rgba(255, 255, 255, 0.45);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+}
+
+.board-color-appleglasspastel .swimlane-header {
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.board-color-appleglasspastel .list {
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-inline-start: none;
+  border-radius: 18px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.06);
+  color: #111827;
+  margin: 10px 0;
+  padding-bottom: 8px;
+}
+
+.board-color-appleglasspastel .list-header {
+  background: rgba(255, 255, 255, 0.45);
+  border-bottom: 1px solid rgba(229, 231, 235, 0.75);
+  border-radius: 18px 18px 0 0;
+}
+
+.board-color-appleglasspastel .list-header .list-header-name,
+.board-color-appleglasspastel .list-header .viewer,
+.board-color-appleglasspastel .minicard-title {
+  color: #0f172a;
+}
+
+.board-color-appleglasspastel .list-body {
+  margin-top: 8px;
+  padding: 11px;
+  scrollbar-color: rgba(37, 99, 235, 0.35) rgba(255, 255, 255, 0);
+  scrollbar-width: thin;
+}
+
+.board-color-appleglasspastel .minicard,
+.board-color-appleglasspastel .card-details,
+.board-color-appleglasspastel.pop-over,
+.board-color-appleglasspastel .sidebar {
+  background: rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  color: #111827;
+}
+
+.board-color-appleglasspastel .minicard {
+  border-radius: 12px;
+  padding: 10px 10px 4px 10px;
+}
+
+.board-color-appleglasspastel .minicard:hover:not(.minicard-composer),
+.board-color-appleglasspastel .is-selected .minicard,
+.board-color-appleglasspastel .draggable-hover-card .minicard {
+  background: rgba(239, 246, 255, 0.88);
+}
+
+.board-color-appleglasspastel .is-selected .minicard {
+  border-inline-start: 3px solid #2563eb;
+}
+
+.board-color-appleglasspastel .card-details {
+  border-radius: 18px;
+}
+
+.board-color-appleglasspastel .card-details-header {
+  background: rgba(239, 246, 255, 0.78);
+  border-bottom: 1px solid rgba(229, 231, 235, 0.75);
+  color: #0f172a;
+}
+
+.board-color-appleglasspastel .card-details-item-title,
+.board-color-appleglasspastel .card-details-left .viewer p,
+.board-color-appleglasspastel .activity-desc .activity-member {
+  color: #111827;
+}
+
+.board-color-appleglasspastel .quiet,
+.board-color-appleglasspastel .quiet a,
+.board-color-appleglasspastel .activity-desc,
+.board-color-appleglasspastel .sidebar-list-item-description {
+  color: #6b7280;
+}
+
+.board-color-appleglasspastel .list.list-composer,
+.board-color-appleglasspastel .list-body .open-minicard-composer,
+.board-color-appleglasspastel .list.list-composer .open-list-composer {
+  background: rgba(255, 255, 255, 0.45);
+  border-radius: 12px;
+  color: #6b7280;
+}
+
+.board-color-appleglasspastel .list-body .open-minicard-composer:hover,
+.board-color-appleglasspastel .list.list-composer .open-list-composer:hover,
+.board-color-appleglasspastel.pop-over .pop-over-list li a:not(.disabled):hover,
+.board-color-appleglasspastel .sidebar .sidebar-content .sidebar-btn:hover,
+.board-color-appleglasspastel .sidebar-list li a:hover {
+  background: rgba(219, 234, 254, 0.78);
+  color: #1e3a8a;
+}
+
+.board-color-appleglasspastel button[type=submit].primary,
+.board-color-appleglasspastel input[type=submit].primary,
+.board-color-appleglasspastel button.primary,
+.board-color-appleglasspastel input.primary,
+.board-color-appleglasspastel .sidebar .sidebar-content .sidebar-btn {
+  background: #2563eb;
+  border: 0;
+  border-radius: 999px;
+  box-shadow: 0 4px 16px rgba(37, 99, 235, 0.12), 0 1px 2px rgba(0,0,0,0.04);
+  color: #fff;
+}
+
+.board-color-appleglasspastel button[type="submit"].primary:hover,
+.board-color-appleglasspastel input[type="submit"].primary:hover,
+.board-color-appleglasspastel button.primary:hover,
+.board-color-appleglasspastel input.primary:hover {
+  background: #1d4ed8;
+  color: #fff;
+}
+
+.board-color-appleglasspastel input[type="email"],
+.board-color-appleglasspastel input[type="password"],
+.board-color-appleglasspastel input[type="text"],
+.board-color-appleglasspastel textarea,
+.board-color-appleglasspastel select {
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(229, 231, 235, 0.9);
+  border-radius: 12px;
+  color: #111827;
+}
+
+.board-color-appleglasspastel input:focus,
+.board-color-appleglasspastel textarea:focus,
+.board-color-appleglasspastel select:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.board-color-appleglasspastel .materialCheckBox.is-checked {
+  border-bottom: 2px solid #2563eb;
+  border-inline-end: 2px solid #2563eb;
+}
+
+.board-color-appleglasspastel .checklist-progress-bar {
+  background-color: #dbeafe !important;
+}
+
+.board-color-appleglasspastel .checklist-progress-bar .checklist-progress {
+  background-color: #2563eb !important;
+}
+
+.board-color-appleglasspastel .is-multiselection-active .multi-selection-checkbox.is-checked + .minicard {
+  background: #eff6ff;
+}
+
+.board-color-appleglasspastel .is-multiselection-active .multi-selection-checkbox:not(.is-checked) + .minicard:hover:not(.minicard-composer) {
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.board-color-appleglasspastel .toggle-label:after {
+  background-color: #2563eb;
+}
+
+.board-color-appleglasspastel .toggle-switch:checked ~ .toggle-label {
+  background-color: #93c5fd;
+}
+
+.board-color-appleglasspastel .toggle-switch:checked ~ .toggle-label:after {
+  background-color: #2563eb;
+}
+
+.board-color-appleglasspastel .card-date.current,
+.board-color-appleglasspastel .minicard .current {
+  background: #1f7d38;
+  color: #fff !important;
+}
+
+.board-color-appleglasspastel .card-date.due,
+.board-color-appleglasspastel .minicard .due {
+  background: #dc3545;
+  color: #fff !important;
+}
+
+.board-color-appleglasspastel .sidebar .sidebar-content {
+  scrollbar-color: rgba(37, 99, 235, 0.35) rgba(255, 255, 255, 0);
+}
+
+@media screen and (max-width: 800px) {
+  .board-color-appleglasspastel.pop-over .header {
+    background: #2563eb;
+    color: #fff;
+  }
+}
+
+/* === END Apple Glass Pastel THEME === */
+
+/* ===============
 THEME - Clear Blue
 =================*/
 

--- a/config/const.js
+++ b/config/const.js
@@ -11,6 +11,7 @@ export const ALLOWED_BOARD_COLORS = [
   'dark',
   'relax',
   'corteza',
+  'appleglasspastel',
   'clearblue',
   'cleargreen',
   'clearorange',

--- a/docs/Theme/Theme.md
+++ b/docs/Theme/Theme.md
@@ -4,11 +4,11 @@ Status: **Core implemented · picker UI design** · Owner: xet7 · Related: #577
 per-user theme), Board Settings / Change Color, Member Settings / Change Color, #5514
 (the native color-wheel `<input type="color">` already used for list colors).
 
-WeKan ships ~19 board theme colors. Many are near-duplicates that differ only by **one or
-two accent colors**; a few (`clearblue`) are **two-color "color slides"** (gradients). This
-document defines how the **Select Color** picker — used in **both** Board Settings and
-Member Settings (the global override) — is reorganized into **categories** with **two-level
-dropdowns** and **custom colors** where it makes sense.
+WeKan ships named board theme colors. Many are near-duplicates that differ only by **one
+or two accent colors**; the `clear*` themes are **two-color "color slides"** (gradients).
+This document defines how the **Select Color** picker — used in **both** Board Settings
+and Member Settings (the global override) — is reorganized into **categories** with
+**two-level dropdowns** and **custom colors** where it makes sense.
 
 ## 1. Categories
 
@@ -19,9 +19,9 @@ The colors partition into four categories (single source of truth:
 | Category | Colors | Custom colors |
 |----------|--------|---------------|
 | **flat** | belize, nephritis, pomegranate, pumpkin, wisteria, moderatepink, strongcyan, limegreen, natural | **1** (single accent) |
-| **clear** | clearblue | **2** (color slide / gradient) |
+| **clear** | clearblue, cleargreen, clearorange, clearpink, clearpurple, clearred | **2** (color slide / gradient) |
 | **dark** | midnight, dark, moderndark, exodark, cleandark | **none** (fixed) |
-| **special** | relax, corteza, modern, cleanlight | **none** (fixed) |
+| **special** | relax, corteza, appleglasspastel, modern, cleanlight | **none** (fixed) |
 
 Rationale: **flat** designs are one accent color over a flat surface, so a single custom color
 fully re-skins them. **clear** designs are a two-color gradient ("slide"), so they take two

--- a/models/lib/themeAccents.js
+++ b/models/lib/themeAccents.js
@@ -29,6 +29,7 @@ const THEME_ACCENTS = {
   dark: '#2c3e51',
   relax: '#27ae61',
   corteza: '#568ba2',
+  appleglasspastel: '#2563eb',
   // The MAIN header bar's colour. It read #2d8ce7 - the quick-access bar's
   // separate, lighter shade - because the guard that derives these matched
   // `#header-quick-access` as well as `#header`. The two bars are one colour

--- a/models/lib/themeCategories.js
+++ b/models/lib/themeCategories.js
@@ -29,7 +29,7 @@ const THEME_CATEGORIES = {
   ],
   clear: ['clearblue', 'cleargreen', 'clearorange', 'clearpink', 'clearpurple', 'clearred'],
   dark: ['midnight', 'dark', 'moderndark', 'exodark', 'cleandark'],
-  special: ['relax', 'corteza', 'modern', 'cleanlight'],
+  special: ['relax', 'corteza', 'appleglasspastel', 'modern', 'cleanlight'],
 };
 
 // 1st-level dropdown order.

--- a/models/server/ExporterExcelCard.js
+++ b/models/server/ExporterExcelCard.js
@@ -99,6 +99,7 @@ const THEME_PROGRESS_COLOR = {
   dark:        'FF2C3E51',
   relax:       'FF27AE61',
   corteza:     'FF568BA2',
+  appleglasspastel: 'FF2563EB',
   clearblue:   'FF499BEA',
   natural:     'FF596557',
   modern:      'FF2A80B8',

--- a/tests/appleGlassPastelTheme.test.cjs
+++ b/tests/appleGlassPastelTheme.test.cjs
@@ -1,0 +1,167 @@
+'use strict';
+
+// Source guards for the fixed Apple Glass Pastel board theme.
+//
+// The general theme guards prove that every named theme is wired into the
+// picker, header bars and accent map. This file pins the specific visual
+// contract of `appleglasspastel`, which comes from
+// refer/009-prompt-phoi-mau-apple-glass-pastel.md: a fixed special theme with a
+// pastel mesh background, glass surfaces, dark readable text and blue primary
+// controls.
+//
+// Run: node tests/appleGlassPastelTheme.test.cjs
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const read = rel => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+const css = read('client/components/boards/boardColors.css');
+const config = read('config/const.js');
+const categories = read('models/lib/themeCategories.js');
+const accents = read('models/lib/themeAccents.js');
+const exporter = read('models/server/ExporterExcelCard.js');
+const docs = read('docs/Theme/Theme.md');
+const preview = read('tests/fixtures/appleGlassPastelThemePreview.html');
+
+const THEME = 'appleglasspastel';
+const CLASS = `board-color-${THEME}`;
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log('  ok -', name);
+}
+
+function rule(selectorNeedle) {
+  const found = [];
+  for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (match[1].includes(selectorNeedle)) found.push(match[2]);
+  }
+  return found.join('\n');
+}
+
+function blockBetween(start, end) {
+  const at = css.indexOf(start);
+  assert.notStrictEqual(at, -1, `${start} must exist`);
+  const to = css.indexOf(end, at);
+  assert.notStrictEqual(to, -1, `${end} must exist after ${start}`);
+  return css.slice(at, to);
+}
+
+console.log('appleGlassPastelTheme:');
+
+test('the theme is registered as a fixed special theme', () => {
+  assert.ok(config.includes(`'${THEME}'`), 'allowed board colors include it');
+  assert.ok(/special:\s*\[[^\]]*'appleglasspastel'[^\]]*\]/.test(categories),
+    'special category includes it');
+  assert.ok(!/flat:\s*\[[^\]]*'appleglasspastel'[^\]]*\]/.test(categories),
+    'not in flat, because this is not a one-accent custom theme');
+  assert.ok(!/clear:\s*\[[^\]]*'appleglasspastel'[^\]]*\]/.test(categories),
+    'not in clear, because this is not a two-stop slide theme');
+});
+
+test('the shared accent and export progress colour use the palette primary', () => {
+  assert.ok(new RegExp(`${THEME}: '#2563eb'`).test(accents),
+    'theme accent is the Apple glass primary blue');
+  assert.ok(new RegExp(`${THEME}: 'FF2563EB'`).test(exporter),
+    'Excel progress colour mirrors the same primary blue');
+});
+
+test('the theme block carries the pastel mesh background from the reference', () => {
+  const themeBlock = blockBetween('THEME - Apple Glass Pastel', 'END Apple Glass Pastel THEME');
+  for (const token of [
+    'rgba(255, 200, 220, 0.55)',
+    'rgba(180, 215, 255, 0.55)',
+    'rgba(200, 230, 255, 0.5)',
+    'rgba(230, 215, 255, 0.5)',
+    'linear-gradient(180deg, #f6f7fb 0%, #eef0f7 100%)',
+  ]) {
+    assert.ok(themeBlock.includes(token), `${token} is part of the mesh`);
+  }
+});
+
+test('glass surfaces use blur, saturation, translucent white, border and soft shadows', () => {
+  const surface = rule(`.${CLASS} .minicard`);
+  const list = rule(`.${CLASS} .list`);
+  const swimlane = rule(`.${CLASS} .swimlane .swimlane-header-wrap`);
+  const combined = `${surface}\n${list}\n${swimlane}`;
+  assert.ok(/rgba\(255,\s*255,\s*255,\s*0\.(65|72)\)/.test(combined),
+    'main surfaces are translucent white');
+  assert.ok(/backdrop-filter:\s*blur\(24px\) saturate\(180%\)/.test(combined),
+    'glass blur and saturation are present');
+  assert.ok(/-webkit-backdrop-filter:\s*blur\(24px\) saturate\(180%\)/.test(combined),
+    'Safari-compatible glass blur is present');
+  assert.ok(/border:\s*1px solid rgba\(255,\s*255,\s*255,\s*0\.55\)/.test(combined),
+    'glass border is present');
+  assert.ok(/box-shadow:\s*0 (2px 8px|8px 30px) rgba\(0,\s*0,\s*0,\s*0\.0[46]\)/.test(combined),
+    'shadows stay soft');
+});
+
+test('primary controls and header use only the blue CTA as solid fill', () => {
+  for (const selector of [
+    `.${CLASS}#header`,
+    `.${CLASS}#header-quick-access`,
+    `.${CLASS} button[type=submit].primary`,
+    `.${CLASS} input[type=submit].primary`,
+    `.${CLASS} .sidebar .sidebar-content .sidebar-btn`,
+  ]) {
+    assert.ok(rule(selector).includes('#2563eb'), `${selector} uses #2563eb`);
+  }
+});
+
+test('text, focus and status colours stay high-contrast and non-pastel', () => {
+  const themeBlock = blockBetween('THEME - Apple Glass Pastel', 'END Apple Glass Pastel THEME');
+  for (const token of ['#111827', '#0f172a', '#6b7280', '#1e3a8a']) {
+    assert.ok(themeBlock.includes(token), `${token} is used for readable UI text/state`);
+  }
+  assert.ok(themeBlock.includes('box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12)'),
+    'focus ring uses the primary blue with low alpha');
+  assert.ok(themeBlock.includes('background: #1f7d38'), 'current/success state is green');
+  assert.ok(themeBlock.includes('background: #dc3545'), 'due/error state is red');
+});
+
+test('picker, public boards, All Boards and board canvas all have selectors', () => {
+  for (const selector of [
+    `.board-backgrounds-list .${CLASS}.background-box`,
+    `.public-board-row.${CLASS}`,
+    `.board-list .${CLASS} a`,
+    `.${CLASS}.board-wrapper`,
+    `.${CLASS} .setting-content .content-body .side-menu ul li.active`,
+    `.${CLASS} .boards-left-menu .menu-item.active a`,
+  ]) {
+    assert.ok(css.includes(selector), `${selector} is styled`);
+  }
+});
+
+test('theme docs list the fixed theme and the current clear slide set', () => {
+  assert.ok(docs.includes('appleglasspastel'), 'docs list the new special theme');
+  assert.ok(docs.includes('clearblue, cleargreen, clearorange, clearpink, clearpurple, clearred'),
+    'docs list every clear slide theme, not only clearblue');
+});
+
+test('the static preview exercises the representative WeKan surfaces', () => {
+  assert.ok(preview.includes('../../client/components/boards/boardColors.css'),
+    'preview imports the real board theme stylesheet');
+  assert.ok(preview.includes('board-color-appleglasspastel board-wrapper'),
+    'preview paints a board wrapper with the theme class');
+  for (const token of [
+    'id="header-quick-access"',
+    'id="header"',
+    'class="list"',
+    'class="minicard',
+    'class="card-details"',
+    'class="sidebar"',
+    'class="pop-over board-color-appleglasspastel"',
+    'class="checklist-progress-bar"',
+    'class="sidebar-btn"',
+    'button class="primary"',
+  ]) {
+    assert.ok(preview.includes(token), `${token} is represented in the preview`);
+  }
+});
+
+console.log(`\n${passed} tests passed`);

--- a/tests/cpuExec.test.cjs
+++ b/tests/cpuExec.test.cjs
@@ -17,7 +17,9 @@ const { execFileSync } = require('child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
 const CPU_EXEC = path.join(repoRoot, 'snap-src/bin/cpu-exec');
-const ARCH = os.arch() === 'x64' ? 'x86_64' : os.arch() === 'arm64' ? 'aarch64' : os.machine ? os.machine() : 'x86_64';
+// cpu-exec checks `uname -m`, so the test must use the same architecture token.
+// On Linux arm64 that is usually `aarch64`; on macOS it is `arm64`.
+const ARCH = execFileSync('uname', ['-m'], { encoding: 'utf8' }).trim();
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cpu-exec-test-'));
 const binDir = path.join(tmp, 'bin');

--- a/tests/dateUtils.normalizeDigits.test.cjs
+++ b/tests/dateUtils.normalizeDigits.test.cjs
@@ -51,7 +51,13 @@ function test(name, fn) {
   await test('Persian datetime string parses to the correct Date', () => {
     const d = new Date(normalizeDigits('۲۰۲۶-۰۶-۲۳T۱۷:۳۰:00'));
     assert.ok(!isNaN(d.getTime()), 'should be a valid Date');
-    assert.strictEqual(d.toISOString(), '2026-06-23T14:30:00.000Z');
+    // No timezone is present, so JavaScript interprets this as local time.
+    // Assert the parsed local fields instead of a UTC string tied to one runner.
+    assert.strictEqual(d.getFullYear(), 2026);
+    assert.strictEqual(d.getMonth(), 5);
+    assert.strictEqual(d.getDate(), 23);
+    assert.strictEqual(d.getHours(), 17);
+    assert.strictEqual(d.getMinutes(), 30);
   });
   await test('isValidDate() accepts a Persian-digit date string', () => {
     assert.strictEqual(isValidDate('۲۰۲۶-۰۶-۲۳'), true);

--- a/tests/fixtures/appleGlassPastelThemePreview.html
+++ b/tests/fixtures/appleGlassPastelThemePreview.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Apple Glass Pastel Theme Preview</title>
+  <link rel="stylesheet" href="../../client/components/boards/boardColors.css">
+  <style>
+    html,
+    body {
+      margin: 0;
+      min-height: 100%;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body {
+      min-height: 100vh;
+      overflow: hidden;
+    }
+
+    #header,
+    #header-quick-access {
+      box-sizing: border-box;
+      min-height: 46px;
+      padding: 10px 18px;
+    }
+
+    #header-main-bar,
+    .header-row {
+      align-items: center;
+      display: flex;
+      gap: 12px;
+    }
+
+    .board-header-btn,
+    .sidebar-btn,
+    button.primary {
+      border: 0;
+      display: inline-flex;
+      font: inherit;
+      padding: 8px 14px;
+      text-decoration: none;
+    }
+
+    .preview-shell {
+      height: calc(100vh - 92px);
+      padding: 20px;
+    }
+
+    .board-canvas {
+      display: flex;
+      gap: 16px;
+      height: 100%;
+      overflow: auto;
+    }
+
+    .list {
+      box-sizing: border-box;
+      flex: 0 0 280px;
+      max-height: 100%;
+    }
+
+    .list-header {
+      padding: 14px;
+    }
+
+    .list-body {
+      display: grid;
+      gap: 12px;
+    }
+
+    .minicard,
+    .card-details,
+    .sidebar,
+    .pop-over {
+      box-sizing: border-box;
+    }
+
+    .minicard {
+      min-height: 76px;
+    }
+
+    .card-details,
+    .sidebar {
+      flex: 0 0 320px;
+      padding: 18px;
+    }
+
+    .metric-row {
+      display: flex;
+      gap: 8px;
+      margin-top: 14px;
+    }
+
+    .card-date,
+    .badge {
+      border-radius: 999px;
+      display: inline-flex;
+      padding: 5px 10px;
+    }
+
+    .form-row {
+      display: grid;
+      gap: 10px;
+      margin-top: 16px;
+    }
+
+    input,
+    textarea,
+    select {
+      box-sizing: border-box;
+      font: inherit;
+      padding: 9px 11px;
+      width: 100%;
+    }
+
+    .pop-over {
+      margin-top: 16px;
+      padding: 14px;
+    }
+  </style>
+</head>
+<body>
+  <header id="header-quick-access" class="board-color-appleglasspastel">
+    <div class="header-row">
+      <a class="board-header-btn" href="#">All Boards</a>
+      <span id="header-user-bar">xet7</span>
+      <a id="header-new-board-icon" class="board-header-btn" href="#">+</a>
+    </div>
+  </header>
+
+  <header id="header" class="board-color-appleglasspastel">
+    <div id="header-main-bar">
+      <a class="board-header-btn" href="#">Board</a>
+      <a class="board-header-btn emphasis" href="#">Save</a>
+      <ul>
+        <li class="current">Kanban</li>
+      </ul>
+    </div>
+  </header>
+
+  <main class="preview-shell board-color-appleglasspastel board-wrapper">
+    <section class="board-canvas">
+      <article class="list">
+        <div class="list-header">
+          <strong class="list-header-name">Sprint Backlog</strong>
+        </div>
+        <div class="list-body">
+          <article class="minicard is-selected">
+            <div class="minicard-title">Apple Glass Pastel theme</div>
+            <div class="metric-row">
+              <span class="card-date current">Ready</span>
+              <span class="badge">P1</span>
+            </div>
+          </article>
+          <article class="minicard">
+            <div class="minicard-title">Visual QA checklist</div>
+            <div class="metric-row">
+              <span class="card-date due">Needs app run</span>
+            </div>
+          </article>
+          <a class="open-minicard-composer" href="#">Add a card</a>
+        </div>
+      </article>
+
+      <aside class="card-details">
+        <div class="card-details-header">
+          <h2 class="card-details-title">Theme Details</h2>
+        </div>
+        <p class="card-details-item-title">Glass surface, readable text, blue CTA.</p>
+        <div class="checklist-progress-bar">
+          <div class="checklist-progress" style="width: 72%;">72%</div>
+        </div>
+        <div class="form-row">
+          <input type="text" value="Focus ring target">
+          <textarea rows="3">Pastel mesh stays behind glass panels.</textarea>
+          <button class="primary" type="button">Primary action</button>
+        </div>
+        <div class="pop-over board-color-appleglasspastel">
+          <div class="pop-over-list">
+            <a href="#">Popover item</a>
+          </div>
+        </div>
+      </aside>
+
+      <aside class="sidebar">
+        <h3>Sidebar</h3>
+        <a class="sidebar-btn" href="#">Themed control</a>
+        <p class="sidebar-list-item-description">Muted text remains readable.</p>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/tests/themeCategories.test.cjs
+++ b/tests/themeCategories.test.cjs
@@ -38,7 +38,8 @@ test('categories partition into flat/clear/dark/special in order', () => {
   }
   assert.deepStrictEqual(TC.colorsInCategory('dark'), ['midnight', 'dark', 'moderndark', 'exodark', 'cleandark']);
   assert.strictEqual(TC.colorsInCategory('flat').length, 9);
-  assert.strictEqual(TC.colorsInCategory('special').length, 4);
+  assert.deepStrictEqual(TC.colorsInCategory('special'),
+    ['relax', 'corteza', 'appleglasspastel', 'modern', 'cleanlight']);
 });
 
 test('categoryOf maps each color, null for unknown', () => {


### PR DESCRIPTION
## Summary

- Add `appleglasspastel` as a fixed `special` board theme.
- Wire its shared accent (`#2563eb`) and Excel exporter progress colour.
- Add glass/pastel CSS for board, picker, public rows, header, lists, minicards, card details, popovers, sidebar controls, inputs, checklist progress, toggles, and scrollbars.
- Add a focused theme guard and static preview fixture.
- Make two existing plain-node guards runner-portable (`cpuExec` architecture token and timezone-less digit-normalized dates).

## Verification

- `HOME="/Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools" /Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools/.meteor/meteor node tests/appleGlassPastelTheme.test.cjs`
- `HOME="/Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools" /Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools/.meteor/meteor node tests/themeCategories.test.cjs`
- `HOME="/Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools" /Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools/.meteor/meteor node tests/themeAccents.test.cjs`
- `HOME="/Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools" /Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools/.meteor/meteor node tests/themeColorPicker.test.cjs`
- `HOME="/Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools" /Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools/.meteor/meteor node tests/cpuExec.test.cjs`
- `HOME="/Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools" /Users/apple/Desktop/ex_project_22/mtips5s_wekan/.tools/.meteor/meteor node tests/dateUtils.normalizeDigits.test.cjs`
- `git diff --cached --check && git diff --check`

Earlier full-suite/runtime QA from the sprint workspace:

- Full plain-node suite: 344 run, 0 failed.
- Real local WeKan runtime: Board Settings -> Change color listed `appleglasspastel` under `Special`; selecting it applied the expected header, pastel mesh board wrapper, and glass list/minicard surfaces on desktop and mobile.

## Notes

- Draft PR because CHANGELOG is not updated yet. The WeKan changelog format requires a real upstream commit URL in the linked summary; this can be added once the maintainer chooses the final merge/commit shape.
