### PR TITLE
docs: the Microsoft Office 365 mail example uses Basic authentication, which Microsoft is retiring

### DIFF
--- a/docs/Features/Email/Troubleshooting-Mail.md
+++ b/docs/Features/Email/Troubleshooting-Mail.md
@@ -131,6 +131,9 @@ and copy converted characters to your password.
 
 ## Example: Microsoft Office 365
 
+- Microsoft will disable Basic authentication for SMTP AUTH by default on existing Microsoft 365 tenants at the end of December 2026, and it is unavailable by default on tenants created after that date. An administrator can still turn it back on for an existing tenant. Timeline: https://techcommunity.microsoft.com/blog/exchange/updated-exchange-online-smtp-auth-basic-authentication-deprecation-timeline/4489835
+- The example below uses Basic authentication. Microsoft's alternatives for devices and applications that send mail are at https://learn.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-microsoft-365-or-office-365
+
 ```
 sudo snap set wekan mail-url='smtp://user:password@smtp.office365.com:587?ignoreTLS=false&tls={rejectUnauthorized:false}&secure=true'
 sudo snap set wekan mail-from='Wekan Team Boards <info@example.com>'


### PR DESCRIPTION
`docs/Features/Email/Troubleshooting-Mail.md` has an `## Example: Microsoft Office 365`
section whose `mail-url` authenticates to `smtp.office365.com` with a username and a
password. That is SMTP AUTH using Basic authentication, and Microsoft is retiring it.

From Microsoft's current timeline (Exchange Team Blog, 27 Jan 2026, "Updated Exchange
Online SMTP AUTH Basic Authentication Deprecation Timeline"):

- End of December 2026 — "SMTP AUTH Basic Authentication will be disabled by default for
  existing tenants. Administrators will still be able to enable it if needed."
- New tenants created after December 2026 — "unavailable by default".

So the example keeps working on a tenant where an administrator has enabled SMTP AUTH,
and stops working by default everywhere else. The note says exactly that, rather than
"stops working in December 2026", which a reader who checked would find false.

This page already carries the same kind of warning for the other provider, directly under
`## OAuth2 proxy` ("Google will disable all but OAuth for IMAP, SMTP and POP starting
Sept. 30 2024", followed by the source URL). I used that existing style.

Scope is two added lines plus a blank one, in that one section. The example itself is
unchanged — it is still correct where SMTP AUTH is enabled, and deleting it would remove
a working configuration.

Disclosure: I work on tooling in the Microsoft 365 SMTP area, so I have a potential
conflict of interest on this subject.
