### PR TITLE
Confirm REST user deletion results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5179,9 +5179,10 @@ browser build to verify).
 **In short:** **HostnameBleed**, found by GitHub CodeQL, makes tenant-hostname
 translation coverage compare example domains as exact text instead of permissive
 regular expressions. A repository-wide negative guard prevents the same test
-fault from returning. The table below is carried over from the release under
-this one, and is refilled from each build's provenance.tsv when this release is
-made.
+fault from returning. The **REST API** now confirms user deletion from the
+database result, reports missing users as 404 and publishes both response
+contracts. The table below is carried over from the release under this one, and
+is refilled from each build's provenance.tsv when this release is made.
 
 | Platform | Binary | From | Version | SHA256 |
 | --- | --- | --- | --- | --- |
@@ -5216,6 +5217,29 @@ The test now uses exact `includes()` comparisons. Positive and negative cases
 prove literal dots are required, while a repository-wide source guard detects
 the reported loop-to-`RegExp` shape and confirms it exists nowhere else in
 tracked first-party JavaScript.
+
+</details>
+
+and fixes the following bug:
+
+<details>
+<summary><a href="https://github.com/wekan/wekan/commit/891b95bf">Deleting a user confirms that one account was removed</a>. Thanks to AhmedLukman and xet7.</summary>
+
+`DELETE /api/users/:userId` returned the requested id even when no account
+matched it, because the route discarded the removal count and built its success
+response from the URL alone. Callers therefore could not distinguish a deletion
+from a no-op.
+
+The route now returns `200` with the id only when exactly one account was
+removed. A missing user returns `404` with `{"error":"User not found"}`. The
+route's source annotation declares both response bodies, and the generated
+OpenAPI document preserves that contract.
+
+Fast regression coverage executes the registered handler for success, missing,
+unexpected-count and unauthorized cases. The live REST test also creates a
+disposable user, deletes it with an administrator's Bearer token, verifies its
+absence directly in MongoDB and requires the repeated request to return the
+documented 404 response.
 
 </details>
 

--- a/openapi/generate_openapi.py
+++ b/openapi/generate_openapi.py
@@ -249,6 +249,7 @@ class EntryPoint(object):
          *    optional by adding square brackets around its name
          *
          * @return Documents a return value
+         * @response 404 {error: string} Documents an additional HTTP response
          */
 
         Notes:
@@ -323,6 +324,55 @@ class EntryPoint(object):
 
                 return
 
+            # 'response' can be set several times. Its value starts with an
+            # HTTP status, followed by an optional return schema and a required
+            # description.
+            if tag == 'response':
+                try:
+                    code, response_data = data.split(maxsplit=1)
+                except ValueError:
+                    self.warn('response needs an HTTP status and description')
+                    return
+
+                if code != 'default' and not re.fullmatch(r'\d{3}', code):
+                    self.warn('invalid HTTP response status {}'.format(code))
+                    return
+
+                response_data = response_data.strip()
+                response_schema = None
+                if response_data.startswith(('{', '[')):
+                    opening = response_data[0]
+                    closing = '}' if opening == '{' else ']'
+                    depth = 0
+                    schema_end = None
+                    for index, char in enumerate(response_data):
+                        if char == opening:
+                            depth += 1
+                        elif char == closing:
+                            depth -= 1
+                            if depth == 0:
+                                schema_end = index + 1
+                                break
+                    if schema_end is None:
+                        self.warn('unterminated response schema for HTTP {}'.format(code))
+                        return
+                    schema_data = response_data[:schema_end]
+                    response_data = response_data[schema_end:].strip()
+                    try:
+                        response_schema = load_return_type_jsdoc_json(schema_data)
+                    except json.decoder.JSONDecodeError:
+                        self.warn('invalid response schema for HTTP {}'.format(code))
+                        return
+
+                if not response_data:
+                    self.warn('response needs a description for HTTP {}'.format(code))
+                    return
+                self._doc.setdefault('responses', {})[code] = {
+                    'description': response_data,
+                    'schema': response_schema,
+                }
+                return
+
             # 'return' tag is json
             if tag == 'return_type':
                 try:
@@ -347,7 +397,7 @@ class EntryPoint(object):
             if line.lstrip().startswith('@'):
                 tag, data = line.lstrip().split(maxsplit=1)
 
-                if tag in ['@operation', '@summary', '@description', '@param', '@return_type', '@tag']:
+                if tag in ['@operation', '@summary', '@description', '@param', '@return_type', '@response', '@tag']:
                     # store the current data
                     store_tag(current_tag, current_data)
 
@@ -409,6 +459,10 @@ class EntryPoint(object):
         return None
 
     @property
+    def responses(self):
+        return self._doc.get('responses', {})
+
+    @property
     def tags(self):
         tags = []
         if self.schema.fields is not None:
@@ -437,6 +491,15 @@ class EntryPoint(object):
             if obj == self.schema.name:
                 rtype = '$ref: "#/definitions/{}"'.format(obj)
             print('{}{}'.format(' ' * indent, rtype))
+
+    def print_openapi_response(self, code, description, schema=None):
+        print("        '{}':".format(code))
+        print('          description: |-')
+        for line in description.split('\n'):
+            print('            {}'.format(line))
+        if schema is not None:
+            print('          schema:')
+            self.print_openapi_return(schema, 12)
 
     def print_openapi(self):
         parameters = [token[1:-2] if token.endswith('Id') else token[1:]
@@ -485,13 +548,18 @@ class EntryPoint(object):
         - application/json
       security:
           - UserSecurity: []
-      responses:
-        '200':
-          description: |-
-            200 response''')
-        if self.returns is not None:
-            print('          schema:')
-            self.print_openapi_return(self.returns, 12)
+      responses:''')
+        response_200 = self.responses.get('200')
+        if response_200 is None:
+            self.print_openapi_response('200', '200 response', self.returns)
+        else:
+            self.print_openapi_response(
+                '200', response_200['description'], response_200['schema'])
+        for code, response in self.responses.items():
+            if code == '200':
+                continue
+            self.print_openapi_response(
+                code, response['description'], response['schema'])
 
 
 class SchemaProperty(object):

--- a/public/api/wekan.yml
+++ b/public/api/wekan.yml
@@ -3282,12 +3282,17 @@ paths:
             200 response
     delete:
       operationId: delete_user
+      summary: Delete a user and confirm that one account was removed
+      description: |
+        Global administrators receive the deleted id; a missing id
+         returns HTTP 404 without reporting a deletion.
       tags:
         - Users
       parameters:
         - name: user
           in: path
-          description: the user value
+          description: |
+            the id of the user to delete
           type: string
           required: true
       produces:
@@ -3298,6 +3303,19 @@ paths:
         '200':
           description: |-
             200 response
+          schema:
+            type: object
+            properties:
+              _id:
+                type: string
+        '404':
+          description: |-
+            No user matched the requested id.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
   # ───────────────────────────────────────────────────────────────────────────
   # Attachment / file API (server/routes/attachmentApi.js)
   #

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -2309,9 +2309,12 @@ WebApp.handlers.delete('/api/users/:userId', async function(req, res) {
     await Authentication.checkUserId(req.userId);
     const id = req.params.userId;
     const removed = await Meteor.users.removeAsync({ _id: id });
-    if (removed !== 1) {
+    if (removed === 0) {
       sendJsonResult(res, { code: 404, data: { error: 'User not found' } });
       return;
+    }
+    if (removed !== 1) {
+      throw new Error(`Unexpected user deletion count: ${removed}`);
     }
     sendJsonResult(res, { code: 200, data: { _id: id } });
   } catch (error) {

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -2293,11 +2293,26 @@ WebApp.handlers.post('/api/users/', async function(req, res) {
   }
 });
 
+/**
+ * @operation delete_user
+ * @summary Delete a user and confirm that one account was removed
+ *
+ * @description Global administrators receive the deleted id; a missing id
+ * returns HTTP 404 without reporting a deletion.
+ *
+ * @param {string} userId the id of the user to delete
+ * @return_type {_id: string}
+ * @response 404 {error: string} No user matched the requested id.
+ */
 WebApp.handlers.delete('/api/users/:userId', async function(req, res) {
   try {
     await Authentication.checkUserId(req.userId);
     const id = req.params.userId;
-    await Meteor.users.removeAsync({ _id: id });
+    const removed = await Meteor.users.removeAsync({ _id: id });
+    if (removed !== 1) {
+      sendJsonResult(res, { code: 404, data: { error: 'User not found' } });
+      return;
+    }
     sendJsonResult(res, { code: 200, data: { _id: id } });
   } catch (error) {
     sendJsonResult(res, publicErrorData(error));

--- a/tests/openapiResponses.test.cjs
+++ b/tests/openapiResponses.test.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+// Non-200 REST responses belong in the route's JSDoc and are generated into
+// public/api/wekan.yml. This pins both halves so a docs rebuild cannot erase
+// DELETE /api/users/{user}'s response contract.
+//
+// Run: node tests/openapiResponses.test.cjs
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const read = relativePath => fs.readFileSync(
+  path.join(repoRoot, relativePath),
+  'utf8',
+);
+
+const generator = read('openapi/generate_openapi.py');
+const users = read('server/models/users.js');
+const openapi = read('public/api/wekan.yml');
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log('  ok -', name);
+}
+
+const routeAt = users.indexOf("WebApp.handlers.delete('/api/users/:userId'");
+const routeDoc = users.slice(users.lastIndexOf('/**', routeAt), routeAt);
+const pathAt = openapi.indexOf('  /api/users/{user}:');
+const nextPathAt = openapi.indexOf('\n  /api/', pathAt + 1);
+const deletePath = openapi.slice(pathAt, nextPathAt);
+
+test('the generator accepts repeatable @response annotations', () => {
+  assert.match(generator, /tag == 'response'/);
+  assert.match(generator, /self\._doc\.setdefault\('responses', \{\}\)\[code\]/);
+  assert.match(generator, /for code, response in self\.responses\.items\(\)/);
+});
+
+test('the user DELETE route owns its success and not-found contracts', () => {
+  assert.ok(routeAt >= 0, 'the route exists');
+  assert.match(routeDoc, /@return_type \{_id: string\}/);
+  assert.match(routeDoc, /@response 404 \{error: string\} No user matched/);
+});
+
+test('the generated OpenAPI path documents the exact 200 response body', () => {
+  assert.ok(pathAt >= 0 && nextPathAt > pathAt, 'the generated user path exists');
+  assert.match(
+    deletePath,
+    /delete:[\s\S]*?'200':[\s\S]*?schema:[\s\S]*?properties:[\s\S]*?_id:[\s\S]*?type: string/,
+  );
+});
+
+test('the generated OpenAPI path documents the exact 404 response body', () => {
+  assert.match(
+    deletePath,
+    /'404':[\s\S]*?No user matched the requested id\.[\s\S]*?schema:[\s\S]*?properties:[\s\S]*?error:[\s\S]*?type: string/,
+  );
+});
+
+console.log(`\n${passed} tests passed`);

--- a/tests/playwright/specs/17-rest-api.e2e.js
+++ b/tests/playwright/specs/17-rest-api.e2e.js
@@ -17,6 +17,7 @@
  *  - copy a card to a 0-based position (deep copy)
  *  - #3062  board card settings GET/PUT
  *  - #4815  GET /api/user/cards (My Cards / Due Cards)
+ *  - DELETE /api/users/:userId confirms deletion and reports missing users
  *
  * The API requires WITH_API=true (the build.sh "Run tests" server sets it).
  * The Bearer token is the user's MongoDB resume token (seedUser returns the raw
@@ -73,6 +74,35 @@ test.describe('REST API: data + permissions', () => {
       headers: authHeaders(user.token),
     });
     expect(rejected.status()).toBe(401);
+  });
+
+  // ---- DELETE /api/users/:userId: confirm the authoritative result --------
+  test('user deletion confirms removal and reports a repeat as 404', async ({ request, adminUser }) => {
+    const target = db.seedUser();
+    try {
+      expect(db.findOne('users', { _id: target.id })).not.toBeNull();
+
+      const deleted = await request.delete(`/api/users/${target.id}`, {
+        headers: authHeaders(adminUser.token),
+      });
+      expect(deleted.status()).toBe(200);
+      expect(await deleted.json()).toEqual({ _id: target.id });
+
+      // Independently poll MongoDB so the response cannot merely echo the id.
+      await expect.poll(
+        () => db.findOne('users', { _id: target.id }),
+        { message: 'the deleted user should be absent from MongoDB' },
+      ).toBeNull();
+
+      const missing = await request.delete(`/api/users/${target.id}`, {
+        headers: authHeaders(adminUser.token),
+        failOnStatusCode: false,
+      });
+      expect(missing.status()).toBe(404);
+      expect(await missing.json()).toEqual({ error: 'User not found' });
+    } finally {
+      db.deleteOne('users', { _id: target.id });
+    }
   });
 
   // ---- #4743 / #5813: bulk create, uniqueness, bulk delete ----------------

--- a/tests/restUserDelete.test.cjs
+++ b/tests/restUserDelete.test.cjs
@@ -1,0 +1,155 @@
+'use strict';
+
+// DELETE /api/users/:userId used to discard removeAsync's result and echo the
+// requested id even when no user matched. Execute the actual registered route
+// with controlled collaborators to pin both responses and the authorization
+// boundary without requiring a running Meteor server.
+//
+// Run: node tests/restUserDelete.test.cjs
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const repoRoot = path.resolve(__dirname, '..');
+const usersSource = fs.readFileSync(
+  path.join(repoRoot, 'server/models/users.js'),
+  'utf8',
+);
+
+const routeStart = usersSource.indexOf(
+  "WebApp.handlers.delete('/api/users/:userId'",
+);
+const routeEnd = usersSource.indexOf(
+  "WebApp.handlers.post('/api/createtoken/:userId'",
+  routeStart,
+);
+
+assert.ok(routeStart >= 0, 'the user DELETE route is present');
+assert.ok(routeEnd > routeStart, 'the route ends before create-token');
+
+let handler;
+const responses = [];
+let checkUserId;
+let removeAsync;
+
+const context = {
+  Authentication: {
+    checkUserId: userId => checkUserId(userId),
+  },
+  Meteor: {
+    users: {
+      removeAsync: selector => removeAsync(selector),
+    },
+  },
+  WebApp: {
+    handlers: {
+      delete(route, callback) {
+        assert.strictEqual(route, '/api/users/:userId');
+        handler = callback;
+      },
+    },
+  },
+  publicErrorData(error) {
+    return { code: error.statusCode || 500, data: error };
+  },
+  sendJsonResult(_res, response) {
+    responses.push(response);
+  },
+};
+
+vm.createContext(context);
+vm.runInContext(usersSource.slice(routeStart, routeEnd), context, {
+  filename: 'server/models/users.js#delete-user',
+});
+assert.strictEqual(typeof handler, 'function', 'the user DELETE handler registered');
+
+let passed = 0;
+async function test(name, fn) {
+  await fn();
+  passed += 1;
+  console.log('  ok -', name);
+}
+
+function reset() {
+  responses.length = 0;
+}
+
+function jsonValue(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+(async () => {
+  await test('one removed user returns the confirmed id with HTTP 200', async () => {
+    reset();
+    checkUserId = async userId => assert.strictEqual(userId, 'admin-id');
+    removeAsync = async selector => {
+      assert.deepStrictEqual(jsonValue(selector), { _id: 'existing-user' });
+      return 1;
+    };
+
+    await handler(
+      { userId: 'admin-id', params: { userId: 'existing-user' } },
+      {},
+    );
+
+    assert.deepStrictEqual(jsonValue(responses), [
+      { code: 200, data: { _id: 'existing-user' } },
+    ]);
+  });
+
+  await test('a nonexistent user returns a deterministic HTTP 404', async () => {
+    reset();
+    checkUserId = async () => {};
+    removeAsync = async () => 0;
+
+    await handler(
+      { userId: 'admin-id', params: { userId: 'missing-user' } },
+      {},
+    );
+
+    assert.deepStrictEqual(jsonValue(responses), [
+      { code: 404, data: { error: 'User not found' } },
+    ]);
+  });
+
+  await test('an unexpected removal count is not reported as success', async () => {
+    reset();
+    checkUserId = async () => {};
+    removeAsync = async () => 2;
+
+    await handler(
+      { userId: 'admin-id', params: { userId: 'ambiguous-user' } },
+      {},
+    );
+
+    assert.deepStrictEqual(jsonValue(responses), [
+      { code: 404, data: { error: 'User not found' } },
+    ]);
+  });
+
+  await test('authorization is checked before removal', async () => {
+    reset();
+    const denied = new Error('Forbidden');
+    denied.statusCode = 403;
+    checkUserId = async () => {
+      throw denied;
+    };
+    removeAsync = async () => {
+      assert.fail('an unauthorized request must not reach removeAsync');
+    };
+
+    await handler(
+      { userId: 'non-admin-id', params: { userId: 'existing-user' } },
+      {},
+    );
+
+    assert.deepStrictEqual(responses, [{ code: 403, data: denied }]);
+  });
+
+  console.log(`\n${passed} tests passed`);
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/restUserDelete.test.cjs
+++ b/tests/restUserDelete.test.cjs
@@ -2,7 +2,7 @@
 
 // DELETE /api/users/:userId used to discard removeAsync's result and echo the
 // requested id even when no user matched. Execute the actual registered route
-// with controlled collaborators to pin both responses and the authorization
+// with controlled collaborators to pin its deletion outcomes and authorization
 // boundary without requiring a running Meteor server.
 //
 // Run: node tests/restUserDelete.test.cjs
@@ -52,7 +52,13 @@ const context = {
     },
   },
   publicErrorData(error) {
-    return { code: error.statusCode || 500, data: error };
+    const status = error.statusCode || 500;
+    return {
+      code: status,
+      data: {
+        error: status >= 500 ? 'Internal server error' : error.message,
+      },
+    };
   },
   sendJsonResult(_res, response) {
     responses.push(response);
@@ -114,7 +120,7 @@ function jsonValue(value) {
     ]);
   });
 
-  await test('an unexpected removal count is not reported as success', async () => {
+  await test('an unexpected removal count returns an internal error', async () => {
     reset();
     checkUserId = async () => {};
     removeAsync = async () => 2;
@@ -125,7 +131,24 @@ function jsonValue(value) {
     );
 
     assert.deepStrictEqual(jsonValue(responses), [
-      { code: 404, data: { error: 'User not found' } },
+      { code: 500, data: { error: 'Internal server error' } },
+    ]);
+  });
+
+  await test('a database failure returns an internal error', async () => {
+    reset();
+    checkUserId = async () => {};
+    removeAsync = async () => {
+      throw new Error('database unavailable');
+    };
+
+    await handler(
+      { userId: 'admin-id', params: { userId: 'existing-user' } },
+      {},
+    );
+
+    assert.deepStrictEqual(jsonValue(responses), [
+      { code: 500, data: { error: 'Internal server error' } },
     ]);
   });
 
@@ -145,7 +168,9 @@ function jsonValue(value) {
       {},
     );
 
-    assert.deepStrictEqual(responses, [{ code: 403, data: denied }]);
+    assert.deepStrictEqual(jsonValue(responses), [
+      { code: 403, data: { error: 'Forbidden' } },
+    ]);
   });
 
   console.log(`\n${passed} tests passed`);


### PR DESCRIPTION
## Summary

- make user deletion report what actually happened in the database
- return `200` only when exactly one account was removed
- return `404` with `{"error":"User not found"}` when no account matched
- return a safe internal error for an unexpected removal result or database failure
- include the success and not-found responses in the generated OpenAPI documentation
- add fast route tests and a live REST-to-MongoDB test

## Why

API clients need to know whether a deletion really happened. Previously, the endpoint simply repeated the user ID from the URL. This made a real deletion and a request for a user that did not exist look the same.

Meteor returns the number of documents removed by MongoDB. Because the route selects a unique user ID, the normal result is `1` when the user was deleted or `0` when no user matched. This change uses that result instead of assuming the deletion worked.

Calling `DELETE /api/users/:userId` with a missing user ID returned `200`, which means success, even though nothing was deleted. Scripts, integrations, and administrators could therefore believe an account was gone when it was not.

Only a zero removal count means the user was not found. An unexpected count or a database error is treated as an internal error instead of being mislabeled as a missing user.

## Testing

- `node tests/restUserDelete.test.cjs` — 5 passed
- `node tests/openapiResponses.test.cjs` — 4 passed
- focused Playwright REST test against a fresh Docker build of this checkout — 1 passed
- changelog format, release-placement, archive, and commit-link suites — 37 passed
- `node tests/run-node-suites.cjs` — both new suites pass under automatic discovery; the complete Windows run has 55 unrelated existing/environment failures involving Unix path semantics, optional modules, and translation symlink handling
