### PR TITLE
Fix #4774: REST registration follows Wekan's setting

### DIFF
--- a/server/apiAuthRoutes.js
+++ b/server/apiAuthRoutes.js
@@ -250,7 +250,9 @@ WebApp.handlers.options('/users/register', function (req, res) {
 
 WebApp.handlers.post('/users/register', async function (req, res) {
   try {
-    if (Accounts._options.forbidClientAccountCreation) {
+    const { ReactiveCache } = require('/imports/reactiveCache');
+    const setting = await ReactiveCache.getCurrentSetting();
+    if (setting?.disableRegistration === true) {
       sendJsonResult(res, { code: 403 });
       return;
     }


### PR DESCRIPTION
## Summary

- make `POST /users/register` follow Wekan's `disableRegistration` setting
- stop treating Meteor useraccounts' internal `forbidClientAccountCreation` flag as Wekan's public registration policy

## Problem

The useraccounts package keeps `Accounts._options.forbidClientAccountCreation` enabled because browser sign-up uses its server method. The REST route used that internal flag as its registration gate, so it returned HTTP 403 even when registration was enabled in Wekan.

## Fix

Read the current Wekan settings through `ReactiveCache` and reject REST registration only when `disableRegistration` is explicitly enabled.

## Verification

- `node --check server/apiAuthRoutes.js`
- `node tests/run-node-suites.cjs loginBruteForceEnumerationWiring apiLogout`
- production `meteor build .build --directory`
- isolated live Wekan and MongoDB test:
  - registration enabled: HTTP 200 with user ID and token
  - returned token authenticated through `GET /api/user`
  - registration disabled: HTTP 403
  - blocked request created no user

Fixes #4774