### PR TITLE
Use neutral cards on All Boards

### DIFF
--- a/client/components/boards/boardsList.css
+++ b/client/components/boards/boardsList.css
@@ -1604,6 +1604,42 @@
 .board-list .board-color-moderndark { background-color: #2a2a2a; }
 .board-list .board-color-exodark { background-color: #222; }
 
+/* All Boards uses ordinary neutral cards. The board's saved colour belongs to
+   the board canvas and header, not to the overview tile; keeping it here made
+   a mixed set of boards read like a gradient palette instead of one list. */
+.board-list > li.js-board,
+.board-list > li.js-board > .board-list-item,
+.board-list > li.js-board > .board-list-item.has-background-image,
+.board-list > li.js-board > .board-list-item > .js-open-board {
+  background: #fff !important;
+  background-image: none !important;
+  background-color: #fff !important;
+  color: #202124;
+}
+
+.board-list > li.js-board > .board-list-item.has-background-image::after {
+  display: none;
+}
+
+.board-list > li.js-board .board-list-item-name,
+.board-list > li.js-board .board-list-item-desc,
+.board-list > li.js-board .board-list-card-count {
+  color: #202124;
+  text-shadow: none;
+}
+
+.board-list > li.js-board .board-list-item-desc {
+  color: #6b7280;
+}
+
+.board-list > li.js-board .board-list-card-count {
+  background: #f3f4f6;
+}
+
+.board-list > li.js-board .board-list-card-count i.fa {
+  color: #6b7280;
+}
+
 .minicard-members {
   padding: 6px 0 6px 8px;
   width: 100%;

--- a/tests/allBoardsNeutralCards.test.cjs
+++ b/tests/allBoardsNeutralCards.test.cjs
@@ -1,0 +1,39 @@
+'use strict';
+
+// Source guard for neutral board cards on the All Boards overview.
+// Run: node tests/allBoardsNeutralCards.test.cjs
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const css = fs.readFileSync(
+  path.join(__dirname, '..', 'client/components/boards/boardsList.css'),
+  'utf8',
+);
+
+const neutralRule = css.match(
+  /\.board-list > li\.js-board,[\s\S]*?\.board-list > li\.js-board > \.board-list-item > \.js-open-board \{[\s\S]*?\n\}/,
+);
+
+assert.ok(neutralRule, 'the All Boards neutral-card rule exists');
+assert.ok(
+  neutralRule[0].includes('background: #fff !important'),
+  'board cards use a plain white background',
+);
+assert.ok(
+  neutralRule[0].includes('background-image: none !important'),
+  'saved board colours and images do not paint the full card',
+);
+assert.match(
+  css,
+  /\.board-list > li\.js-board > \.board-list-item\.has-background-image::after \{[\s\S]*?display: none;/,
+  'the full-card image overlay is disabled',
+);
+assert.match(
+  css,
+  /\.board-list > li\.js-board \.board-list-item-name,[\s\S]*?text-shadow: none;/,
+  'card text does not retain the image-overlay shadow',
+);
+
+console.log('allBoardsNeutralCards: ok');


### PR DESCRIPTION
## Summary

- keep All Boards card surfaces neutral instead of inheriting board colors
- preserve board-color accents on dedicated color indicators
- add a source guard covering the neutral-card behavior

## Validation

- `node tests/allBoardsNeutralCards.test.cjs`
- `git diff --check upstream/main...HEAD`