### PR TITLE
Keep the CHANGELOG summary of commit 793f760ea on one line.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,8 +313,7 @@ behavior is unchanged; all 790 Node suites and 15 targeted browser checks pass.
 | mac-x64 | FerretDB | [wekan/FerretDB](https://github.com/wekan/FerretDB/releases/download/v1.53.0/ferretdb-mac-x64) | v1.53.0 | `d97dfa9afa60aa05f25384327de82efe7b71d958ed24c1f66618284294a65cd3` |
 
 <details>
-<summary><a href="https://github.com/wekan/wekan/commit/793f760ea">Fix
-alltests fixtures and HTTP cookie assertions</a>. Thanks to xet7.</summary>
+<summary><a href="https://github.com/wekan/wekan/commit/793f760ea">Fix alltests fixtures and HTTP cookie assertions</a>. Thanks to xet7.</summary>
 
 The September 7 alltests run failed on generated Playwright artifacts, changed
 Finnish wording, long fixture labels and an HTTPS-only cookie expectation on


### PR DESCRIPTION
tests/changelogFormat.test.cjs requires every <details> summary to be one line, opened and closed on it. In the v11.56 section the summary of commit 793f760ea is wrapped across two lines, so that assertion aborts the suite — it is the only failing one of the 790 node suites on current main.

Only the line break inside the <summary> is removed. The wording of the published entry is untouched, and no other summary in CHANGELOG.md or in old-CHANGELOG/ is wrapped.

Note: after this fix the suite still fails on a second, unrelated assertion — the newest release section must have at least one entry or bullet, and v11.58 has only its prose paragraph and the provenance table. Happy to send that separately once you say which way you want it.