### PR TITLE
Await REST user creation before returning its ID.

### DIFF
--- a/server/models/users.js
+++ b/server/models/users.js
@@ -2246,7 +2246,7 @@ WebApp.handlers.post('/api/boards/:boardId/members/:userId/remove', async functi
 WebApp.handlers.post('/api/users/', async function(req, res) {
   try {
     await Authentication.checkUserId(req.userId);
-    const id = Accounts.createUser({
+    const id = await Accounts.createUser({
       username: req.body.username,
       email: req.body.email,
       password: req.body.password,

--- a/tests/restCreateUserAwait.test.cjs
+++ b/tests/restCreateUserAwait.test.cjs
@@ -1,0 +1,47 @@
+'use strict';
+
+// Plain-Node regression guard for POST /api/users/.
+// Run: node tests/restCreateUserAwait.test.cjs
+//
+// Accounts.createUser returns a Promise on Meteor 3. Sending that Promise as
+// `_id` serializes it as an empty object even though the user is created. The
+// route must await account creation before serializing the resulting user ID.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const usersSource = fs.readFileSync(
+  path.resolve(__dirname, '../server/models/users.js'),
+  'utf8',
+);
+const routeStart = usersSource.indexOf(
+  "WebApp.handlers.post('/api/users/', async function(req, res)",
+);
+const routeEnd = usersSource.indexOf(
+  "WebApp.handlers.delete('/api/users/:userId'",
+  routeStart,
+);
+
+assert.notStrictEqual(routeStart, -1, 'POST /api/users/ route must exist');
+assert.notStrictEqual(routeEnd, -1, 'the user creation route must have an end');
+
+const route = usersSource.slice(routeStart, routeEnd);
+
+assert.match(
+  route,
+  /const id = await Accounts\.createUser\(\{/,
+  'account creation must resolve before its result is sent as `_id`',
+);
+assert.match(
+  route,
+  /sendJsonResult\(res, \{ code: 200, data: \{ _id: id \} \}\);/,
+  'the resolved user ID must be returned in the success response',
+);
+assert.doesNotMatch(
+  route,
+  /const id = Accounts\.createUser\(\{/,
+  'an unawaited Promise serializes as an empty object instead of a user ID',
+);
+
+console.log('  ok - POST /api/users/ awaits and returns the created user ID');


### PR DESCRIPTION
## Summary

- await `Accounts.createUser` in `POST /api/users/`
- return the resolved string user ID instead of serializing the Promise as `{}`
- add a plain-Node regression guard for the route

## Live verification

Tested with a clean MongoDB replica set and the official
`wekanteam/wekan:v11.07` image.

Before the fix, the endpoint returned HTTP 200 with:

```json
{"_id":{}}
```

The user appeared shortly afterward with a string ID, confirming that account
creation continued after the response had serialized the unresolved Promise.

After applying the source-equivalent await change to the same image, the
endpoint returned HTTP 200 with a non-empty string ID. The user was immediately
queryable and the response ID exactly matched the stored user ID.

## Tests

- `node tests/run-node-suites.cjs restCreateUserAwait` — passed
- full plain-Node run — all 500 suites executed; 456 passed and 44 unrelated
  suites failed in the fresh Windows checkout because of missing npm
  dependencies, POSIX path/executable assumptions, and existing translation
  file checks
