### PR TITLE
docs: the Theme file table points at the pre-reorganisation path

### DIFF
--- a/docs/Features/Page/Theme.md
+++ b/docs/Features/Page/Theme.md
@@ -32,7 +32,7 @@ template and says whose theme is being set:
 | `server/models/users.js` | `.js` methods | `setGlobalThemeColor` — the user's own override. |
 | `server/methods/tenant.js` | `.js` methods | `getAdminThemeColor` / `setAdminThemeColor` — the site theme, and which document it lands in. |
 | `models/lib/tenantAdmin.js` | `.js` module, pure helpers | `themeTarget()` — the instance's theme, or one Organization's. |
-| `docs/Theme/Theme.md` | `.md` guide | What the themes look like, and the custom-colour categories. |
+| `docs/Features/Theme/Theme.md` | `.md` guide | What the themes look like, and the custom-colour categories. |
 
 ## The order of themes
 


### PR DESCRIPTION
`docs/Features/Page/Theme.md` lists the files involved in theming. One row names
`docs/Theme/Theme.md`, which moved to `docs/Features/Theme/Theme.md` in `c4cb87345`
("Reorganize documentation and repair links.", 2026-08-17). The row still points at the old
location, so that link is the one the reorganisation missed.

One line, the table row only. No other document in the tree references the moved path.

Found with an automated check that reads the paths a document names and tests each against
the repository.

Found with [docproof](https://github.com/melbinjp/docproof), which checks what documentation claims against what the repository actually contains.
